### PR TITLE
Add skills reference guides and update copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,33 +24,12 @@ uv pip install git+https://github.com/boettiger-lab/datasets.git
 
 Do not run data processing commands (vector, raster, repartition) locally — those run inside k8s pods.
 
-## Kubernetes
+## Available Skills
 
-- `kubectl` is pre-configured for the NRP Nautilus cluster, namespace `biodiversity`
-- Secrets `aws` and `rclone-config` are already set up in the namespace
-- All jobs use `priorityClassName: opportunistic` (preemptible)
-- The generated YAML handles all k8s configuration — you just apply it
+Detailed reference guides are in `skills/`. **Do not read these proactively** — load a skill only when the task requires it:
 
-## S3 Storage
-
-This cluster uses Ceph S3 (not AWS). The `cng-datasets` tool handles all S3 configuration automatically in the generated k8s jobs.
-
-For **local read-only access** to public data:
-```
-https://s3-west.nrp-nautilus.io/<bucket>/<path>
-```
-Use path-style URLs, not virtual-hosted-style. No credentials needed for public buckets.
-
-For `rclone`, the remote name is `nrp`:
-```
-rclone ls nrp:<bucket>/
-```
-
-You do not need to know about internal S3 endpoints — the generated jobs handle this.
-
-## GDAL
-
-For inspecting remote files locally, use VSI-style paths:
-```bash
-ogrinfo /vsicurl/https://s3-west.nrp-nautilus.io/<bucket>/raw/<file>.gdb
-```
+| Skill file | When to load |
+|---|---|
+| `skills/nrp-k8s/SKILL.md` | Creating or debugging Kubernetes jobs on NRP Nautilus (priority classes, resource limits, GPU avoidance, namespace quotas) |
+| `skills/nrp-s3/SKILL.md` | S3 bucket operations: endpoints, rclone, bucket policies, CORS, DuckDB S3 access, syncing to source.coop |
+| `skills/gdal-remote/SKILL.md` | Reading remote geospatial files with GDAL/OGR virtual filesystems, DuckDB spatial, format conversions, Parquet driver availability |

--- a/skills/gdal-remote/SKILL.md
+++ b/skills/gdal-remote/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: gdal-remote
+description: >
+  Work with geospatial data using GDAL/OGR and DuckDB, especially reading remote files
+  via virtual filesystems (/vsicurl/, /vsis3/), inspecting multi-layer sources, converting
+  between formats, and handling geometry edge cases. Covers the relationship between
+  GDAL, DuckDB spatial, and Parquet/GeoParquet — including which tool can read what and
+  common pitfalls with driver availability. Use when working with geospatial file formats
+  (GDB, GPKG, Shapefile, GeoParquet, GeoTIFF, PMTiles), converting between them, or
+  reading remote geospatial data.
+license: Apache-2.0
+metadata:
+  author: boettiger-lab
+  version: "1.0"
+---
+
+# GDAL, OGR, and DuckDB for Remote Geospatial Data
+
+GDAL/OGR is the foundational library for reading and writing geospatial formats. DuckDB with its spatial extension is often a better choice for analytical queries on Parquet. Understanding which tool to use when — and what each can and cannot do — is essential.
+
+## Choosing the Right Tool
+
+| Task | Best tool | Why |
+|------|-----------|-----|
+| Inspect layers in a remote GDB/GPKG | `ogrinfo` | Quick, no data download |
+| Convert GDB/Shapefile → GeoParquet | `ogr2ogr` or DuckDB `ST_Read` | Both work; DuckDB allows transforms in SQL |
+| Query/filter a GeoParquet file | DuckDB native `read_parquet()` | Columnar pushdown, much faster than GDAL |
+| Spatial joins, aggregation on Parquet | DuckDB with spatial extension | SQL interface, fast |
+| Convert GeoParquet → GeoJSON/GeoJSONSeq | `ogr2ogr` | Streaming, handles large files |
+| Create COG from GeoTIFF | `gdal.Translate` / `gdal.Warp` | Python API or CLI |
+| Reproject raster data | `gdalwarp` | Full control over resampling |
+
+## GDAL Parquet Driver Availability
+
+**GDAL is often not built with the Parquet (Arrow) driver.** This depends on whether the Arrow/Parquet C++ libraries were available at compile time. Always check first:
+
+```bash
+# Check if Parquet driver is available
+ogrinfo --formats | grep -i parquet
+
+# Check if Arrow driver is available
+ogrinfo --formats | grep -i arrow
+```
+
+If you see no output, GDAL cannot read or write Parquet files. In that case, use DuckDB instead for Parquet operations.
+
+The `ghcr.io/osgeo/gdal:ubuntu-full-latest` Docker image (used in this repo) **does** include the Parquet driver. Most system-installed GDAL packages (e.g., `apt install gdal-bin`) do **not**.
+
+## DuckDB vs GDAL for Parquet
+
+When working with GeoParquet files, **DuckDB is almost always the better choice**:
+
+- Native columnar Parquet reader with predicate pushdown and column pruning
+- Fast SQL-based filtering, joins, and aggregation
+- Reads directly from S3 (`s3://`) or HTTPS URLs
+- Handles hive-partitioned layouts natively (`read_parquet('s3://bucket/hex/**')`)
+
+Use GDAL for Parquet only when you need format conversion (e.g., Parquet → GeoJSONSeq for tippecanoe).
+
+## DuckDB Spatial and Its Vendored GDAL
+
+DuckDB's `spatial` extension bundles its own internal copy of GDAL. This vendored GDAL has important limitations:
+
+### What DuckDB spatial's `ST_Read()` CAN do
+
+- Read most GDAL vector formats: Shapefile, GDB, GPKG, GeoJSON, FlatGeobuf, etc.
+- Use VSI prefixes to read remote files: `/vsicurl/https://...`, `/vsis3/...`
+- Apply spatial transforms: `ST_Transform()`, `ST_FlipCoordinates()`
+- Select specific layers from multi-layer sources
+
+```sql
+INSTALL spatial;
+LOAD spatial;
+
+-- Read a remote GDB layer
+SELECT * FROM ST_Read('/vsicurl/https://example.com/data.gdb', layer='MyLayer');
+
+-- Read with reprojection
+SELECT ST_Transform(geom, 'EPSG:4269', 'EPSG:4326') AS geom, *
+FROM ST_Read('/vsicurl/https://example.com/data.gdb', layer='MyLayer');
+```
+
+### What DuckDB spatial's `ST_Read()` CANNOT do
+
+- **Read GeoParquet** — the vendored GDAL is not built with Arrow libraries, so `ST_Read('file.parquet')` will fail
+- **Write to `/vsis3/`** — the vendored GDAL cannot write directly to S3 buckets (a fully configured system GDAL can)
+
+### Reading GeoParquet in DuckDB (the right way)
+
+Use DuckDB's **native Parquet reader**, not `ST_Read()`. Load the spatial extension first so DuckDB recognizes the geometry blob column:
+
+```sql
+INSTALL spatial;
+LOAD spatial;
+
+-- DuckDB's native reader handles parquet; spatial extension detects geometry
+SELECT * FROM read_parquet('s3://public-padus/padus-4-1/fee.parquet') LIMIT 10;
+
+-- Also works with HTTPS
+SELECT * FROM read_parquet('https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee.parquet');
+
+-- Hive-partitioned reads
+SELECT * FROM read_parquet('s3://public-padus/padus-4-1/fee/hex/**');
+```
+
+Key distinction: DuckDB native `read_parquet()` uses `s3://` prefixes (configured via DuckDB secrets). DuckDB spatial's `ST_Read()` uses GDAL's `/vsicurl/` or `/vsis3/` prefixes. Don't mix them up.
+
+## OGR: Inspecting Remote Data
+
+### List layers in a multi-layer source
+
+```bash
+ogrinfo /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/raw/PADUS4_1Geodatabase.gdb
+```
+
+Output shows layer names, geometry types, and feature counts.
+
+### Get layer details (schema, feature count, extent)
+
+```bash
+# Specific layer — use -so for summary only (no feature dump)
+ogrinfo -so /vsicurl/https://example.com/data.gdb LayerName
+
+# All layers summary
+ogrinfo -so -al /vsicurl/https://example.com/data.gdb
+```
+
+The `-so` (summary only) flag is essential for remote files — without it, ogrinfo tries to print every feature.
+
+### Count features in a layer
+
+Parse the `Feature Count:` line from ogrinfo output:
+
+```bash
+ogrinfo -so /vsicurl/https://example.com/data.gdb LayerName | grep "Feature Count"
+```
+
+## OGR: Format Conversion
+
+### Basic conversion with layer selection
+
+```bash
+# GDB layer → GeoParquet
+ogr2ogr -f Parquet output.parquet /vsicurl/https://example.com/data.gdb "LayerName"
+
+# GDB layer → GeoJSONSeq (for tippecanoe, streaming)
+ogr2ogr -f GeoJSONSeq output.geojsonl /vsicurl/https://example.com/data.gdb "LayerName" -progress
+```
+
+### Writing directly to S3 with `/vsis3/`
+
+When GDAL is properly configured with S3 credentials and endpoints, you can write directly to S3:
+
+```bash
+ogr2ogr -f Parquet /vsis3/bucket/output.parquet /vsis3/bucket/raw/source.gdb "LayerName" -progress
+```
+
+This requires GDAL environment variables to be set:
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_S3_ENDPOINT=rook-ceph-rgw-nautiluss3.rook   # internal endpoint inside k8s
+export AWS_HTTPS=NO
+export AWS_VIRTUAL_HOSTING=FALSE
+```
+
+### Pipe to tippecanoe for PMTiles
+
+```bash
+# Stream GeoJSONSeq directly to tippecanoe via /vsistdout/
+ogr2ogr -f GeoJSONSeq /vsistdout/ /vsis3/bucket/data.gdb "LayerName" \
+  | tippecanoe -o output.pmtiles -l layername \
+    --drop-densest-as-needed --extend-zooms-if-still-dropping --force
+
+# Or from GeoParquet
+ogr2ogr -f GeoJSONSeq /vsistdout/ /vsicurl/https://example.com/data.parquet \
+  | tippecanoe -o output.pmtiles -l layername \
+    --drop-densest-as-needed --extend-zooms-if-still-dropping --force
+```
+
+## Geometry Edge Cases
+
+### Curved geometries (MULTISURFACE, CURVEPOLYGON)
+
+Some GDB files contain curved geometry types that many tools cannot handle. Linearize them during conversion:
+
+```bash
+ogr2ogr -f GPKG \
+  -nlt CONVERT_TO_LINEAR \
+  -nlt PROMOTE_TO_MULTI \
+  output.gpkg input.gdb "LayerName"
+```
+
+- `-nlt CONVERT_TO_LINEAR` — converts CircularString, CompoundCurve, CurvePolygon, MultiSurface to linear equivalents
+- `-nlt PROMOTE_TO_MULTI` — ensures consistent multi-geometry types (MULTIPOLYGON not mixed POLYGON/MULTIPOLYGON)
+
+You can combine these in a two-step pipeline: linearize to GPKG first, then convert to Parquet.
+
+### FID / row ID issues
+
+Some formats (GDB especially) include an FID column that can cause Arrow type mapping issues. Use `-unsetFid` if you hit problems:
+
+```bash
+ogr2ogr -f Parquet output.parquet input.gdb "LayerName" -unsetFid
+```
+
+## VSI Virtual Filesystem Prefixes
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `/vsicurl/` | Read remote files over HTTP/HTTPS | `/vsicurl/https://example.com/data.gdb` |
+| `/vsis3/` | Read/write S3 buckets (requires credentials) | `/vsis3/bucket/path/file.parquet` |
+| `/vsistdout/` | Stream output to stdout (for piping) | `ogr2ogr -f GeoJSONSeq /vsistdout/ input.gdb` |
+| `/vsicurl_streaming/` | Streaming HTTP read (less seeking) | For formats that support sequential access |
+| `/vsizip/` | Read inside zip archives | `/vsizip//vsicurl/https://example.com/data.zip` |
+
+### Converting between URL styles
+
+When you have an `s3://` URL and need a VSI path:
+
+```
+s3://bucket/path/file.gdb
+→ /vsis3/bucket/path/file.gdb           (for GDAL with S3 credentials)
+→ /vsicurl/https://s3-west.nrp-nautilus.io/bucket/path/file.gdb   (for public HTTP access)
+```
+
+When you have an HTTPS URL:
+```
+https://s3-west.nrp-nautilus.io/bucket/path/file.gdb
+→ /vsicurl/https://s3-west.nrp-nautilus.io/bucket/path/file.gdb
+```
+
+## GDAL Python API (Raster)
+
+For raster operations, use the GDAL Python API:
+
+```python
+from osgeo import gdal, osr
+gdal.UseExceptions()
+
+# Open a remote raster
+ds = gdal.Open('/vsicurl/https://example.com/raster.tif')
+
+# Get metadata
+gt = ds.GetGeoTransform()  # [origin_x, pixel_width, 0, origin_y, 0, -pixel_height]
+srs = osr.SpatialReference(wkt=ds.GetProjection())
+band = ds.GetRasterBand(1)
+nodata = band.GetNoDataValue()
+
+# Create a COG with reprojection
+warp_options = gdal.WarpOptions(
+    dstSRS='EPSG:4326',
+    format='COG',
+    creationOptions=['COMPRESS=DEFLATE', 'BLOCKSIZE=512', 'NUM_THREADS=ALL_CPUS'],
+    resampleAlg='nearest',
+    multithread=True,
+)
+gdal.Warp('output.tif', '/vsicurl/https://example.com/raster.tif', options=warp_options)
+
+# Create COG without reprojection (just optimize)
+gdal.Translate('output.tif', 'input.tif',
+    format='COG',
+    creationOptions=['COMPRESS=DEFLATE', 'BLOCKSIZE=512'])
+```
+
+## Common Pitfalls
+
+1. **Assuming GDAL has Parquet support** — Check `ogrinfo --formats | grep -i parquet` first. Most system installs lack it. Use DuckDB for Parquet instead.
+2. **Using `ST_Read()` for GeoParquet in DuckDB** — The vendored GDAL in DuckDB spatial can't read Parquet. Use `read_parquet()` with the spatial extension loaded.
+3. **Mixing URL styles** — `s3://` is for DuckDB native reader; `/vsicurl/` and `/vsis3/` are for GDAL (including DuckDB's `ST_Read()`). Don't pass `s3://` to `ST_Read()` or `/vsicurl/` to `read_parquet()`.
+4. **Forgetting `-so` with remote ogrinfo** — Without summary-only mode, ogrinfo dumps every feature over the network.
+5. **Curved geometries silently breaking downstream** — Always linearize GDB sources with `-nlt CONVERT_TO_LINEAR` if the source contains MULTISURFACE, CURVEPOLYGON, or similar types.
+6. **DuckDB spatial's vendored GDAL can't write to S3** — `ST_Read` can read `/vsis3/` paths but `COPY ... TO '/vsis3/...'` via the spatial extension's GDAL won't work. Use DuckDB's native `COPY ... TO 's3://...'` for Parquet output, or use system GDAL for other formats.

--- a/skills/nrp-k8s/SKILL.md
+++ b/skills/nrp-k8s/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: nrp-k8s-batch
+description: >
+  Run batch processing jobs on the NRP (National Research Platform) Nautilus Kubernetes
+  cluster. Covers the mandatory requirements for CPU jobs: opportunistic priority class,
+  resource requests/limits, and GPU node avoidance. Use when creating or managing
+  Kubernetes jobs on the NRP Nautilus cluster, or when the user mentions NRP, Nautilus,
+  or needs to run batch workloads on a shared academic cluster.
+license: Apache-2.0
+compatibility: >
+  Requires kubectl configured for the NRP Nautilus cluster (namespace: biodiversity).
+  Works with any agent that can run shell commands.
+metadata:
+  author: boettiger-lab
+  version: "1.0"
+---
+
+# NRP Kubernetes Batch Jobs
+
+The NRP (National Research Platform) Nautilus cluster is a shared academic Kubernetes cluster primarily designed for GPU workloads. CPU-only batch jobs require specific configuration to coexist properly.
+
+## Namespace
+
+All our jobs run in the `biodiversity` namespace:
+
+```bash
+kubectl -n biodiversity get jobs
+```
+
+## Mandatory Requirements for CPU Jobs
+
+### 1. Priority class (REQUIRED)
+
+All CPU jobs **must** use the `opportunistic` priority class. This makes pods preemptible so they don't block GPU users. Without this, your job may be rejected or cause problems for other users.
+
+```yaml
+spec:
+  template:
+    spec:
+      priorityClassName: opportunistic
+```
+
+### 2. Resource requests and limits (REQUIRED)
+
+The NRP cluster **requires** both `requests` and `limits` on every container. Jobs without resource specifications will not be scheduled.
+
+Set requests equal to limits for guaranteed QoS (Quality of Service). Be respectful — request only what you need:
+
+```yaml
+resources:
+  requests:
+    cpu: "4"
+    memory: "8Gi"
+  limits:
+    cpu: "4"
+    memory: "8Gi"
+```
+
+If you need ephemeral scratch disk (e.g., for large temporary files), request it explicitly:
+
+```yaml
+resources:
+  requests:
+    cpu: "4"
+    memory: "32Gi"
+    ephemeral-storage: "250Gi"
+  limits:
+    cpu: "4"
+    memory: "32Gi"
+```
+
+### 3. GPU node avoidance (recommended)
+
+To avoid wasting GPU node capacity on CPU-only work, add a node anti-affinity. This is strongly recommended but not strictly enforced:
+
+```yaml
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+```
+
+## Minimal Job Example
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-job
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+        - name: worker
+          image: ghcr.io/boettiger-lab/datasets:latest
+          command: ["bash", "-c", "echo hello"]
+          resources:
+            requests:
+              cpu: "4"
+              memory: "8Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+```
+
+## Secrets
+
+Two secrets are available in the `biodiversity` namespace. See the [nrp-s3 skill](../nrp-s3/SKILL.md) for full details on S3 environment variables.
+
+### `aws` — S3 credentials (environment variables)
+
+```yaml
+env:
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: aws
+        key: AWS_ACCESS_KEY_ID
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: aws
+        key: AWS_SECRET_ACCESS_KEY
+```
+
+### `rclone-config` — Rclone configuration (volume mount)
+
+```yaml
+volumeMounts:
+  - name: rclone-config
+    mountPath: /root/.config/rclone
+    readOnly: true
+volumes:
+  - name: rclone-config
+    secret:
+      secretName: rclone-config
+```
+
+## Useful Fields
+
+| Field | Purpose |
+|-------|---------|
+| `ttlSecondsAfterFinished: 10800` | Auto-deletes completed jobs after 3 hours to avoid resource leaks |
+| `completionMode: Indexed` | For parallel workloads — each pod gets a unique `JOB_COMPLETION_INDEX` |
+| `backoffLimitPerIndex` | Retries per index (instead of global `backoffLimit`) — useful for indexed jobs |
+| `podFailurePolicy` with `DisruptionTarget: Ignore` | Don't count preemptions as failures (important with `opportunistic` priority) |
+
+## Common Pitfalls
+
+1. **Missing resource requests/limits** — Jobs will not schedule without them. Always specify both, and keep requests = limits.
+2. **Forgetting `priorityClassName: opportunistic`** — Required for all CPU jobs on this cluster.
+3. **Requesting too many resources** — Be respectful. Don't request 64 CPUs if you only need 4.
+4. **Max 200 completions per indexed job** — Hard limit to avoid overwhelming the cluster's etcd.

--- a/skills/nrp-s3/SKILL.md
+++ b/skills/nrp-s3/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: nrp-s3
+description: >
+  Manage S3 object storage on the NRP (National Research Platform) Nautilus cluster,
+  which uses Ceph S3 (not AWS). Covers public vs internal endpoints, rclone usage,
+  bucket creation, public-read policies, CORS configuration, DuckDB S3 access,
+  credential handling, and syncing to external S3 providers like source.coop.
+  Use when working with S3 buckets on NRP Nautilus, uploading or downloading data,
+  configuring bucket access, reading data from Ceph S3 storage, or syncing datasets
+  to source.coop or other AWS S3 destinations.
+license: Apache-2.0
+compatibility: >
+  Requires kubectl configured for the NRP Nautilus cluster, rclone with an "nrp" remote,
+  and optionally the AWS CLI. Works with any agent that can run shell commands.
+metadata:
+  author: boettiger-lab
+  version: "1.0"
+---
+
+# NRP S3 Storage
+
+The NRP Nautilus cluster provides S3-compatible object storage powered by Ceph (Rook). This is **not** AWS S3 — it has its own endpoints, credential system, and quirks.
+
+## Two Endpoints
+
+There are two S3 endpoints. Getting these right is critical.
+
+| Endpoint | URL | Use |
+|----------|-----|-----|
+| **Public** | `s3-west.nrp-nautilus.io` | External access (browsers, local machines, HTTPS) |
+| **Internal** | `rook-ceph-rgw-nautiluss3.rook` | Inside k8s pods (faster, high-concurrency, no TLS overhead) |
+
+### When to use which
+
+- **Local machine / CI / external tools**: Always use the public endpoint
+- **Inside k8s pods**: Use the internal endpoint for S3 read/write operations
+- **Public data URLs for end users**: Always use the public endpoint
+
+### Concurrency
+
+The **internal endpoint** handles high-concurrency workloads well — many parallel threads reading S3 simultaneously (e.g., DuckDB with high thread counts, parallel pod reads). The **public endpoint** does not handle high concurrency gracefully and will throttle with 503 SlowDown errors under load. Always use the internal endpoint for heavy parallel reads inside the cluster.
+
+### Public URL format
+
+Public data is accessible via HTTPS using **path-style** URLs (not virtual-hosted):
+
+```
+https://s3-west.nrp-nautilus.io/<bucket>/<path>
+```
+
+Example:
+```
+https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee.parquet
+```
+
+**Never** use virtual-hosted-style URLs like `<bucket>.s3-west.nrp-nautilus.io` — they won't work.
+
+## Credentials
+
+### Kubernetes secrets
+
+Two secrets are pre-configured in the `biodiversity` namespace:
+
+1. **`aws`** — Contains `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+2. **`rclone-config`** — Contains a complete rclone configuration file (includes remotes for both `nrp` and `source` for source.coop)
+
+In k8s job YAML, reference them like this:
+
+```yaml
+env:
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef:
+        name: aws
+        key: AWS_ACCESS_KEY_ID
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef:
+        name: aws
+        key: AWS_SECRET_ACCESS_KEY
+volumes:
+  - name: rclone-config
+    secret:
+      secretName: rclone-config
+volumeMounts:
+  - name: rclone-config
+    mountPath: /root/.config/rclone
+    readOnly: true
+```
+
+### Local credentials
+
+Locally, rclone is already configured with a remote named `nrp`. AWS credentials should be set as environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) when using the AWS CLI directly.
+
+## Environment Variables for K8s Pods
+
+When running inside the cluster, pods need these environment variables:
+
+```yaml
+env:
+  - name: AWS_ACCESS_KEY_ID
+    valueFrom:
+      secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID }
+  - name: AWS_SECRET_ACCESS_KEY
+    valueFrom:
+      secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY }
+  - name: AWS_S3_ENDPOINT
+    value: "rook-ceph-rgw-nautiluss3.rook"      # Internal endpoint
+  - name: AWS_PUBLIC_ENDPOINT
+    value: "s3-west.nrp-nautilus.io"             # For public URL generation
+  - name: AWS_HTTPS
+    value: "false"                                # Internal endpoint is HTTP
+  - name: AWS_VIRTUAL_HOSTING
+    value: "FALSE"                                # Path-style URLs required
+```
+
+Note: `AWS_HTTPS` is `"false"` for the internal endpoint (plain HTTP inside the cluster). The public endpoint always uses HTTPS.
+
+## Rclone
+
+Rclone is the primary tool for file transfers. The remote is named `nrp`.
+
+### Common operations
+
+```bash
+# List bucket contents
+rclone ls nrp:<bucket>/
+
+# Upload a file
+rclone copy local-file.parquet nrp:<bucket>/path/ -P
+
+# Upload a directory
+rclone copy ./local-dir/ nrp:<bucket>/remote-dir/ -P
+
+# Download a file
+rclone copy nrp:<bucket>/path/file.parquet ./local/ -P
+
+# Sync (mirror source to destination, deletes extras)
+rclone sync nrp:<bucket>/source/ nrp:<bucket>/dest/ -P
+```
+
+### Inside k8s pods
+
+The rclone config is mounted from the `rclone-config` secret. No additional configuration is needed — just use `rclone copy ... nrp:<bucket>/...`.
+
+## Bucket Management
+
+### Creating a bucket
+
+```bash
+rclone mkdir nrp:<bucket-name>
+```
+
+### Setting public read access
+
+Use the AWS CLI with the public endpoint:
+
+```bash
+aws s3api put-bucket-policy \
+  --bucket <bucket-name> \
+  --endpoint-url https://s3-west.nrp-nautilus.io \
+  --policy '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {"AWS": ["*"]},
+        "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+        "Resource": ["arn:aws:s3:::<bucket-name>"]
+      },
+      {
+        "Effect": "Allow",
+        "Principal": {"AWS": ["*"]},
+        "Action": ["s3:GetObject"],
+        "Resource": ["arn:aws:s3:::<bucket-name>/*"]
+      }
+    ]
+  }'
+```
+
+### Setting CORS (required for browser access to PMTiles, etc.)
+
+```bash
+aws s3api put-bucket-cors \
+  --bucket <bucket-name> \
+  --endpoint-url https://s3-west.nrp-nautilus.io \
+  --cors-configuration '{
+    "CORSRules": [{
+      "AllowedOrigins": ["*"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag", "Content-Length", "Content-Type", "Accept-Ranges", "Content-Range"],
+      "MaxAgeSeconds": 3600
+    }]
+  }'
+```
+
+### Verifying configuration
+
+```bash
+# Check bucket policy
+aws s3api get-bucket-policy \
+  --bucket <bucket-name> \
+  --endpoint-url https://s3-west.nrp-nautilus.io
+
+# Check CORS
+aws s3api get-bucket-cors \
+  --bucket <bucket-name> \
+  --endpoint-url https://s3-west.nrp-nautilus.io
+```
+
+## DuckDB S3 Access
+
+To read from NRP S3 in DuckDB (locally or in pods):
+
+```sql
+INSTALL httpfs;
+LOAD httpfs;
+
+CREATE OR REPLACE SECRET s3_secret (
+    TYPE S3,
+    KEY_ID '',
+    SECRET '',
+    USE_SSL 'TRUE',
+    ENDPOINT 's3-west.nrp-nautilus.io',
+    URL_STYLE 'path',
+    REGION 'us-east-1'
+);
+
+-- Now you can query directly
+SELECT * FROM 's3://public-padus/padus-4-1/fee.parquet' LIMIT 10;
+```
+
+For **public** (anonymous) access, empty `KEY_ID` and `SECRET` work. For write access, provide real credentials.
+
+Inside k8s pods, use the internal endpoint and set `USE_SSL` to `'FALSE'`. The internal endpoint handles high thread counts well, so DuckDB can use its full parallelism:
+
+```sql
+CREATE OR REPLACE SECRET s3_secret (
+    TYPE S3,
+    KEY_ID '${AWS_ACCESS_KEY_ID}',
+    SECRET '${AWS_SECRET_ACCESS_KEY}',
+    USE_SSL 'FALSE',
+    ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
+    URL_STYLE 'path',
+    REGION 'us-east-1'
+);
+```
+
+## GDAL / OGR with Remote Files
+
+Use `/vsicurl/` prefix to read remote files without downloading:
+
+```bash
+# Inspect a remote geodatabase
+ogrinfo /vsicurl/https://s3-west.nrp-nautilus.io/<bucket>/raw/data.gdb
+
+# Convert a remote file to local parquet
+ogr2ogr -f Parquet output.parquet /vsicurl/https://s3-west.nrp-nautilus.io/<bucket>/raw/data.gdb "LayerName"
+```
+
+## Standard Bucket Layout
+
+```
+<bucket>/
+├── raw/                              # Source/original data (uploaded once)
+├── <dataset>.parquet                 # Cloud-optimized GeoParquet
+├── <dataset>.pmtiles                 # Vector tiles for web maps
+├── <dataset>/
+│   └── hex/
+│       └── h0={cell}/data_0.parquet  # H3 hex-indexed, hive-partitioned
+├── README.md                         # Data dictionary and usage docs
+└── stac-collection.json              # STAC metadata
+```
+
+## Syncing to Source.coop
+
+[Source.coop](https://source.coop) is a public geospatial data hosting service backed by real AWS S3. It was created by the former lead of AWS's Open Data program. We mirror our processed datasets to source.coop for broader public access.
+
+### Why run as a k8s job
+
+Large dataset syncs must be run **as a Kubernetes job on the cluster**, not from your local machine. Syncing locally means the data egresses from NRP to your machine, then re-uploads to AWS — this is slow, unreliable for large datasets, and prone to network timeouts. Running the sync as a pod means the data flows directly from NRP's internal network to AWS.
+
+### Generate a sync job
+
+```bash
+cng-datasets sync-job \
+  --job-name sync-to-source-coop \
+  --source nrp:public-mappinginequality \
+  --destination source:us-west-2.opendata.source.coop/cboettig/mappinginequality \
+  --output sync-job.yaml
+```
+
+Then apply:
+
+```bash
+kubectl apply -f sync-job.yaml
+kubectl logs -f job/sync-to-source-coop
+```
+
+### How it works
+
+- The `rclone-config` secret mounted in the pod contains a `[source]` remote configured with AWS credentials that have write access to the source.coop bucket.
+- The destination format is `source:<region>.opendata.source.coop/<org>/<repo>` — you must first create the repository via the source.coop web interface.
+- The job runs `rclone sync` inside the pod, transferring data directly from NRP Ceph to AWS S3.
+
+### Reading from source.coop in DuckDB
+
+Source.coop data is public on standard AWS S3:
+
+```sql
+CREATE OR REPLACE SECRET source_secret (
+    TYPE S3,
+    KEY_ID '',
+    SECRET '',
+    ENDPOINT 's3.amazonaws.com',
+    REGION 'us-west-2',
+    URL_STYLE 'path'
+);
+
+SELECT * FROM 's3://us-west-2.opendata.source.coop/cboettig/social-vulnerability/2022/SVI2022_US_tract.parquet' LIMIT 10;
+```
+
+Or via HTTPS: `https://data.source.coop/cboettig/<repo>/<file>`
+
+## Common Pitfalls
+
+1. **Using virtual-hosted URLs** — Always use path-style: `https://s3-west.nrp-nautilus.io/<bucket>/...`
+2. **Using the public endpoint inside pods** — Use the internal endpoint `rook-ceph-rgw-nautiluss3.rook` for all S3 operations inside the cluster
+3. **High-concurrency reads on the public endpoint** — The public endpoint throttles under concurrent load. Use the internal endpoint for parallel reads (DuckDB, many pods, etc.)
+4. **Forgetting CORS** — PMTiles and other browser-based tools require CORS to be set on the bucket
+5. **HTTPS inside pods** — The internal endpoint is HTTP, not HTTPS. Set `AWS_HTTPS=false`
+6. **Hardcoding credentials** — Always use k8s secrets, never hardcode in YAML files
+7. **Forgetting to set public policy** — New buckets are private by default; you must explicitly set the public read policy
+8. **Syncing large data locally** — Always sync large datasets to external S3 (e.g., source.coop) via a k8s job, not from your local machine


### PR DESCRIPTION
## Changes

- Add `skills/nrp-k8s/SKILL.md`: NRP Nautilus k8s batch job requirements (priority classes, resource limits, GPU avoidance, namespace quotas)
- Add `skills/nrp-s3/SKILL.md`: Ceph S3 endpoints, rclone, bucket policies, CORS, DuckDB S3 access, source.coop sync
- Add `skills/gdal-remote/SKILL.md`: Remote geospatial file reading, GDAL/OGR virtual filesystems, DuckDB spatial, format conversions

## Copilot Instructions Update

- Replace the inline Kubernetes, S3 Storage, and GDAL sections with a lazy-load skills reference table
- Copilot now knows the skills exist and when to read them, but doesn't load them upfront