### PR TITLE
AGENTS.md: require h3 resolution fields and per-feature dedup warnings on hex assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,14 @@ rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.j
   - **Hex asset**: exclude the geometry column; include H3 index columns (`h0`, `h8`, `h9`, `h10` etc.) and `_cng_fid`/`bbox` if present
   - **PMTiles / COG assets**: no `table:columns` needed (not SQL-queryable)
 
+- **Hex assets MUST declare their H3 resolutions explicitly** via `h3:native_resolution` and `h3:parent_resolutions` on the asset itself. Column-name presence (`h10`, `h9`, …) is not enough — downstream tools shouldn't have to enumerate `table:columns` to find out what resolutions exist. `h3:native_resolution` is the finest resolution (one row per feature-cell at this res); `h3:parent_resolutions` is the list of rollup resolutions, which MUST include `0` (the partition key).
+
+- **Hex assets MUST flag per-feature duplication on any attribute a consumer might aggregate.** One hex row = one (feature, cell) pair, so any column that represents a per-feature total — area (`GIS_Acres`, `SHAPE_Area`), length (`SHAPE_Length`), population, count, amount, funding, intensity — is repeated on every cell the feature covers. The column description on the hex asset MUST state this and give a dedup recipe. Use one of:
+  - **Area/length from hex count** (never SUM the source value): `COUNT(DISTINCT h<N>) × cell_area_at_resolution_N` (res 10 ≈ 0.13 acres; res 9 ≈ 24.7 acres; res 8 ≈ 182 acres).
+  - **SUM after dedup** (when the attribute is a real per-feature value): `SELECT DISTINCT <feature_key>, <attr> …` or `ROW_NUMBER() OVER (PARTITION BY <feature_key>)` before aggregating.
+
+  Columns that are safe to aggregate on hex (H3 indexes, `_cng_fid`, `bbox`) don't need a warning. If no column on the hex asset is safe to SUM, say so once in the collection description too.
+
   ```json
   "assets": {
     "sldl-parquet": {
@@ -252,6 +260,7 @@ rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.j
       "title": "…",
       "table:columns": [
         {"name": "GEOID", "type": "string", "description": "…"},
+        {"name": "ALAND", "type": "int64", "description": "Land area in m² of the source district polygon."},
         {"name": "geometry", "type": "geometry", "description": "Feature geometry (GeoParquet)"}
       ]
     },
@@ -259,11 +268,16 @@ rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.j
       "href": "https://…/sldl/hex/h0=*/data_0.parquet",
       "type": "application/x-parquet",
       "title": "…",
+      "h3:native_resolution": 10,
+      "h3:parent_resolutions": [9, 8, 0],
       "table:columns": [
         {"name": "GEOID", "type": "string", "description": "…"},
-        {"name": "h10", "type": "integer", "description": "H3 index at resolution 10"},
-        {"name": "h8",  "type": "integer", "description": "H3 index at resolution 8"},
-        {"name": "h0",  "type": "integer", "description": "H3 index at resolution 0 (partition key)"}
+        {"name": "ALAND", "type": "int64",
+         "description": "Land area in m² of the source district polygon. **Repeated on every hex row the district covers — never SUM(ALAND) on hex data. Compute area from hex count: COUNT(DISTINCT h10) × 1,478 m².**"},
+        {"name": "h10", "type": "uint64", "description": "H3 cell ID at resolution 10 (~1,478 m² ≈ 0.13 acres)."},
+        {"name": "h9",  "type": "uint64", "description": "H3 cell ID at resolution 9 (~0.1 km² ≈ 24.7 acres)."},
+        {"name": "h8",  "type": "uint64", "description": "H3 cell ID at resolution 8 (~0.737 km² ≈ 182 acres)."},
+        {"name": "h0",  "type": "int64",  "description": "H3 cell ID at resolution 0, used as the partition key for hive-partitioned reads."}
       ]
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,14 +237,47 @@ rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.j
 
 - **Any vector asset with named layers** (PMTiles, GDB, GPKG, etc.) MUST include `"vector:layers": ["<name>"]`. For PMTiles the layer name = last segment of `--dataset`.
 
-- **`table:columns`** array documenting every column. For **coded categorical** columns (e.g. `FED`, `OA`, `PERM`), the description MUST list all valid values in `CODE=Definition, ...` format. Discover actual values via DuckDB before writing:
+- **`table:columns` goes on each parquet asset — NOT at the collection level.** Put it inside the asset object for the GeoParquet and hex assets. Do not add a top-level `table:columns` to the collection. The geo-agent reads asset-level schemas via MCP; collection-level is only a fallback for legacy datasets.
+
+  Each parquet asset documents exactly the columns it contains:
+  - **GeoParquet asset**: include the geometry column (`Shape`, `geom`, or `geometry`)
+  - **Hex asset**: exclude the geometry column; include H3 index columns (`h0`, `h8`, `h9`, `h10` etc.) and `_cng_fid`/`bbox` if present
+  - **PMTiles / COG assets**: no `table:columns` needed (not SQL-queryable)
+
+  ```json
+  "assets": {
+    "sldl-parquet": {
+      "href": "https://…/sldl.parquet",
+      "type": "application/x-parquet",
+      "title": "…",
+      "table:columns": [
+        {"name": "GEOID", "type": "string", "description": "…"},
+        {"name": "geometry", "type": "geometry", "description": "Feature geometry (GeoParquet)"}
+      ]
+    },
+    "sldl-hex": {
+      "href": "https://…/sldl/hex/h0=*/data_0.parquet",
+      "type": "application/x-parquet",
+      "title": "…",
+      "table:columns": [
+        {"name": "GEOID", "type": "string", "description": "…"},
+        {"name": "h10", "type": "integer", "description": "H3 index at resolution 10"},
+        {"name": "h8",  "type": "integer", "description": "H3 index at resolution 8"},
+        {"name": "h0",  "type": "integer", "description": "H3 index at resolution 0 (partition key)"}
+      ]
+    }
+  }
+  ```
+
+  For **coded categorical** columns, the description MUST list all valid values in `CODE=Definition, …` format and include a `"values"` array. Discover actual values via DuckDB before writing:
   ```sql
-  SELECT column_name, COUNT(*) AS n FROM read_parquet('s3://...') GROUP BY column_name ORDER BY n DESC
+  SELECT column_name, COUNT(*) AS n FROM read_parquet('s3://…') GROUP BY column_name ORDER BY n DESC
   ```
   Example:
   ```json
   {"name": "owner_type", "type": "string",
-   "description": "Owner type code. Values: FED=Federal, STAT=State, LOC=Local, NGO=Non-governmental/non-profit, TRIB=Tribal/Indigenous, PVT=Private, UNK=Unknown"}
+   "description": "Owner type code. Values: FED=Federal, STAT=State, LOC=Local, NGO=Non-governmental/non-profit, TRIB=Tribal/Indigenous, PVT=Private, UNK=Unknown",
+   "values": ["FED", "STAT", "LOC", "NGO", "TRIB", "PVT", "UNK"]}
   ```
   Missing definitions cause LLM agents to guess values (e.g. `WHERE owner_type = 'Federal'` instead of `'FED'`) and return empty results.
 


### PR DESCRIPTION
## Summary

Two new Step 5 rules that prevent the class of bugs we just fixed in #118 and #119:

1. **Hex assets MUST declare their H3 resolutions explicitly** via `h3:native_resolution` and `h3:parent_resolutions` on the asset. Column-name presence (`h10`, `h9`, …) isn't a reliable signal — downstream tools shouldn't have to enumerate `table:columns` to find out what resolutions exist.

2. **Hex-asset column descriptions MUST flag per-feature duplication on any attribute a consumer might aggregate** (area, length, amount, count, population, funding, intensity) with a dedup recipe. This is the root cause of the `SUM(GIS_Acres)` and `SUM(amount)` inflation bugs — the warnings existed in collection descriptions, which `get_schema` doesn't surface, not in column descriptions.

The JSON example is updated to show both rules with a realistic `ALAND` case.

## Background

Issue #118 (TPL `amount`): billion-dollar inflation from SUM-over-hex with no dedup guidance in the column description.

Issue #119 (PAD-US `GIS_Acres`): agent burned 8+ turns on area calculations because the warning lived in the collection description, not the column. Investigation also showed all five PAD-US sub-collections were still on legacy collection-level `table:columns` despite PR #116 documenting the asset-level standard — so the migration was whack-a-mole.

Both have been fixed on S3: `conservation-almanac-2024` and all five `padus-4-1/*` sub-collections now carry asset-level `table:columns`, the new `h3:native_resolution` / `h3:parent_resolutions` fields, and hex-asset dedup warnings. This PR just pins the authoring rule so new datasets don't reintroduce the same class of bug.

## Test plan

- [x] Live verification that all six fixed STACs carry the two new fields and pass the dedup-warning rule
- [ ] Reviewer confirms the wording is clear and the dedup recipe is practical