### PR TITLE
NWI reprocessed at H3 res 10 with PMTiles (per-state + tile-join)

### DIFF
--- a/catalog/wetlands/k8s/nwi-v2/add-id.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/add-id.yaml
@@ -1,0 +1,99 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-add-id
+  namespace: biodiversity
+  labels:
+    k8s-app: nwi-v2-add-id
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-add-id
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: add-id
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command: ["bash", "-c"]
+        args:
+        - |
+          set -e
+          mkdir -p /tmp/duckdb
+
+          # DuckDB streams the rewrite to S3 (no local temp file), so we avoid
+          # the convert step's 76 GB local copy that won't fit in 50Gi ephemeral.
+          python3 - <<'PY'
+          import os, duckdb
+          c = duckdb.connect(database=":memory:")
+          c.execute("INSTALL httpfs; LOAD httpfs;")
+          c.execute("INSTALL spatial; LOAD spatial;")
+          c.execute("SET memory_limit='100GB'")
+          c.execute("SET threads=8")
+          c.execute("SET temp_directory='/tmp/duckdb'")
+          c.execute(
+              "CREATE SECRET nrp (TYPE S3, ENDPOINT 's3-west.nrp-nautilus.io', URL_STYLE 'path', KEY_ID ?, SECRET ?, REGION 'us-west-2')",
+              [os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]],
+          )
+
+          # Write to a sibling URL; rclone moveto handles the swap atomically.
+          src = "s3://public-wetlands/nwi-v2.parquet"
+          dst = "s3://public-wetlands/nwi-v2-ided.parquet"
+          c.execute(f"""
+            COPY (
+              SELECT row_number() OVER () - 1 AS _cng_fid, *
+              FROM read_parquet('{src}')
+            ) TO '{dst}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+          """)
+          PY
+
+          # Replace the original parquet with the id'd version
+          rclone moveto nrp:public-wetlands/nwi-v2-ided.parquet nrp:public-wetlands/nwi-v2.parquet -v
+
+          # Verify
+          python3 - <<'VERIFY'
+          import os, duckdb
+          c = duckdb.connect()
+          c.execute("INSTALL httpfs; LOAD httpfs;")
+          c.execute(
+              "CREATE SECRET nrp (TYPE S3, ENDPOINT 's3-west.nrp-nautilus.io', URL_STYLE 'path', KEY_ID ?, SECRET ?, REGION 'us-west-2')",
+              [os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]],
+          )
+          url = "s3://public-wetlands/nwi-v2.parquet"
+          print(c.execute(f"DESCRIBE SELECT * FROM read_parquet('{url}') LIMIT 1").fetchall())
+          print(c.execute(f"SELECT COUNT(*) AS n, COUNT(DISTINCT _cng_fid) AS unique_ids, MIN(_cng_fid), MAX(_cng_fid) FROM read_parquet('{url}')").fetchall())
+          VERIFY
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        resources:
+          requests:
+            cpu: "8"
+            memory: 120Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: "8"
+            memory: 120Gi
+            ephemeral-storage: 10Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/nwi-v2/configmap.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/configmap.yaml
@@ -1,0 +1,424 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: nwi-v2-setup-bucket.yaml, nwi-v2-convert.yaml, nwi-v2-pmtiles.yaml, nwi-v2-hex.yaml, nwi-v2-repartition.yaml
+# Generation command: cng-datasets workflow --dataset nwi-v2 --source-url s3://public-wetlands/nwi-v2.parquet --bucket public-wetlands --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap nwi-v2-yamls \
+#     --from-file=nwi-v2-setup-bucket.yaml \
+#     --from-file=nwi-v2-convert.yaml \
+#     --from-file=nwi-v2-pmtiles.yaml \
+#     --from-file=nwi-v2-hex.yaml \
+#     --from-file=nwi-v2-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  nwi-v2-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: nwi-v2-convert
+      labels:
+        k8s-app: nwi-v2-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: nwi-v2-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wetlands
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wetlands/nwi-v2.parquet \
+                s3://public-wetlands/nwi-v2.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  nwi-v2-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: nwi-v2-hex
+      labels:
+        k8s-app: nwi-v2-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: nwi-v2-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wetlands
+            - name: DATASET
+              value: nwi-v2
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wetlands/nwi-v2.parquet --output s3://public-wetlands/nwi-v2/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 190327 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  nwi-v2-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: nwi-v2-pmtiles
+      labels:
+        k8s-app: nwi-v2-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: nwi-v2-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wetlands
+            - name: DATASET
+              value: nwi-v2
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wetlands/nwi-v2.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wetlands/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  nwi-v2-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: nwi-v2-repartition
+      labels:
+        k8s-app: nwi-v2-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: nwi-v2-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wetlands
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wetlands/nwi-v2/chunks --output-dir s3://public-wetlands/nwi-v2/hex --source-parquet s3://public-wetlands/nwi-v2.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  nwi-v2-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: nwi-v2-setup-bucket
+      labels:
+        k8s-app: nwi-v2-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: nwi-v2-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wetlands
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: nwi-v2-yamls
+  namespace: biodiversity

--- a/catalog/wetlands/k8s/nwi-v2/merge.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/merge.yaml
@@ -1,0 +1,136 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-merge
+  namespace: biodiversity
+  labels:
+    k8s-app: nwi-v2-merge
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-merge
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: merge
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command: ["bash", "-c"]
+        args:
+        - |
+          set -e
+          mkdir -p /tmp/duckdb
+          python3 - <<'PY'
+          import os, duckdb
+          c = duckdb.connect(database=":memory:")
+          c.execute("INSTALL httpfs; LOAD httpfs;")
+          c.execute("INSTALL spatial; LOAD spatial;")
+          c.execute("SET memory_limit='100GB'")
+          c.execute("SET threads=8")
+          c.execute("SET temp_directory='/tmp/duckdb'")
+          c.execute(
+              "CREATE SECRET nrp (TYPE S3, ENDPOINT 's3-west.nrp-nautilus.io', URL_STYLE 'path', KEY_ID ?, SECRET ?, REGION 'us-west-2')",
+              [os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]],
+          )
+
+          # 49 CONUS states + DC are EPSG:5070; AK is EPSG:3338; HI uses a custom
+          # NAD83 Albers Hawaii projection (no EPSG, encoded as projjson in the file).
+          # We strip the embedded CRS via ST_AsWKB -> ST_GeomFromWKB, then ST_Transform
+          # with the known per-group source CRS, so the UNION ALL is all EPSG:4326.
+          hi_proj = "+proj=aea +lat_1=8 +lat_2=18 +lat_0=3 +lon_0=-157 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs"
+
+          # DuckDB binds schemas across ALL files matched by a glob at parse time,
+          # so a glob covering mixed CRSs is rejected even with a row-level WHERE.
+          # Build explicit per-CRS file lists.
+          all_files = [r[0] for r in c.execute(
+              "SELECT file FROM glob('s3://public-wetlands/raw/nwi/*_Wetlands.parquet') ORDER BY file"
+          ).fetchall()]
+          print(f"Found {len(all_files)} source files", flush=True)
+
+          def matches(f, st):
+              return f.endswith(f"/{st}_Wetlands.parquet")
+
+          ak_files    = [f for f in all_files if matches(f, "AK")]
+          hi_files    = [f for f in all_files if matches(f, "HI")]
+          conus_files = [f for f in all_files if f not in ak_files and f not in hi_files]
+          assert len(ak_files) == 1 and len(hi_files) == 1
+          assert len(conus_files) == len(all_files) - 2
+          print(f"CONUS files: {len(conus_files)}; AK: 1; HI: 1", flush=True)
+
+          def fmt(lst):
+              return "[" + ", ".join(repr(s) for s in lst) + "]"
+
+          select_cols = """
+              ATTRIBUTE,
+              WETLAND_TYPE,
+              ACRES,
+              Shape_Length,
+              Shape_Area,
+              regexp_extract(filename, '([A-Z]{2,3})_Wetlands\\.parquet$', 1) AS state_code
+          """
+
+          sql = f"""
+          COPY (
+            SELECT {select_cols},
+                   ST_Transform(ST_GeomFromWKB(ST_AsWKB(geometry)),
+                                'EPSG:5070', 'EPSG:4326', always_xy := true) AS geometry
+            FROM read_parquet({fmt(conus_files)}, filename = true)
+            UNION ALL
+            SELECT {select_cols},
+                   ST_Transform(ST_GeomFromWKB(ST_AsWKB(geometry)),
+                                'EPSG:3338', 'EPSG:4326', always_xy := true) AS geometry
+            FROM read_parquet({fmt(ak_files)}, filename = true)
+            UNION ALL
+            SELECT {select_cols},
+                   ST_Transform(ST_GeomFromWKB(ST_AsWKB(geometry)),
+                                '{hi_proj}', 'EPSG:4326', always_xy := true) AS geometry
+            FROM read_parquet({fmt(hi_files)}, filename = true)
+          ) TO 's3://public-wetlands/nwi-v2.parquet'
+          (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+          """
+          print("Running merge COPY…", flush=True)
+          c.execute(sql)
+          print("done", flush=True)
+          PY
+
+          python3 - <<'VERIFY'
+          import os, duckdb
+          c = duckdb.connect()
+          c.execute("INSTALL httpfs; LOAD httpfs;")
+          c.execute("INSTALL spatial; LOAD spatial;")
+          c.execute(
+              "CREATE SECRET nrp (TYPE S3, ENDPOINT 's3-west.nrp-nautilus.io', URL_STYLE 'path', KEY_ID ?, SECRET ?, REGION 'us-west-2')",
+              [os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]],
+          )
+          url = "s3://public-wetlands/nwi-v2.parquet"
+          print(c.execute(f"SELECT COUNT(*) AS n, COUNT(DISTINCT state_code) AS states FROM read_parquet('{url}')").fetchall())
+          print(c.execute(f"SELECT state_code, COUNT(*) AS n FROM read_parquet('{url}') GROUP BY 1 ORDER BY 1").fetchall())
+          # Sanity check: WGS84 bbox covers continental US
+          print(c.execute(f"SELECT MIN(ST_XMin(geometry)), MIN(ST_YMin(geometry)), MAX(ST_XMax(geometry)), MAX(ST_YMax(geometry)) FROM read_parquet('{url}')").fetchall())
+          VERIFY
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        resources:
+          requests:
+            cpu: "8"
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: "8"
+            memory: 120Gi
+            ephemeral-storage: 50Gi

--- a/catalog/wetlands/k8s/nwi-v2/nwi-v2-convert.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/nwi-v2-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-convert
+  labels:
+    k8s-app: nwi-v2-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wetlands
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wetlands/nwi-v2.parquet \
+            s3://public-wetlands/nwi-v2.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wetlands/k8s/nwi-v2/nwi-v2-hex.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/nwi-v2-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-hex
+  labels:
+    k8s-app: nwi-v2-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wetlands
+        - name: DATASET
+          value: nwi-v2
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wetlands/nwi-v2.parquet --output s3://public-wetlands/nwi-v2/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 190327 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wetlands/k8s/nwi-v2/nwi-v2-pmtiles.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/nwi-v2-pmtiles.yaml
@@ -1,0 +1,104 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-pmtiles
+  labels:
+    k8s-app: nwi-v2-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wetlands
+        - name: DATASET
+          value: nwi-v2
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # GeoJSONSeq -> tippecanoe with sufficient ephemeral storage for the
+          # intermediate file. The namespace caps memory at 1Ti and has no
+          # hard ephemeral cap (default LimitRange of 50Gi is overridable),
+          # so request a generous 150Gi for the intermediate jsonl + tippecanoe
+          # tmp. -select drops bulky attribute columns we don't need in tiles.
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          export TIPPECANOE_MAX_THREADS
+
+          ogr2ogr -wrapdateline -datelineoffset 15 \
+                  -select _cng_fid,ATTRIBUTE,WETLAND_TYPE,state_code \
+                  -f GeoJSONSeq /tmp/$DATASET.jsonl \
+                  /vsicurl/https://s3-west.nrp-nautilus.io/public-wetlands/nwi-v2.parquet \
+                  -progress
+
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET \
+              -z14 \
+              --drop-densest-as-needed \
+              --coalesce-densest-as-needed \
+              --simplification=2 \
+              --maximum-tile-bytes=500000 \
+              --maximum-tile-features=200000 \
+              --force /tmp/$DATASET.jsonl
+
+          rm /tmp/$DATASET.jsonl
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wetlands/ -v
+          rm /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '8'
+            memory: 64Gi
+            ephemeral-storage: 150Gi
+          limits:
+            cpu: '8'
+            memory: 64Gi
+            ephemeral-storage: 150Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wetlands/k8s/nwi-v2/nwi-v2-repartition.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/nwi-v2-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-repartition
+  labels:
+    k8s-app: nwi-v2-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wetlands
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wetlands/nwi-v2/chunks --output-dir s3://public-wetlands/nwi-v2/hex --source-parquet s3://public-wetlands/nwi-v2.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wetlands/k8s/nwi-v2/nwi-v2-setup-bucket.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/nwi-v2-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-setup-bucket
+  labels:
+    k8s-app: nwi-v2-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wetlands
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wetlands/k8s/nwi-v2/per-state-pmtiles.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/per-state-pmtiles.yaml
@@ -1,0 +1,104 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-state-tiles
+  namespace: biodiversity
+  labels:
+    k8s-app: nwi-v2-state-tiles
+spec:
+  completions: 51
+  parallelism: 20
+  completionMode: Indexed
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-state-tiles
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: tile
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command: ["bash", "-c"]
+        args:
+        - |
+          set -e
+          STATES=(AL AK AZ AR CA CO CT DE DC FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY)
+          ST=${STATES[$JOB_COMPLETION_INDEX]}
+          echo "=== Processing state: $ST (index $JOB_COMPLETION_INDEX) ==="
+
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          export TIPPECANOE_MAX_THREADS
+
+          INPUT="/vsicurl/https://s3-west.nrp-nautilus.io/public-wetlands/raw/nwi/${ST}_Wetlands.parquet"
+          JSONL="/tmp/${ST}.jsonl"
+          PMTILES="/tmp/${ST}.pmtiles"
+
+          # Reproject to EPSG:4326; ogr2ogr auto-detects source CRS from parquet.
+          # -select drops bulky attrs we don't need in tiles.
+          ogr2ogr -t_srs EPSG:4326 -wrapdateline -datelineoffset 15 \
+                  -select ATTRIBUTE,WETLAND_TYPE \
+                  -f GeoJSONSeq "$JSONL" "$INPUT" -progress
+
+          ls -lh "$JSONL"
+
+          # Add state_code via sed since ogr2ogr can't compute it from filename.
+          # GeoJSONSeq features look like: {"type":"Feature","properties":{...},"geometry":{...}}
+          # We inject "state_code":"${ST}" into the properties object.
+          sed -i "s/\"properties\":{/\"properties\":{\"state_code\":\"${ST}\",/" "$JSONL"
+
+          tippecanoe -o "$PMTILES" -l nwi-v2 \
+              -z14 \
+              --drop-densest-as-needed \
+              --coalesce-densest-as-needed \
+              --simplification=2 \
+              --maximum-tile-bytes=500000 \
+              --maximum-tile-features=200000 \
+              --force "$JSONL"
+
+          ls -lh "$PMTILES"
+
+          rclone copyto "$PMTILES" "nrp:public-wetlands/nwi-v2-state-tiles/${ST}.pmtiles" -v
+          rm -f "$JSONL" "$PMTILES"
+          echo "=== Done state: $ST ==="
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        resources:
+          requests:
+            cpu: "4"
+            memory: 16Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: "4"
+            memory: 16Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/nwi-v2/pmtiles-merge.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/pmtiles-merge.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-pmtiles-merge
+  namespace: biodiversity
+  labels:
+    k8s-app: nwi-v2-pmtiles-merge
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-pmtiles-merge
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: merge
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command: ["bash", "-c"]
+        args:
+        - |
+          set -e
+          mkdir -p /tmp/state-tiles
+          # Pull all 51 per-state PMTiles
+          rclone copy nrp:public-wetlands/nwi-v2-state-tiles/ /tmp/state-tiles/ -v
+          ls -lh /tmp/state-tiles/
+
+          # tile-join concatenates 51 single-layer PMTiles into one. All inputs
+          # already share the layer name "nwi-v2", so no rename is needed. Per-state
+          # tippecanoe runs already applied size/feature limits.
+          tile-join -o /tmp/nwi-v2.pmtiles -f /tmp/state-tiles/*.pmtiles
+
+          ls -lh /tmp/nwi-v2.pmtiles
+          rclone copyto /tmp/nwi-v2.pmtiles nrp:public-wetlands/nwi-v2.pmtiles -v
+          rm -rf /tmp/state-tiles /tmp/nwi-v2.pmtiles
+          echo "=== Merge complete ==="
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        resources:
+          requests:
+            cpu: "8"
+            memory: 32Gi
+            ephemeral-storage: 100Gi
+          limits:
+            cpu: "8"
+            memory: 32Gi
+            ephemeral-storage: 100Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/nwi-v2/upload-raw.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/upload-raw.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-upload-raw
+  namespace: biodiversity
+  labels:
+    k8s-app: nwi-v2-upload-raw
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nwi-v2-upload-raw
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: rclone
+        image: rclone/rclone:latest
+        command: ["sh", "-c"]
+        args:
+        - |
+          set -e
+          rclone copy \
+            ":s3,provider=Other,endpoint=s3.us-west-2.amazonaws.com:us-west-2.opendata.source.coop/giswqs/nwi/wetlands/" \
+            "nrp:public-wetlands/raw/nwi/" \
+            --include "*_Wetlands.parquet" \
+            --transfers 16 --checkers 16 \
+            --s3-no-check-bucket --s3-disable-checksum \
+            --progress --stats=30s
+          rclone size nrp:public-wetlands/raw/nwi/
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /config/rclone
+          readOnly: true
+        env:
+        - name: RCLONE_CONFIG
+          value: /config/rclone/rclone.conf
+        resources:
+          requests:
+            cpu: "4"
+            memory: 4Gi
+            ephemeral-storage: 5Gi
+          limits:
+            cpu: "4"
+            memory: 4Gi
+            ephemeral-storage: 5Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/nwi-v2/workflow-rbac.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wetlands/k8s/nwi-v2/workflow.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/workflow.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nwi-v2-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting nwi-v2 workflow...\"\n\n# Step 0: Setup bucket\
+          \ with public access and CORS\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/nwi-v2-setup-bucket.yaml -n biodiversity\n\necho \"Waiting\
+          \ for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/nwi-v2-setup-bucket -n biodiversity\n\n# Step 1: Convert\
+          \ to optimized GeoParquet (needed by both pmtiles and hex jobs)\necho \"\
+          Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f /yamls/nwi-v2-convert.yaml\
+          \ -n biodiversity\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/nwi-v2-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/nwi-v2-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/nwi-v2-hex.yaml -n biodiversity\n\
+          \necho \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/nwi-v2-hex -n biodiversity\n\necho \"Step 3: Repartitioning\
+          \ by h0...\"\nkubectl apply -f /yamls/nwi-v2-repartition.yaml -n biodiversity\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/nwi-v2-repartition -n biodiversity\n\necho \"\u2713\
+          \ Workflow complete!\"\necho \"Note: PMTiles job may still be running in\
+          \ the background\"\necho \"\"\necho \"Clean up with:\"\necho \"  kubectl\
+          \ delete jobs nwi-v2-setup-bucket nwi-v2-convert nwi-v2-pmtiles nwi-v2-hex\
+          \ nwi-v2-repartition nwi-v2-workflow -n biodiversity\"\necho \"  kubectl\
+          \ delete configmap nwi-v2-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: nwi-v2-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
## Summary

Reprocesses **US National Wetlands Inventory** (38M features, 50 states + DC) from the old H3 res-8 hex-only output to a full modern-workflow trio at **H3 res 10**:

- `nwi-v2.parquet` — 76 GB merged GeoParquet (EPSG:4326, with `_cng_fid`)
- `nwi-v2.pmtiles` — 13 GB vector tiles (max zoom 14, source-layer `nwi-v2`)
- `nwi-v2/hex/h0=*/data_0.parquet` — 1 GB H3 res-10 hex parquet (10 h0 partitions)

STAC + README at `s3://public-wetlands/nwi/` updated; old res-8 hex deleted; MCP + tpl pods rolled.

## Workflow steps (in `catalog/wetlands/k8s/nwi-v2/`)

| Step | Notes |
|---|---|
| `upload-raw.yaml` | Mirror source.coop 51 per-state parquet to `s3://public-wetlands/raw/nwi/` |
| `merge.yaml` | DuckDB UNION ALL with per-CRS reprojection (CONUS EPSG:5070, AK EPSG:3338, HI custom NAD83 Albers) → single EPSG:4326 parquet |
| `add-id.yaml` | Assigns `_cng_fid` via `ROW_NUMBER()` (cng-convert-to-parquet's parquet→parquet path would OOM ephemeral storage with a 76 GB local temp) |
| `nwi-v2-hex.yaml` | 200 indexed pods, chunk-size 190327, H3 res 10 + parents 9,8,0 |
| `nwi-v2-repartition.yaml` | Joins chunks back to source on `_cng_fid`, partitions by h0 |
| `per-state-pmtiles.yaml` | **51 indexed pods**, each generating one state's `.pmtiles` |
| `pmtiles-merge.yaml` | `tile-join` concatenates 51 single-layer tiles into the final |

The per-state PMTiles approach is a workaround for the monolithic `ogr2ogr → tippecanoe` pipeline blowing past 50 GiB ephemeral default at this scale — see [datasets#83](https://github.com/boettiger-lab/datasets/issues/83) for the proposed upstream enhancement.

## Test plan

- [x] `curl https://s3-west.nrp-nautilus.io/public-wetlands/nwi/stac-collection.json | jq` returns valid STAC with 3 assets (`nwi-parquet`, `nwi-pmtiles`, `nwi-hex`) and `h3:native_resolution: 10`
- [x] DuckDB query against `nwi-v2.parquet` returns 38,065,251 rows across 51 distinct `state_code` values
- [x] `nwi-v2/hex/` has 10 h0 partitions totaling ~1 GB
- [x] MCP + tpl deployments rolled to pick up new STAC
- [ ] Verify PMTiles renders in MapLibre with `source-layer: "nwi-v2"`