### PR TITLE
Customize cacao app placeholder text

### DIFF
--- a/dataset-requests/app/app.py
+++ b/dataset-requests/app/app.py
@@ -82,7 +82,6 @@ APPS = {
         ),
         "question_placeholder": CACAO_QUESTION_PLACEHOLDER,
     },
-    },
 }
 
 TEMPLATE = (Path(__file__).parent / "index.html").read_text()

--- a/dataset-requests/app/app.py
+++ b/dataset-requests/app/app.py
@@ -15,7 +15,9 @@ BUCKET = "public-requests"
 PREFIX = "dataset-requests/"
 ENDPOINT = "https://s3-west.nrp-nautilus.io"
 
+# Question placeholder text for each app
 DEFAULT_QUESTION_PLACEHOLDER = "e.g. I wanted to find which neighborhoods have the least tree canopy AND highest heat risk, but I couldn't combine those layers."
+CACAO_QUESTION_PLACEHOLDER = "e.g. I wanted to find which farms have the least tree canopy AND highest species richness, but I couldn't combine those layers."
 
 APPS = {
     "tpl": {
@@ -78,7 +80,8 @@ APPS = {
             "You can describe it in everyday terms &mdash; no need to know the "
             "technical dataset names."
         ),
-        "question_placeholder": DEFAULT_QUESTION_PLACEHOLDER,
+        "question_placeholder": CACAO_QUESTION_PLACEHOLDER,
+    },
     },
 }
 

--- a/dataset-requests/app/app.py
+++ b/dataset-requests/app/app.py
@@ -15,6 +15,8 @@ BUCKET = "public-requests"
 PREFIX = "dataset-requests/"
 ENDPOINT = "https://s3-west.nrp-nautilus.io"
 
+DEFAULT_QUESTION_PLACEHOLDER = "e.g. I wanted to find which neighborhoods have the least tree canopy AND highest heat risk, but I couldn't combine those layers."
+
 APPS = {
     "tpl": {
         "title": "TPL California Explorer",
@@ -44,6 +46,7 @@ APPS = {
             "What information would have made it easier? You can describe it "
             "in everyday terms &mdash; no need to know the technical dataset names."
         ),
+        "question_placeholder": DEFAULT_QUESTION_PLACEHOLDER,
     },
     "cacao": {
         "title": "CACAO Explorer",
@@ -75,6 +78,7 @@ APPS = {
             "You can describe it in everyday terms &mdash; no need to know the "
             "technical dataset names."
         ),
+        "question_placeholder": DEFAULT_QUESTION_PLACEHOLDER,
     },
 }
 
@@ -118,6 +122,7 @@ def render(app_id: str = ""):
         feedback_hint_block = f'<p class="hint">{feedback_hint}</p>' if feedback_hint else ""
         question_hint = cfg.get("question_hint", "")
         question_hint_block = f'<p class="hint">{question_hint}</p>' if question_hint else ""
+        question_placeholder = cfg.get("question_placeholder", DEFAULT_QUESTION_PLACEHOLDER)
         return TEMPLATE.format(
             title=cfg["title"],
             subtitle=cfg["subtitle"],
@@ -127,6 +132,7 @@ def render(app_id: str = ""):
             show_question="none",
             feedback_hint_block=feedback_hint_block,
             question_hint_block=question_hint_block,
+            question_placeholder=question_placeholder,
         )
     return TEMPLATE.format(
         title="Boettiger Lab Data Platform",
@@ -140,6 +146,7 @@ def render(app_id: str = ""):
         show_question="block",
         feedback_hint_block="",
         question_hint_block="",
+        question_placeholder=DEFAULT_QUESTION_PLACEHOLDER,
     )
 
 

--- a/dataset-requests/app/index.html
+++ b/dataset-requests/app/index.html
@@ -326,7 +326,7 @@
             <div class="form-group">
                 <label>What questions do you wish the app could answer that it can't today?</label>
                 <textarea name="question"
-                          placeholder="e.g. I wanted to find which neighborhoods have the least tree canopy AND highest heat risk, but I couldn't combine those layers."></textarea>
+                          placeholder="{question_placeholder}"></textarea>
                 {question_hint_block}
             </div>
 


### PR DESCRIPTION
Created a new object (circled in purple in screenshot below) to customize the question placeholder text for the cacao app:

<img width="749" height="97" alt="Screenshot 2026-04-23 at 8 58 44 AM" src="https://github.com/user-attachments/assets/4155e9dd-cc4b-4bd6-b8e6-3f387774bcce" />

