### PR TITLE
SNESA map-unit-polys: enrich PMTiles with description fields

### DIFF
--- a/catalog/cgs/k8s/map-unit-polys/sierra-nevada-atlas-map-unit-polys-pmtiles.yaml
+++ b/catalog/cgs/k8s/map-unit-polys/sierra-nevada-atlas-map-unit-polys-pmtiles.yaml
@@ -53,9 +53,31 @@ spec:
         - -c
         - |
           set -e
-          # Use optimized GeoParquet (has ID column) from convert job
-          # GDAL can read parquet via vsicurl
-          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/map-unit-polys.parquet -progress
+
+          # Join descriptions onto polygons so PMTiles tooltips/styling can read
+          # FullName/Age/GeoMaterial/Description directly without a client-side join.
+          python3 <<'PYEOF'
+          import duckdb
+          c = duckdb.connect()
+          c.execute("LOAD spatial; LOAD httpfs;")
+          c.execute("""
+            COPY (
+              SELECT
+                p.MapUnit,
+                p.IdentityConfidence,
+                d.FullName,
+                d.Age,
+                d.GeoMaterial,
+                d.Description,
+                p.Shape
+              FROM read_parquet('https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/map-unit-polys.parquet') p
+              LEFT JOIN read_parquet('https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/description-of-map-units.parquet') d
+              USING (MapUnit)
+            ) TO '/tmp/enriched.parquet' (FORMAT PARQUET);
+          """)
+          PYEOF
+
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /tmp/enriched.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq
           # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
@@ -67,7 +89,7 @@ spec:
 
           # Upload to S3 using rclone
           rclone copy /tmp/$DATASET.pmtiles nrp:public-cgs/sierra-nevada-atlas/
-          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles /tmp/enriched.parquet
         resources:
           requests:
             cpu: '4'


### PR DESCRIPTION
## Summary

- Joins `description-of-map-units.parquet` onto polygons on `MapUnit` in the PMTiles build step, so `FullName`, `Age`, `GeoMaterial`, and `Description` ride in the vector tiles instead of being a client-side lookup.
- MapLibre tooltips can read these directly; styling can collapse from a hand-rolled 268-MapUnit `match` (see tpl-ca's `layers-input.json` workaround) down to 27 GeoMaterial categories.
- GeoParquet, hex parquet, and the descriptions lookup are untouched — the lookup remains the canonical schema, DuckDB users can still join at query time.

PMTiles size grew **28 MB → 85 MB**, mostly Description text (avg 1360 chars × 6,221 polygons). PMTiles is range-requested in practice; acceptable for a regional dataset.

The PMTiles asset on NRP S3 is already rebuilt and the `map-unit-polys/stac-collection.json` already advertises the new `table:columns` (uploaded out-of-band, per AGENTS.md S3-canonical rule).

Refs #149.

## Test plan

- [x] Verified PMTiles upload at https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/map-unit-polys.pmtiles (84.5 MB, 2026-05-08).
- [x] Decoded one mid-zoom MVT tile and confirmed all six attribute keys (`MapUnit`, `IdentityConfidence`, `FullName`, `Age`, `GeoMaterial`, `Description`) are present on every feature.
- [x] DuckDB join coverage 6221/6221 (no NULL `MapUnit` matches missing).
- [ ] Visual check in tpl-ca after merge — confirm hover and per-GeoMaterial styling work without the 268-entry `match` workaround.