### PR TITLE
Fix cgls-lc100 hex aggregation: use mode for categorical raster (#110)

### DIFF
--- a/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex.yaml
@@ -63,7 +63,7 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column lc_class
+          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column lc_class --hex-resampling mode
         resources:
           requests:
             cpu: '4'

--- a/catalog/land-cover/k8s/cgls-lc100/configmap.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/configmap.yaml
@@ -68,7 +68,7 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column lc_class
+              cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column lc_class --hex-resampling mode
             resources:
               requests:
                 cpu: '4'


### PR DESCRIPTION
## Summary

- Add `--hex-resampling mode` to the `cgls-lc100-2019` hex job so the H3 aggregation uses the most-frequent source class instead of the mean.
- Enabled by upstream fix boettiger-lab/datasets#80, which surfaced `--hex-resampling` (previously hardcoded to `gdal.GRA_Average`).

## Why

Averaging categorical land-cover codes produced non-canonical values (e.g. avg(Urban=50, Cropland=40)=45), making hex-based queries like `WHERE lc_class = 40` miss any hex spanning a class boundary. See #110.

## Verification

Reran the hex job (99 cells first pass + 23 rechunked with 50Gi ephemeral-storage after the 20Gi default tripped DuckDB sort spill). Final distinct values across all h0 partitions:

```
lc_class:  0, 20, 30, 40, 50, 60, 70, 80, 90, 100,
           111, 112, 113, 114, 115, 116,
           121, 122, 123, 124, 125, 126, 200
rows total: 23
non-canonical class values: 0
```

All 23 are canonical CGLS-LC100 codes. Zero artifacts remain.

Closes #110.