### PR TITLE
Add PAD-US individual layer STAC collections; fix pmtiles wrapdateline

### DIFF
--- a/catalog/pad-us/k8s/combined/padus-4-1-combined-pmtiles.yaml
+++ b/catalog/pad-us/k8s/combined/padus-4-1-combined-pmtiles.yaml
@@ -65,7 +65,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
-          ogr2ogr -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/combined.parquet -progress
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/combined.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq
           tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl

--- a/catalog/pad-us/k8s/easement/padus-4-1-easement-pmtiles.yaml
+++ b/catalog/pad-us/k8s/easement/padus-4-1-easement-pmtiles.yaml
@@ -65,7 +65,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
-          ogr2ogr -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement.parquet -progress
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq
           tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl

--- a/catalog/pad-us/k8s/fee/padus-4-1-fee-pmtiles.yaml
+++ b/catalog/pad-us/k8s/fee/padus-4-1-fee-pmtiles.yaml
@@ -65,7 +65,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
-          ogr2ogr -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee.parquet -progress
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq
           tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl

--- a/catalog/pad-us/k8s/marine/padus-4-1-marine-pmtiles.yaml
+++ b/catalog/pad-us/k8s/marine/padus-4-1-marine-pmtiles.yaml
@@ -65,7 +65,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
-          ogr2ogr -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine.parquet -progress
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq
           tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl

--- a/catalog/pad-us/k8s/proclamation/padus-4-1-proclamation-pmtiles.yaml
+++ b/catalog/pad-us/k8s/proclamation/padus-4-1-proclamation-pmtiles.yaml
@@ -65,7 +65,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
-          ogr2ogr -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation.parquet -progress
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq
           tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl

--- a/catalog/pad-us/stac/easement-stac-collection.json
+++ b/catalog/pad-us/stac/easement-stac-collection.json
@@ -1,0 +1,171 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+    ],
+    "type": "Collection",
+    "id": "pad-us-4.1-easement",
+    "title": "PAD-US 4.1 Easement - Conservation Easements",
+    "description": "Conservation easements from PAD-US 4.1, containing 341,954 features representing legal agreements that restrict land use to protect conservation values while leaving the land in private or public ownership. Conservation easements are the most numerous protection type in PAD-US. Includes term-limited easements (see Term and Duration fields). Managed by USGS Gap Analysis Project (GAP). Indexed by H3 hexagons at resolution 10 (~15m² cells).",
+    "license": "other",
+    "license_other": "Public Domain (U.S. Government Work) - Not subject to copyright protection within the United States (17 U.S.C. § 105). International rights may apply.",
+    "keywords": [
+        "protected areas",
+        "conservation",
+        "easements",
+        "conservation easements",
+        "land trust",
+        "GAP",
+        "USGS",
+        "private conservation",
+        "United States"
+    ],
+    "providers": [
+        {
+            "name": "USGS Gap Analysis Project",
+            "roles": [
+                "producer",
+                "licensor"
+            ],
+            "url": "https://www.usgs.gov/programs/gap-analysis-project"
+        },
+        {
+            "name": "Boettiger Lab",
+            "roles": [
+                "processor",
+                "host"
+            ],
+            "url": "https://github.com/boettiger-lab"
+        }
+    ],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    14,
+                    -64,
+                    72
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1800-01-01T00:00:00Z",
+                    "2024-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement/stac-collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "describedby",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/README.md",
+            "type": "text/markdown",
+            "title": "Detailed Data Documentation and Usage Examples"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5066/P96WBCHS",
+            "title": "PAD-US 4.1 DOI"
+        },
+        {
+            "rel": "about",
+            "href": "https://www.usgs.gov/programs/gap-analysis-project/science/pad-us-data-overview",
+            "title": "PAD-US Data Overview"
+        }
+    ],
+    "summaries": {
+        "formats": [
+            "geoparquet",
+            "pmtiles",
+            "h3-parquet"
+        ],
+        "gap_status": ["1", "2", "3", "4"],
+        "iucn_categories": ["Ia", "Ib", "II", "III", "IV", "V", "VI"],
+        "owner_types": ["FED", "STAT", "LOC", "PVT", "JNT", "TRIB", "TERR", "DIST", "NGO"],
+        "public_access": ["OA", "RA", "XA", "UK"]
+    },
+    "assets": {
+        "geoparquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement.parquet",
+            "type": "application/vnd.apache.parquet",
+            "title": "GeoParquet file with 341,954 conservation easements",
+            "description": "Cloud-native GeoParquet format optimized for analytical queries. Use with DuckDB, Polars, pandas, or any GeoParquet-compatible tool. Geometries in EPSG:4326.",
+            "roles": ["data"]
+        },
+        "pmtiles": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement.pmtiles",
+            "type": "application/vnd.pmtiles",
+            "title": "PMTiles for web mapping",
+            "description": "Pyramid of map tiles in PMTiles format. Supports zoom levels 0-14 for efficient web map rendering.",
+            "vector:layers": ["easement"],
+            "roles": ["visual"]
+        },
+        "h3-parquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement/hex/",
+            "type": "application/vnd.apache.parquet",
+            "title": "H3 hex-indexed parquet files",
+            "description": "Parquet files partitioned by H3 cell at resolution 10 (~15m²). Partitioned by h0 for efficient spatial queries.",
+            "roles": ["data"],
+            "table:storage_options": {
+                "partitioning": "h0"
+            }
+        }
+    },
+    "table:columns": [
+        {"name": "_cng_fid", "type": "int64", "description": "Cloud-native geometry feature ID. Unique identifier for each easement feature."},
+        {"name": "FeatClass", "type": "string", "description": "Feature class. Always 'Easement' for this layer."},
+        {"name": "Category", "type": "string", "description": "GAP stewardship category: 'Federal Land', 'State Land', 'Local Land', 'Private Conservation Land', 'Joint Ownership', or 'Designation Area'."},
+        {"name": "Own_Type", "type": "string", "description": "Owner type code: FED (Federal), STAT (State), LOC (Local), PVT (Private), JNT (Joint), TRIB (Tribal), TERR (Territorial), DIST (District), NGO (Non-Governmental Organization)."},
+        {"name": "Own_Name", "type": "string", "description": "Owner name. Entity that holds title to the land (not the easement holder)."},
+        {"name": "Loc_Own", "type": "string", "description": "Local owner name in local terminology when different from Own_Name."},
+        {"name": "Mang_Type", "type": "string", "description": "Manager type code. Indicates the type of entity holding the easement and responsible for monitoring compliance."},
+        {"name": "Mang_Name", "type": "string", "description": "Manager name. Organization holding the conservation easement (e.g., land trust, agency)."},
+        {"name": "Loc_Mang", "type": "string", "description": "Local manager name in local terminology when different from Mang_Name."},
+        {"name": "Des_Tp", "type": "string", "description": "Designation type code (e.g., 'CE' for Conservation Easement, 'FLTCE' for Forest Legacy Trust CE)."},
+        {"name": "Loc_Ds", "type": "string", "description": "Local designation name in original language or local terminology."},
+        {"name": "Unit_Nm", "type": "string", "description": "Unit name. Official name of the easement or protected area."},
+        {"name": "Loc_Nm", "type": "string", "description": "Local or alternative name for the easement."},
+        {"name": "State_Nm", "type": "string", "description": "State name. Two-letter postal abbreviation of the U.S. state or territory."},
+        {"name": "Agg_Src", "type": "string", "description": "Aggregator source organization."},
+        {"name": "GIS_Src", "type": "string", "description": "GIS source. Original data provider or source dataset name."},
+        {"name": "Src_Date", "type": "string", "description": "Source date in YYYYMMDD or YYYY format."},
+        {"name": "GIS_Acres", "type": "int32", "description": "GIS-calculated area in acres."},
+        {"name": "Source_PAID", "type": "string", "description": "Source Protected Area ID from the source agency's dataset."},
+        {"name": "WDPA_Cd", "type": "int32", "description": "World Database on Protected Areas site code. Null for sites not in WDPA."},
+        {"name": "Pub_Access", "type": "string", "description": "Public access code: OA (Open Access), RA (Restricted Access), XA (Closed), UK (Unknown). Many easements are XA (restricted from public access)."},
+        {"name": "Access_Src", "type": "string", "description": "Source of the public access information."},
+        {"name": "Access_Dt", "type": "string", "description": "Date the public access status was determined."},
+        {"name": "GAP_Sts", "type": "string", "description": "GAP Status Code: '1'=Permanent biodiversity primary; '2'=Permanent biodiversity primary/major; '3'=Permanent multiple uses; '4'=No known biodiversity mandate."},
+        {"name": "GAPCdSrc", "type": "string", "description": "Source document used to assign the GAP Status Code."},
+        {"name": "GAPCdDt", "type": "string", "description": "Date the GAP Status Code was assigned."},
+        {"name": "IUCN_Cat", "type": "string", "description": "IUCN Protected Area Management Category: Ia, Ib, II, III, IV, V, or VI."},
+        {"name": "IUCNCtSrc", "type": "string", "description": "Source document used to assign the IUCN Category."},
+        {"name": "IUCNCtDt", "type": "string", "description": "Date the IUCN Category was assigned."},
+        {"name": "Date_Est", "type": "string", "description": "Date the easement was formally recorded or established."},
+        {"name": "Comments", "type": "string", "description": "Additional information or notes about the easement."},
+        {"name": "Term", "type": "int32", "description": "Term flag. 1 = temporary/term-limited easement; 0 or NULL = permanent easement. Important for understanding the permanence of protection."},
+        {"name": "Duration", "type": "string", "description": "Duration of protection for term-limited easements (e.g., '20 years', 'until 2050'). Null for permanent easements."},
+        {"name": "SHAPE_Length", "type": "float64", "description": "Perimeter length in meters (original CRS). Recalculate in appropriate CRS for analysis."},
+        {"name": "SHAPE_Area", "type": "float64", "description": "Area in square meters (original CRS). Use GIS_Acres for area comparisons."},
+        {"name": "SHAPE", "type": "bytes", "description": "Geometry in WKB format, EPSG:4326 (WGS84). Typically MULTIPOLYGON."},
+        {"name": "bbox", "type": "struct<xmin: double, ymin: double, xmax: double, ymax: double>", "description": "Bounding box in EPSG:4326."}
+    ]
+}

--- a/catalog/pad-us/stac/fee-stac-collection.json
+++ b/catalog/pad-us/stac/fee-stac-collection.json
@@ -1,0 +1,171 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+    ],
+    "type": "Collection",
+    "id": "pad-us-4.1-fee",
+    "title": "PAD-US 4.1 Fee - Fee-Owned Protected Areas",
+    "description": "Fee-owned protected areas from PAD-US 4.1, containing 296,456 features where land is directly owned (fee simple title) by federal, state, local, tribal, or private conservation entities. This is the largest and most commonly used PAD-US layer, covering lands such as National Parks, National Forests, state parks, and private conservation lands. Managed by USGS Gap Analysis Project (GAP). Indexed by H3 hexagons at resolution 10 (~15m² cells).",
+    "license": "other",
+    "license_other": "Public Domain (U.S. Government Work) - Not subject to copyright protection within the United States (17 U.S.C. § 105). International rights may apply.",
+    "keywords": [
+        "protected areas",
+        "conservation",
+        "fee ownership",
+        "GAP",
+        "USGS",
+        "national parks",
+        "national forests",
+        "state parks",
+        "federal lands",
+        "public lands",
+        "United States"
+    ],
+    "providers": [
+        {
+            "name": "USGS Gap Analysis Project",
+            "roles": [
+                "producer",
+                "licensor"
+            ],
+            "url": "https://www.usgs.gov/programs/gap-analysis-project"
+        },
+        {
+            "name": "Boettiger Lab",
+            "roles": [
+                "processor",
+                "host"
+            ],
+            "url": "https://github.com/boettiger-lab"
+        }
+    ],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    14,
+                    -64,
+                    72
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1800-01-01T00:00:00Z",
+                    "2024-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee/stac-collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "describedby",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/README.md",
+            "type": "text/markdown",
+            "title": "Detailed Data Documentation and Usage Examples"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5066/P96WBCHS",
+            "title": "PAD-US 4.1 DOI"
+        },
+        {
+            "rel": "about",
+            "href": "https://www.usgs.gov/programs/gap-analysis-project/science/pad-us-data-overview",
+            "title": "PAD-US Data Overview"
+        }
+    ],
+    "summaries": {
+        "formats": [
+            "geoparquet",
+            "pmtiles",
+            "h3-parquet"
+        ],
+        "gap_status": ["1", "2", "3", "4"],
+        "iucn_categories": ["Ia", "Ib", "II", "III", "IV", "V", "VI"],
+        "owner_types": ["FED", "STAT", "LOC", "PVT", "JNT", "TRIB", "TERR", "DIST", "NGO"],
+        "public_access": ["OA", "RA", "XA", "UK"]
+    },
+    "assets": {
+        "geoparquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee.parquet",
+            "type": "application/vnd.apache.parquet",
+            "title": "GeoParquet file with 296,456 fee-owned protected areas",
+            "description": "Cloud-native GeoParquet format optimized for analytical queries. Use with DuckDB, Polars, pandas, or any GeoParquet-compatible tool. Geometries in EPSG:4326.",
+            "roles": ["data"]
+        },
+        "pmtiles": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee.pmtiles",
+            "type": "application/vnd.pmtiles",
+            "title": "PMTiles for web mapping",
+            "description": "Pyramid of map tiles in PMTiles format. Supports zoom levels 0-14 for efficient web map rendering.",
+            "vector:layers": ["fee"],
+            "roles": ["visual"]
+        },
+        "h3-parquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee/hex/",
+            "type": "application/vnd.apache.parquet",
+            "title": "H3 hex-indexed parquet files",
+            "description": "Parquet files partitioned by H3 cell at resolution 10 (~15m²). Partitioned by h0 for efficient spatial queries. Each row contains a protected area feature with its intersecting H3 cell.",
+            "roles": ["data"],
+            "table:storage_options": {
+                "partitioning": "h0"
+            }
+        }
+    },
+    "table:columns": [
+        {"name": "_cng_fid", "type": "int64", "description": "Cloud-native geometry feature ID. Unique identifier for each protected area feature."},
+        {"name": "FeatClass", "type": "string", "description": "Feature class. Always 'Fee' for this layer, indicating fee simple ownership."},
+        {"name": "Category", "type": "string", "description": "GAP stewardship category: 'Federal Land', 'State Land', 'Local Land', 'Private Conservation Land', 'Joint Ownership', or 'Designation Area'."},
+        {"name": "Own_Type", "type": "string", "description": "Owner type code: FED (Federal), STAT (State), LOC (Local), PVT (Private), JNT (Joint), TRIB (Tribal), TERR (Territorial), DIST (District), NGO (Non-Governmental Organization)."},
+        {"name": "Own_Name", "type": "string", "description": "Owner name. Specific agency or entity that holds legal title to the protected area."},
+        {"name": "Loc_Own", "type": "string", "description": "Local owner name. Owner name in local terminology when different from Own_Name."},
+        {"name": "Mang_Type", "type": "string", "description": "Manager type code. Same codes as Own_Type. Indicates the type of entity responsible for day-to-day management."},
+        {"name": "Mang_Name", "type": "string", "description": "Manager name. Agency or organization responsible for day-to-day management."},
+        {"name": "Loc_Mang", "type": "string", "description": "Local manager name. Manager name in local terminology when different from Mang_Name."},
+        {"name": "Des_Tp", "type": "string", "description": "Designation type code (e.g., 'NP' for National Park, 'NWR' for National Wildlife Refuge, 'WILD' for Wilderness)."},
+        {"name": "Loc_Ds", "type": "string", "description": "Local designation. Official designation name in original language or local terminology."},
+        {"name": "Unit_Nm", "type": "string", "description": "Unit name. Official name of the protected area."},
+        {"name": "Loc_Nm", "type": "string", "description": "Local name. Alternative or historical name for the protected area."},
+        {"name": "State_Nm", "type": "string", "description": "State name. Two-letter postal abbreviation of the U.S. state or territory."},
+        {"name": "Agg_Src", "type": "string", "description": "Aggregator source. Organization that compiled the data into PAD-US."},
+        {"name": "GIS_Src", "type": "string", "description": "GIS source. Original GIS data provider or source dataset name."},
+        {"name": "Src_Date", "type": "string", "description": "Source date in YYYYMMDD or YYYY format."},
+        {"name": "GIS_Acres", "type": "int32", "description": "GIS-calculated area in acres. Most reliable area measure, calculated from the geometry."},
+        {"name": "Source_PAID", "type": "string", "description": "Source Protected Area ID from the source agency's dataset."},
+        {"name": "WDPA_Cd", "type": "int32", "description": "World Database on Protected Areas site code. Null for sites not in WDPA."},
+        {"name": "Pub_Access", "type": "string", "description": "Public access code: OA (Open Access), RA (Restricted Access), XA (Closed), UK (Unknown)."},
+        {"name": "Access_Src", "type": "string", "description": "Source of the public access information."},
+        {"name": "Access_Dt", "type": "string", "description": "Date the public access status was determined in YYYYMMDD or YYYY format."},
+        {"name": "GAP_Sts", "type": "string", "description": "GAP Status Code: '1'=Permanent biodiversity primary goal; '2'=Permanent biodiversity primary/major goal; '3'=Permanent multiple uses; '4'=No known biodiversity mandate."},
+        {"name": "GAPCdSrc", "type": "string", "description": "Source document used to assign the GAP Status Code."},
+        {"name": "GAPCdDt", "type": "string", "description": "Date the GAP Status Code was assigned in YYYYMMDD or YYYY format."},
+        {"name": "IUCN_Cat", "type": "string", "description": "IUCN Protected Area Management Category: Ia, Ib, II, III, IV, V, or VI."},
+        {"name": "IUCNCtSrc", "type": "string", "description": "Source document used to assign the IUCN Category."},
+        {"name": "IUCNCtDt", "type": "string", "description": "Date the IUCN Category was assigned in YYYYMMDD or YYYY format."},
+        {"name": "Date_Est", "type": "string", "description": "Date the protected area was formally established."},
+        {"name": "Comments", "type": "string", "description": "Additional information, caveats, or notes about the protected area feature."},
+        {"name": "SHAPE_Length", "type": "float64", "description": "Perimeter length in meters (original CRS). Recalculate in appropriate CRS for analysis."},
+        {"name": "SHAPE_Area", "type": "float64", "description": "Area in square meters (original CRS). Use GIS_Acres for area comparisons."},
+        {"name": "SHAPE", "type": "bytes", "description": "Geometry in WKB format, EPSG:4326 (WGS84). Typically MULTIPOLYGON."},
+        {"name": "bbox", "type": "struct<xmin: double, ymin: double, xmax: double, ymax: double>", "description": "Bounding box in EPSG:4326. Useful for spatial indexing."}
+    ]
+}

--- a/catalog/pad-us/stac/marine-stac-collection.json
+++ b/catalog/pad-us/stac/marine-stac-collection.json
@@ -1,0 +1,171 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+    ],
+    "type": "Collection",
+    "id": "pad-us-4.1-marine",
+    "title": "PAD-US 4.1 Marine - Marine Protected Areas",
+    "description": "Marine protected areas from PAD-US 4.1, containing 1,739 features representing coastal and offshore waters under some degree of protection. Includes National Marine Sanctuaries, Marine National Monuments, and other federal and state marine protected areas around the U.S. coastline and territories. Managed by USGS Gap Analysis Project (GAP). Indexed by H3 hexagons at resolution 10 (~15m² cells).",
+    "license": "other",
+    "license_other": "Public Domain (U.S. Government Work) - Not subject to copyright protection within the United States (17 U.S.C. § 105). International rights may apply.",
+    "keywords": [
+        "protected areas",
+        "marine protected areas",
+        "MPA",
+        "ocean",
+        "coastal",
+        "national marine sanctuaries",
+        "GAP",
+        "USGS",
+        "NOAA",
+        "biodiversity",
+        "United States"
+    ],
+    "providers": [
+        {
+            "name": "USGS Gap Analysis Project",
+            "roles": [
+                "producer",
+                "licensor"
+            ],
+            "url": "https://www.usgs.gov/programs/gap-analysis-project"
+        },
+        {
+            "name": "Boettiger Lab",
+            "roles": [
+                "processor",
+                "host"
+            ],
+            "url": "https://github.com/boettiger-lab"
+        }
+    ],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    14,
+                    -64,
+                    72
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1800-01-01T00:00:00Z",
+                    "2024-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine/stac-collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "describedby",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/README.md",
+            "type": "text/markdown",
+            "title": "Detailed Data Documentation and Usage Examples"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5066/P96WBCHS",
+            "title": "PAD-US 4.1 DOI"
+        },
+        {
+            "rel": "about",
+            "href": "https://www.usgs.gov/programs/gap-analysis-project/science/pad-us-data-overview",
+            "title": "PAD-US Data Overview"
+        }
+    ],
+    "summaries": {
+        "formats": [
+            "geoparquet",
+            "pmtiles",
+            "h3-parquet"
+        ],
+        "gap_status": ["1", "2", "3", "4"],
+        "iucn_categories": ["Ia", "Ib", "II", "III", "IV", "V", "VI"],
+        "owner_types": ["FED", "STAT", "LOC", "NGO"],
+        "public_access": ["OA", "RA", "XA", "UK"]
+    },
+    "assets": {
+        "geoparquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine.parquet",
+            "type": "application/vnd.apache.parquet",
+            "title": "GeoParquet file with 1,739 marine protected areas",
+            "description": "Cloud-native GeoParquet format optimized for analytical queries. Use with DuckDB, Polars, pandas, or any GeoParquet-compatible tool. Geometries in EPSG:4326.",
+            "roles": ["data"]
+        },
+        "pmtiles": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine.pmtiles",
+            "type": "application/vnd.pmtiles",
+            "title": "PMTiles for web mapping",
+            "description": "Pyramid of map tiles in PMTiles format. Supports zoom levels 0-14 for efficient web map rendering.",
+            "vector:layers": ["marine"],
+            "roles": ["visual"]
+        },
+        "h3-parquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine/hex/",
+            "type": "application/vnd.apache.parquet",
+            "title": "H3 hex-indexed parquet files",
+            "description": "Parquet files partitioned by H3 cell at resolution 10 (~15m²). Partitioned by h0 for efficient spatial queries.",
+            "roles": ["data"],
+            "table:storage_options": {
+                "partitioning": "h0"
+            }
+        }
+    },
+    "table:columns": [
+        {"name": "_cng_fid", "type": "int64", "description": "Cloud-native geometry feature ID. Unique identifier for each marine protected area feature."},
+        {"name": "FeatClass", "type": "string", "description": "Feature class. Always 'Marine' for this layer."},
+        {"name": "Category", "type": "string", "description": "GAP stewardship category: 'Federal Land', 'State Land', or other applicable category."},
+        {"name": "Own_Type", "type": "string", "description": "Owner type code: FED (Federal), STAT (State), LOC (Local), NGO (Non-Governmental Organization)."},
+        {"name": "Own_Name", "type": "string", "description": "Owner name. Agency holding jurisdiction over the marine area (e.g., NOAA, U.S. Navy)."},
+        {"name": "Loc_Own", "type": "string", "description": "Local owner name in local terminology when different from Own_Name."},
+        {"name": "Mang_Type", "type": "string", "description": "Manager type code. Indicates the type of entity responsible for management."},
+        {"name": "Mang_Name", "type": "string", "description": "Manager name. Agency responsible for management (e.g., NOAA Office of National Marine Sanctuaries)."},
+        {"name": "Loc_Mang", "type": "string", "description": "Local manager name in local terminology."},
+        {"name": "Des_Tp", "type": "string", "description": "Designation type code (e.g., 'NMS' for National Marine Sanctuary, 'MPA' for Marine Protected Area)."},
+        {"name": "Loc_Ds", "type": "string", "description": "Local designation name."},
+        {"name": "Unit_Nm", "type": "string", "description": "Unit name. Official name of the marine protected area."},
+        {"name": "Loc_Nm", "type": "string", "description": "Local or alternative name."},
+        {"name": "State_Nm", "type": "string", "description": "State name. Two-letter postal abbreviation. May include offshore territories."},
+        {"name": "Agg_Src", "type": "string", "description": "Aggregator source organization."},
+        {"name": "GIS_Src", "type": "string", "description": "GIS source dataset name."},
+        {"name": "Src_Date", "type": "string", "description": "Source date in YYYYMMDD or YYYY format."},
+        {"name": "GIS_Acres", "type": "int32", "description": "GIS-calculated area in acres."},
+        {"name": "Source_PAID", "type": "string", "description": "Source Protected Area ID."},
+        {"name": "WDPA_Cd", "type": "int32", "description": "World Database on Protected Areas site code."},
+        {"name": "Pub_Access", "type": "string", "description": "Public access code: OA (Open Access), RA (Restricted Access), XA (Closed), UK (Unknown)."},
+        {"name": "Access_Src", "type": "string", "description": "Source of the public access information."},
+        {"name": "Access_Dt", "type": "string", "description": "Date the public access status was determined."},
+        {"name": "GAP_Sts", "type": "string", "description": "GAP Status Code: '1'=Permanent biodiversity primary; '2'=Permanent biodiversity primary/major; '3'=Permanent multiple uses; '4'=No known biodiversity mandate."},
+        {"name": "GAPCdSrc", "type": "string", "description": "Source document used to assign the GAP Status Code."},
+        {"name": "GAPCdDt", "type": "string", "description": "Date the GAP Status Code was assigned."},
+        {"name": "IUCN_Cat", "type": "string", "description": "IUCN Protected Area Management Category: Ia, Ib, II, III, IV, V, or VI."},
+        {"name": "IUCNCtSrc", "type": "string", "description": "Source document used to assign the IUCN Category."},
+        {"name": "IUCNCtDt", "type": "string", "description": "Date the IUCN Category was assigned."},
+        {"name": "Date_Est", "type": "string", "description": "Date the marine protected area was formally established."},
+        {"name": "Comments", "type": "string", "description": "Additional information or notes."},
+        {"name": "SHAPE_Length", "type": "float64", "description": "Perimeter length in meters (original CRS)."},
+        {"name": "SHAPE_Area", "type": "float64", "description": "Area in square meters (original CRS). Use GIS_Acres for comparisons."},
+        {"name": "SHAPE", "type": "bytes", "description": "Geometry in WKB format, EPSG:4326 (WGS84). Typically MULTIPOLYGON."},
+        {"name": "bbox", "type": "struct<xmin: double, ymin: double, xmax: double, ymax: double>", "description": "Bounding box in EPSG:4326."}
+    ]
+}

--- a/catalog/pad-us/stac/proclamation-stac-collection.json
+++ b/catalog/pad-us/stac/proclamation-stac-collection.json
@@ -1,0 +1,168 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+    ],
+    "type": "Collection",
+    "id": "pad-us-4.1-proclamation",
+    "title": "PAD-US 4.1 Proclamation - Proclamation Boundaries",
+    "description": "Proclamation boundaries from PAD-US 4.1, containing 3,439 features representing the authorized (legislated or proclaimed) boundaries of protected areas, which often include private inholdings and areas not yet acquired. These boundaries reflect the full intended extent of protection as authorized by Presidential proclamations, Congress, or agency action — distinct from the actually owned (fee) lands within them. Common examples include National Monument outer boundaries and National Forest proclamation boundaries. Managed by USGS Gap Analysis Project (GAP). Indexed by H3 hexagons at resolution 10 (~15m² cells).",
+    "license": "other",
+    "license_other": "Public Domain (U.S. Government Work) - Not subject to copyright protection within the United States (17 U.S.C. § 105). International rights may apply.",
+    "keywords": [
+        "protected areas",
+        "proclamation boundaries",
+        "national monuments",
+        "authorized boundaries",
+        "GAP",
+        "USGS",
+        "federal lands",
+        "United States"
+    ],
+    "providers": [
+        {
+            "name": "USGS Gap Analysis Project",
+            "roles": [
+                "producer",
+                "licensor"
+            ],
+            "url": "https://www.usgs.gov/programs/gap-analysis-project"
+        },
+        {
+            "name": "Boettiger Lab",
+            "roles": [
+                "processor",
+                "host"
+            ],
+            "url": "https://github.com/boettiger-lab"
+        }
+    ],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    14,
+                    -64,
+                    72
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1800-01-01T00:00:00Z",
+                    "2024-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation/stac-collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "describedby",
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/README.md",
+            "type": "text/markdown",
+            "title": "Detailed Data Documentation and Usage Examples"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5066/P96WBCHS",
+            "title": "PAD-US 4.1 DOI"
+        },
+        {
+            "rel": "about",
+            "href": "https://www.usgs.gov/programs/gap-analysis-project/science/pad-us-data-overview",
+            "title": "PAD-US Data Overview"
+        }
+    ],
+    "summaries": {
+        "formats": [
+            "geoparquet",
+            "pmtiles",
+            "h3-parquet"
+        ],
+        "gap_status": ["1", "2", "3", "4"],
+        "iucn_categories": ["Ia", "Ib", "II", "III", "IV", "V", "VI"],
+        "owner_types": ["FED", "STAT", "LOC", "JNT", "TRIB"],
+        "public_access": ["OA", "RA", "XA", "UK"]
+    },
+    "assets": {
+        "geoparquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation.parquet",
+            "type": "application/vnd.apache.parquet",
+            "title": "GeoParquet file with 3,439 proclamation boundaries",
+            "description": "Cloud-native GeoParquet format optimized for analytical queries. Use with DuckDB, Polars, pandas, or any GeoParquet-compatible tool. Geometries in EPSG:4326.",
+            "roles": ["data"]
+        },
+        "pmtiles": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation.pmtiles",
+            "type": "application/vnd.pmtiles",
+            "title": "PMTiles for web mapping",
+            "description": "Pyramid of map tiles in PMTiles format. Supports zoom levels 0-14 for efficient web map rendering.",
+            "vector:layers": ["proclamation"],
+            "roles": ["visual"]
+        },
+        "h3-parquet": {
+            "href": "https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation/hex/",
+            "type": "application/vnd.apache.parquet",
+            "title": "H3 hex-indexed parquet files",
+            "description": "Parquet files partitioned by H3 cell at resolution 10 (~15m²). Partitioned by h0 for efficient spatial queries.",
+            "roles": ["data"],
+            "table:storage_options": {
+                "partitioning": "h0"
+            }
+        }
+    },
+    "table:columns": [
+        {"name": "_cng_fid", "type": "int64", "description": "Cloud-native geometry feature ID. Unique identifier for each proclamation boundary feature."},
+        {"name": "FeatClass", "type": "string", "description": "Feature class. Always 'Proclamation' for this layer."},
+        {"name": "Category", "type": "string", "description": "GAP stewardship category: 'Federal Land', 'State Land', or applicable category."},
+        {"name": "Own_Type", "type": "string", "description": "Owner type code: FED (Federal), STAT (State), LOC (Local), JNT (Joint), TRIB (Tribal)."},
+        {"name": "Own_Name", "type": "string", "description": "Owner name. Agency or entity with jurisdiction over the proclaimed area."},
+        {"name": "Loc_Own", "type": "string", "description": "Local owner name in local terminology."},
+        {"name": "Mang_Type", "type": "string", "description": "Manager type code. Indicates the type of entity responsible for management."},
+        {"name": "Mang_Name", "type": "string", "description": "Manager name. Agency managing the proclaimed area (e.g., Bureau of Land Management, National Park Service)."},
+        {"name": "Loc_Mang", "type": "string", "description": "Local manager name in local terminology."},
+        {"name": "Des_Tp", "type": "string", "description": "Designation type code (e.g., 'NM' for National Monument, 'NF' for National Forest proclamation boundary)."},
+        {"name": "Loc_Ds", "type": "string", "description": "Local designation name."},
+        {"name": "Unit_Nm", "type": "string", "description": "Unit name. Official name of the proclaimed protected area."},
+        {"name": "Loc_Nm", "type": "string", "description": "Local or alternative name."},
+        {"name": "State_Nm", "type": "string", "description": "State name. Two-letter postal abbreviation."},
+        {"name": "Agg_Src", "type": "string", "description": "Aggregator source organization."},
+        {"name": "GIS_Src", "type": "string", "description": "GIS source dataset name."},
+        {"name": "Src_Date", "type": "string", "description": "Source date in YYYYMMDD or YYYY format."},
+        {"name": "GIS_Acres", "type": "int32", "description": "GIS-calculated area in acres. Note: proclamation boundaries may include private inholdings not under protection."},
+        {"name": "Source_PAID", "type": "string", "description": "Source Protected Area ID."},
+        {"name": "WDPA_Cd", "type": "int32", "description": "World Database on Protected Areas site code."},
+        {"name": "Pub_Access", "type": "string", "description": "Public access code: OA (Open Access), RA (Restricted Access), XA (Closed), UK (Unknown)."},
+        {"name": "Access_Src", "type": "string", "description": "Source of the public access information."},
+        {"name": "Access_Dt", "type": "string", "description": "Date the public access status was determined."},
+        {"name": "GAP_Sts", "type": "string", "description": "GAP Status Code: '1'=Permanent biodiversity primary; '2'=Permanent biodiversity primary/major; '3'=Permanent multiple uses; '4'=No known biodiversity mandate."},
+        {"name": "GAPCdSrc", "type": "string", "description": "Source document used to assign the GAP Status Code."},
+        {"name": "GAPCdDt", "type": "string", "description": "Date the GAP Status Code was assigned."},
+        {"name": "IUCN_Cat", "type": "string", "description": "IUCN Protected Area Management Category: Ia, Ib, II, III, IV, V, or VI."},
+        {"name": "IUCNCtSrc", "type": "string", "description": "Source document used to assign the IUCN Category."},
+        {"name": "IUCNCtDt", "type": "string", "description": "Date the IUCN Category was assigned."},
+        {"name": "Date_Est", "type": "string", "description": "Date the proclamation was signed or boundary was formally authorized."},
+        {"name": "Comments", "type": "string", "description": "Additional information or notes."},
+        {"name": "SHAPE_Length", "type": "float64", "description": "Perimeter length in meters (original CRS)."},
+        {"name": "SHAPE_Area", "type": "float64", "description": "Area in square meters (original CRS). Use GIS_Acres for comparisons."},
+        {"name": "SHAPE", "type": "bytes", "description": "Geometry in WKB format, EPSG:4326 (WGS84). Typically MULTIPOLYGON."},
+        {"name": "bbox", "type": "struct<xmin: double, ymin: double, xmax: double, ymax: double>", "description": "Bounding box in EPSG:4326."}
+    ]
+}


### PR DESCRIPTION
## Changes

### STAC Catalog
- Add STAC collection files for all 4 individual PAD-US layers: fee, easement, marine, proclamation
- All 5 PAD-US layers (including combined) now registered in parent catalog at `public-data/stac/catalog.json`

### k8s Jobs
- Fix pmtiles jobs for all layers: add `-wrapdateline -datelineoffset 15` to `ogr2ogr` to handle antimeridian-crossing geometries