### PR TITLE
Add missing MinIO sync jobs and auto-create buckets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,41 @@ rclone copyto /tmp/catalog.json nrp:public-data/stac/catalog.json
 
 The child link should point to your dataset's `stac-collection.json` URL.
 
+### Step 7: Add a MinIO Sync Job
+
+All NRP S3 buckets are mirrored to a MinIO backup server via per-bucket k8s Jobs in `catalog/sync/k8s/`. After adding a new dataset to a **new bucket**, create a sync job for it:
+
+```bash
+# Use any existing sync job as a template
+cp catalog/sync/k8s/sync-public-padus.yaml catalog/sync/k8s/sync-<bucket>.yaml
+# Edit: replace "public-padus" with your bucket name in job name, mkdir, sync source/dest, and echo lines
+```
+
+Each sync job:
+1. Creates the destination bucket on MinIO if it doesn't exist (`rclone mkdir`)
+2. Syncs all objects from NRP to MinIO (`rclone sync` with throttling)
+
+**If your dataset uses an existing bucket** (e.g., adding a new census layer to `public-census`), the sync job already exists — no action needed.
+
+**Run sync jobs:**
+```bash
+# All buckets
+kubectl apply -f catalog/sync/k8s/
+
+# Single bucket
+kubectl apply -f catalog/sync/k8s/sync-<bucket>.yaml
+
+# Rerun a failed sync
+kubectl delete job sync-<bucket> -n biodiversity
+kubectl apply -f catalog/sync/k8s/sync-<bucket>.yaml
+```
+
+**Monitor:**
+```bash
+kubectl get jobs | grep sync
+kubectl logs job/sync-<bucket>
+```
+
 ## Common Parameters
 
 ### Memory and Chunking Mental Model

--- a/README.md
+++ b/README.md
@@ -84,11 +84,29 @@ Key commands:
 | `kubectl get jobs` | Monitors job status | Your laptop |
 | Everything else | Processing, S3 uploads, etc. | Kubernetes pods |
 
+## MinIO Backup Sync
+
+All NRP S3 buckets are mirrored to a MinIO backup server. Per-bucket sync jobs live in `catalog/sync/k8s/`:
+
+```bash
+# Sync all buckets
+kubectl apply -f catalog/sync/k8s/
+
+# Sync a single bucket
+kubectl apply -f catalog/sync/k8s/sync-public-census.yaml
+
+# Monitor
+kubectl get jobs | grep sync
+```
+
+Each job auto-creates the destination bucket on MinIO if needed, then runs `rclone sync` with bandwidth throttling. When adding a new NRP bucket, add a corresponding sync job (see [AGENTS.md](AGENTS.md) Step 7).
+
 ## Infrastructure
 
 - **Cluster:** NRP Nautilus, namespace `biodiversity`
 - **S3:** Ceph object storage (S3-compatible, not AWS)
 - **Public endpoint:** `https://s3-west.nrp-nautilus.io/<bucket>/<path>`
+- **MinIO backup:** `minio.carlboettiger.info` (synced via `catalog/sync/k8s/` jobs)
 - **Secrets:** `aws` and `rclone-config` are pre-configured in the namespace
 
 See [.github/copilot-instructions.md](.github/copilot-instructions.md) for detailed infrastructure context.

--- a/catalog/sync/k8s/sync-public-ca-wolves.yaml
+++ b/catalog/sync/k8s/sync-public-ca-wolves.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-public-hydrobasins
+  name: sync-public-ca-wolves
   namespace: biodiversity
 spec:
   backoffLimit: 1
@@ -38,10 +38,10 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
-              rclone mkdir "minio:public-hydrobasins"
-              echo "Syncing: nrp:public-hydrobasins -> minio:public-hydrobasins"
-              rclone sync $RCLONE_FLAGS "nrp:public-hydrobasins" "minio:public-hydrobasins"
-              echo "Done: public-hydrobasins"
+              rclone mkdir "minio:public-ca-wolves"
+              echo "Syncing: nrp:public-ca-wolves -> minio:public-ca-wolves"
+              rclone sync $RCLONE_FLAGS "nrp:public-ca-wolves" "minio:public-ca-wolves"
+              echo "Done: public-ca-wolves"
       volumes:
         - name: rclone-config
           secret:

--- a/catalog/sync/k8s/sync-public-ca30x30.yaml
+++ b/catalog/sync/k8s/sync-public-ca30x30.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-ca30x30"
               echo "Syncing: nrp:public-ca30x30 -> minio:public-ca30x30"
               rclone sync $RCLONE_FLAGS "nrp:public-ca30x30" "minio:public-ca30x30"
               echo "Done: public-ca30x30"

--- a/catalog/sync/k8s/sync-public-calenviroscreen.yaml
+++ b/catalog/sync/k8s/sync-public-calenviroscreen.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-calenviroscreen"
               echo "Syncing: nrp:public-calenviroscreen -> minio:public-calenviroscreen"
               rclone sync $RCLONE_FLAGS "nrp:public-calenviroscreen" "minio:public-calenviroscreen"
               echo "Done: public-calenviroscreen"

--- a/catalog/sync/k8s/sync-public-carbon.yaml
+++ b/catalog/sync/k8s/sync-public-carbon.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-carbon"
               echo "Syncing: nrp:public-carbon -> minio:public-carbon"
               rclone sync $RCLONE_FLAGS "nrp:public-carbon" "minio:public-carbon"
               echo "Done: public-carbon"

--- a/catalog/sync/k8s/sync-public-census.yaml
+++ b/catalog/sync/k8s/sync-public-census.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-census"
               echo "Syncing: nrp:public-census -> minio:public-census"
               rclone sync $RCLONE_FLAGS "nrp:public-census" "minio:public-census"
               echo "Done: public-census"

--- a/catalog/sync/k8s/sync-public-cpad.yaml
+++ b/catalog/sync/k8s/sync-public-cpad.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-cpad"
               echo "Syncing: nrp:public-cpad -> minio:public-cpad"
               rclone sync $RCLONE_FLAGS "nrp:public-cpad" "minio:public-cpad"
               echo "Done: public-cpad"

--- a/catalog/sync/k8s/sync-public-data.yaml
+++ b/catalog/sync/k8s/sync-public-data.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-data"
               echo "Syncing: nrp:public-data -> minio:public-data"
               rclone sync $RCLONE_FLAGS "nrp:public-data" "minio:public-data"
               echo "Done: public-data"

--- a/catalog/sync/k8s/sync-public-datacenters.yaml
+++ b/catalog/sync/k8s/sync-public-datacenters.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-datacenters"
               echo "Syncing: nrp:public-datacenters -> minio:public-datacenters"
               rclone sync $RCLONE_FLAGS "nrp:public-datacenters" "minio:public-datacenters"
               echo "Done: public-datacenters"

--- a/catalog/sync/k8s/sync-public-ecoregion.yaml
+++ b/catalog/sync/k8s/sync-public-ecoregion.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-ecoregion"
               echo "Syncing: nrp:public-ecoregion -> minio:public-ecoregion"
               rclone sync $RCLONE_FLAGS "nrp:public-ecoregion" "minio:public-ecoregion"
               echo "Done: public-ecoregion"

--- a/catalog/sync/k8s/sync-public-fire.yaml
+++ b/catalog/sync/k8s/sync-public-fire.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-fire"
               echo "Syncing: nrp:public-fire -> minio:public-fire"
               rclone sync $RCLONE_FLAGS "nrp:public-fire" "minio:public-fire"
               echo "Done: public-fire"

--- a/catalog/sync/k8s/sync-public-gbif.yaml
+++ b/catalog/sync/k8s/sync-public-gbif.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-gbif"
               echo "Syncing: nrp:public-gbif -> minio:public-gbif"
               rclone sync $RCLONE_FLAGS "nrp:public-gbif" "minio:public-gbif"
               echo "Done: public-gbif"

--- a/catalog/sync/k8s/sync-public-gfw.yaml
+++ b/catalog/sync/k8s/sync-public-gfw.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-public-hydrobasins
+  name: sync-public-gfw
   namespace: biodiversity
 spec:
   backoffLimit: 1
@@ -38,10 +38,10 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
-              rclone mkdir "minio:public-hydrobasins"
-              echo "Syncing: nrp:public-hydrobasins -> minio:public-hydrobasins"
-              rclone sync $RCLONE_FLAGS "nrp:public-hydrobasins" "minio:public-hydrobasins"
-              echo "Done: public-hydrobasins"
+              rclone mkdir "minio:public-gfw"
+              echo "Syncing: nrp:public-gfw -> minio:public-gfw"
+              rclone sync $RCLONE_FLAGS "nrp:public-gfw" "minio:public-gfw"
+              echo "Done: public-gfw"
       volumes:
         - name: rclone-config
           secret:

--- a/catalog/sync/k8s/sync-public-grids.yaml
+++ b/catalog/sync/k8s/sync-public-grids.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-grids"
               echo "Syncing: nrp:public-grids -> minio:public-grids"
               rclone sync $RCLONE_FLAGS "nrp:public-grids" "minio:public-grids"
               echo "Done: public-grids"

--- a/catalog/sync/k8s/sync-public-high-seas.yaml
+++ b/catalog/sync/k8s/sync-public-high-seas.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-public-hydrobasins
+  name: sync-public-high-seas
   namespace: biodiversity
 spec:
   backoffLimit: 1
@@ -38,10 +38,10 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
-              rclone mkdir "minio:public-hydrobasins"
-              echo "Syncing: nrp:public-hydrobasins -> minio:public-hydrobasins"
-              rclone sync $RCLONE_FLAGS "nrp:public-hydrobasins" "minio:public-hydrobasins"
-              echo "Done: public-hydrobasins"
+              rclone mkdir "minio:public-high-seas"
+              echo "Syncing: nrp:public-high-seas -> minio:public-high-seas"
+              rclone sync $RCLONE_FLAGS "nrp:public-high-seas" "minio:public-high-seas"
+              echo "Done: public-high-seas"
       volumes:
         - name: rclone-config
           secret:

--- a/catalog/sync/k8s/sync-public-im3.yaml
+++ b/catalog/sync/k8s/sync-public-im3.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-im3"
               echo "Syncing: nrp:public-im3 -> minio:public-im3"
               rclone sync $RCLONE_FLAGS "nrp:public-im3" "minio:public-im3"
               echo "Done: public-im3"

--- a/catalog/sync/k8s/sync-public-inat.yaml
+++ b/catalog/sync/k8s/sync-public-inat.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-inat"
               echo "Syncing: nrp:public-inat -> minio:public-inat"
               rclone sync $RCLONE_FLAGS "nrp:public-inat" "minio:public-inat"
               echo "Done: public-inat"

--- a/catalog/sync/k8s/sync-public-indigenous.yaml
+++ b/catalog/sync/k8s/sync-public-indigenous.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-indigenous"
               echo "Syncing: nrp:public-indigenous -> minio:public-indigenous"
               rclone sync $RCLONE_FLAGS "nrp:public-indigenous" "minio:public-indigenous"
               echo "Done: public-indigenous"

--- a/catalog/sync/k8s/sync-public-iucn.yaml
+++ b/catalog/sync/k8s/sync-public-iucn.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-iucn"
               echo "Syncing: nrp:public-iucn -> minio:public-iucn"
               rclone sync $RCLONE_FLAGS "nrp:public-iucn" "minio:public-iucn"
               echo "Done: public-iucn"

--- a/catalog/sync/k8s/sync-public-land-cover.yaml
+++ b/catalog/sync/k8s/sync-public-land-cover.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-public-hydrobasins
+  name: sync-public-land-cover
   namespace: biodiversity
 spec:
   backoffLimit: 1
@@ -38,10 +38,10 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
-              rclone mkdir "minio:public-hydrobasins"
-              echo "Syncing: nrp:public-hydrobasins -> minio:public-hydrobasins"
-              rclone sync $RCLONE_FLAGS "nrp:public-hydrobasins" "minio:public-hydrobasins"
-              echo "Done: public-hydrobasins"
+              rclone mkdir "minio:public-land-cover"
+              echo "Syncing: nrp:public-land-cover -> minio:public-land-cover"
+              rclone sync $RCLONE_FLAGS "nrp:public-land-cover" "minio:public-land-cover"
+              echo "Done: public-land-cover"
       volumes:
         - name: rclone-config
           secret:

--- a/catalog/sync/k8s/sync-public-mappinginequality.yaml
+++ b/catalog/sync/k8s/sync-public-mappinginequality.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-mappinginequality"
               echo "Syncing: nrp:public-mappinginequality -> minio:public-mappinginequality"
               rclone sync $RCLONE_FLAGS "nrp:public-mappinginequality" "minio:public-mappinginequality"
               echo "Done: public-mappinginequality"

--- a/catalog/sync/k8s/sync-public-mobi.yaml
+++ b/catalog/sync/k8s/sync-public-mobi.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-mobi"
               echo "Syncing: nrp:public-mobi -> minio:public-mobi"
               rclone sync $RCLONE_FLAGS "nrp:public-mobi" "minio:public-mobi"
               echo "Done: public-mobi"

--- a/catalog/sync/k8s/sync-public-ncp.yaml
+++ b/catalog/sync/k8s/sync-public-ncp.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-ncp"
               echo "Syncing: nrp:public-ncp -> minio:public-ncp"
               rclone sync $RCLONE_FLAGS "nrp:public-ncp" "minio:public-ncp"
               echo "Done: public-ncp"

--- a/catalog/sync/k8s/sync-public-overturemaps.yaml
+++ b/catalog/sync/k8s/sync-public-overturemaps.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-overturemaps"
               echo "Syncing: nrp:public-overturemaps -> minio:public-overturemaps"
               rclone sync $RCLONE_FLAGS "nrp:public-overturemaps" "minio:public-overturemaps"
               echo "Done: public-overturemaps"

--- a/catalog/sync/k8s/sync-public-padus.yaml
+++ b/catalog/sync/k8s/sync-public-padus.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-padus"
               echo "Syncing: nrp:public-padus -> minio:public-padus"
               rclone sync $RCLONE_FLAGS "nrp:public-padus" "minio:public-padus"
               echo "Done: public-padus"

--- a/catalog/sync/k8s/sync-public-rivers.yaml
+++ b/catalog/sync/k8s/sync-public-rivers.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-public-hydrobasins
+  name: sync-public-rivers
   namespace: biodiversity
 spec:
   backoffLimit: 1
@@ -38,10 +38,10 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
-              rclone mkdir "minio:public-hydrobasins"
-              echo "Syncing: nrp:public-hydrobasins -> minio:public-hydrobasins"
-              rclone sync $RCLONE_FLAGS "nrp:public-hydrobasins" "minio:public-hydrobasins"
-              echo "Done: public-hydrobasins"
+              rclone mkdir "minio:public-rivers"
+              echo "Syncing: nrp:public-rivers -> minio:public-rivers"
+              rclone sync $RCLONE_FLAGS "nrp:public-rivers" "minio:public-rivers"
+              echo "Done: public-rivers"
       volumes:
         - name: rclone-config
           secret:

--- a/catalog/sync/k8s/sync-public-social-vulnerability.yaml
+++ b/catalog/sync/k8s/sync-public-social-vulnerability.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-social-vulnerability"
               echo "Syncing: nrp:public-social-vulnerability -> minio:public-social-vulnerability"
               rclone sync $RCLONE_FLAGS "nrp:public-social-vulnerability" "minio:public-social-vulnerability"
               echo "Done: public-social-vulnerability"

--- a/catalog/sync/k8s/sync-public-tpl.yaml
+++ b/catalog/sync/k8s/sync-public-tpl.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-tpl"
               echo "Syncing: nrp:public-tpl -> minio:public-tpl"
               rclone sync $RCLONE_FLAGS "nrp:public-tpl" "minio:public-tpl"
               echo "Done: public-tpl"

--- a/catalog/sync/k8s/sync-public-wdpa.yaml
+++ b/catalog/sync/k8s/sync-public-wdpa.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-wdpa"
               echo "Syncing: nrp:public-wdpa -> minio:public-wdpa"
               rclone sync $RCLONE_FLAGS "nrp:public-wdpa" "minio:public-wdpa"
               echo "Done: public-wdpa"

--- a/catalog/sync/k8s/sync-public-wetlands.yaml
+++ b/catalog/sync/k8s/sync-public-wetlands.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-wetlands"
               echo "Syncing: nrp:public-wetlands -> minio:public-wetlands"
               rclone sync $RCLONE_FLAGS "nrp:public-wetlands" "minio:public-wetlands"
               echo "Done: public-wetlands"

--- a/catalog/sync/k8s/sync-public-wyoming.yaml
+++ b/catalog/sync/k8s/sync-public-wyoming.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: sync-public-hydrobasins
+  name: sync-public-wyoming
   namespace: biodiversity
 spec:
   backoffLimit: 1
@@ -38,10 +38,10 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
-              rclone mkdir "minio:public-hydrobasins"
-              echo "Syncing: nrp:public-hydrobasins -> minio:public-hydrobasins"
-              rclone sync $RCLONE_FLAGS "nrp:public-hydrobasins" "minio:public-hydrobasins"
-              echo "Done: public-hydrobasins"
+              rclone mkdir "minio:public-wyoming"
+              echo "Syncing: nrp:public-wyoming -> minio:public-wyoming"
+              rclone sync $RCLONE_FLAGS "nrp:public-wyoming" "minio:public-wyoming"
+              echo "Done: public-wyoming"
       volumes:
         - name: rclone-config
           secret:

--- a/catalog/sync/k8s/sync-shared-ca30x30-app.yaml
+++ b/catalog/sync/k8s/sync-shared-ca30x30-app.yaml
@@ -38,6 +38,7 @@ spec:
             - |
               set -euo pipefail
               RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:shared-ca30x30-app"
               echo "Syncing: nrp:shared-ca30x30-app -> minio:shared-ca30x30-app"
               rclone sync $RCLONE_FLAGS "nrp:shared-ca30x30-app" "minio:shared-ca30x30-app"
               echo "Done: shared-ca30x30-app"


### PR DESCRIPTION
## Summary

- All 32 sync jobs now run `rclone mkdir` before `rclone sync`, so destination buckets are created on MinIO automatically (no manual bucket creation needed)
- Added 6 missing sync jobs for buckets added since PR #70: `public-ca-wolves`, `public-gfw`, `public-high-seas`, `public-land-cover`, `public-rivers`, `public-wyoming`
- Documented sync process in AGENTS.md (new Step 7) and README.md

Closes #43 follow-up gap where new buckets weren't getting sync jobs.