### PR TITLE
Import EPA SAB v3 community water systems (CWS)

### DIFF
--- a/catalog/epa-sab/k8s/cws/configmap.yaml
+++ b/catalog/epa-sab/k8s/cws/configmap.yaml
@@ -1,0 +1,425 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: epa-sab-v3-cws-setup-bucket.yaml, epa-sab-v3-cws-convert.yaml, epa-sab-v3-cws-pmtiles.yaml, epa-sab-v3-cws-hex.yaml, epa-sab-v3-cws-repartition.yaml
+# Generation command: cng-datasets workflow --dataset epa-sab-v3/cws --source-url https://s3-west.nrp-nautilus.io/public-epa-water/raw/Service_Areas_V_3_0.gpkg --bucket public-epa-water --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap epa-sab-v3-cws-yamls \
+#     --from-file=epa-sab-v3-cws-setup-bucket.yaml \
+#     --from-file=epa-sab-v3-cws-convert.yaml \
+#     --from-file=epa-sab-v3-cws-pmtiles.yaml \
+#     --from-file=epa-sab-v3-cws-hex.yaml \
+#     --from-file=epa-sab-v3-cws-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  epa-sab-v3-cws-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: epa-sab-v3-cws-convert
+      labels:
+        k8s-app: epa-sab-v3-cws-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: epa-sab-v3-cws-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-epa-water
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://s3-west.nrp-nautilus.io/public-epa-water/raw/Service_Areas_V_3_0.gpkg \
+                s3://public-epa-water/epa-sab-v3/cws.parquet \
+                --row-group-size 100000 \
+                --layer CWS
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  epa-sab-v3-cws-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: epa-sab-v3-cws-hex
+      labels:
+        k8s-app: epa-sab-v3-cws-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: epa-sab-v3-cws-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-epa-water
+            - name: DATASET
+              value: epa-sab-v3-cws
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-epa-water/epa-sab-v3/cws.parquet --output s3://public-epa-water/epa-sab-v3/cws/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 224 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  epa-sab-v3-cws-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: epa-sab-v3-cws-pmtiles
+      labels:
+        k8s-app: epa-sab-v3-cws-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: epa-sab-v3-cws-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-epa-water
+            - name: DATASET
+              value: cws
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-epa-water/epa-sab-v3/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  epa-sab-v3-cws-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: epa-sab-v3-cws-repartition
+      labels:
+        k8s-app: epa-sab-v3-cws-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: epa-sab-v3-cws-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-epa-water
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-epa-water/epa-sab-v3/cws/chunks --output-dir s3://public-epa-water/epa-sab-v3/cws/hex --source-parquet s3://public-epa-water/epa-sab-v3/cws.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  epa-sab-v3-cws-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: epa-sab-v3-cws-setup-bucket
+      labels:
+        k8s-app: epa-sab-v3-cws-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: epa-sab-v3-cws-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-epa-water
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: epa-sab-v3-cws-yamls
+  namespace: biodiversity

--- a/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-convert.yaml
+++ b/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-convert.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epa-sab-v3-cws-convert
+  labels:
+    k8s-app: epa-sab-v3-cws-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: epa-sab-v3-cws-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-epa-water
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://s3-west.nrp-nautilus.io/public-epa-water/raw/Service_Areas_V_3_0.gpkg \
+            s3://public-epa-water/epa-sab-v3/cws.parquet \
+            --row-group-size 100000 \
+            --layer CWS
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-hex.yaml
+++ b/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epa-sab-v3-cws-hex
+  labels:
+    k8s-app: epa-sab-v3-cws-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: epa-sab-v3-cws-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-epa-water
+        - name: DATASET
+          value: epa-sab-v3-cws
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-epa-water/epa-sab-v3/cws.parquet --output s3://public-epa-water/epa-sab-v3/cws/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 224 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-pmtiles.yaml
+++ b/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-pmtiles.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epa-sab-v3-cws-pmtiles
+  labels:
+    k8s-app: epa-sab-v3-cws-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: epa-sab-v3-cws-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-epa-water
+        - name: DATASET
+          value: cws
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-epa-water/epa-sab-v3/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-repartition.yaml
+++ b/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epa-sab-v3-cws-repartition
+  labels:
+    k8s-app: epa-sab-v3-cws-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: epa-sab-v3-cws-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-epa-water
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-epa-water/epa-sab-v3/cws/chunks --output-dir s3://public-epa-water/epa-sab-v3/cws/hex --source-parquet s3://public-epa-water/epa-sab-v3/cws.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-setup-bucket.yaml
+++ b/catalog/epa-sab/k8s/cws/epa-sab-v3-cws-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epa-sab-v3-cws-setup-bucket
+  labels:
+    k8s-app: epa-sab-v3-cws-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: epa-sab-v3-cws-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-epa-water
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/epa-sab/k8s/cws/workflow-rbac.yaml
+++ b/catalog/epa-sab/k8s/cws/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/epa-sab/k8s/cws/workflow.yaml
+++ b/catalog/epa-sab/k8s/cws/workflow.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epa-sab-v3-cws-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting epa-sab-v3-cws workflow...\"\n\n# Step 0: Setup\
+          \ bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/epa-sab-v3-cws-setup-bucket.yaml -n biodiversity\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/epa-sab-v3-cws-setup-bucket -n biodiversity\n\n# Step\
+          \ 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/epa-sab-v3-cws-convert.yaml -n biodiversity\n\necho \"Waiting for\
+          \ GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/epa-sab-v3-cws-convert -n biodiversity\n\n# Step 2:\
+          \ Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/epa-sab-v3-cws-pmtiles.yaml -n biodiversity\n\
+          kubectl apply -f /yamls/epa-sab-v3-cws-hex.yaml -n biodiversity\n\necho\
+          \ \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/epa-sab-v3-cws-hex -n biodiversity\n\necho \"Step\
+          \ 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/epa-sab-v3-cws-repartition.yaml\
+          \ -n biodiversity\n\necho \"Waiting for repartition to complete...\"\nkubectl\
+          \ wait --for=condition=complete --timeout=3600s job/epa-sab-v3-cws-repartition\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs epa-sab-v3-cws-setup-bucket epa-sab-v3-cws-convert\
+          \ epa-sab-v3-cws-pmtiles epa-sab-v3-cws-hex epa-sab-v3-cws-repartition epa-sab-v3-cws-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap epa-sab-v3-cws-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: epa-sab-v3-cws-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/sync/k8s/sync-public-epa-water.yaml
+++ b/catalog/sync/k8s/sync-public-epa-water.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-epa-water
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-epa-water"
+              echo "Syncing: nrp:public-epa-water -> minio:public-epa-water"
+              rclone sync $RCLONE_FLAGS "nrp:public-epa-water" "minio:public-epa-water"
+              echo "Done: public-epa-water"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config


### PR DESCRIPTION
Closes #160.

Ingests version 3 (March 2026) of the U.S. EPA Office of Research and Development's **Service Area Boundary (SAB)** dataset, **CWS layer only** (transient + non-transient non-community systems can be added later as a sibling under the same bucket).

## What's published

New bucket: `public-epa-water` (public-read + CORS, MinIO mirror job included). STAC tree:

- root catalog → `public-epa-water/stac-collection.json` (new "EPA Water Datasets" domain)
  - → `public-epa-water/epa-sab-v3/cws/stac-collection.json`

| Asset | URL |
|---|---|
| GeoParquet | https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws.parquet |
| PMTiles | https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws.pmtiles |
| H3 hex (res 10) | https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/hex/h0=*/data_0.parquet |
| README | https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/README.md |
| STAC | https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/stac-collection.json |

## Pipeline details

- 44,656 source features → 44,128 represented in hex (528 very-small service areas, ~1.2%, don't cover a single H3 res-10 cell; documented in STAC summary and hex asset description).
- 95.16M total hex rows across 13 h0 partitions.
- Source GPKG (NAD83) reprojected to WGS84 (`OGC:CRS84`) at conversion time. Geometry column is `geom`.
- PMTiles `source-layer` = `cws` (last segment of `--dataset epa-sab-v3/cws`).
- Hex asset flags per-feature duplication on `Population_Served_Count`, `Service_Connections_Count`, `Shape_Area`, `Shape_Length` per the AGENTS.md convention; coded value lists in STAC `table:columns` for `Pop_Cat_5`, `Service_Area_Type`, `Model_Method`.

## Motivation

TPL is exploring engagement of water utilities in source-watershed protection, particularly in high wildfire-risk areas. CWS service-area polygons + PWSID joins to SDWIS are the canonical layer for "which utility serves the people downstream of this watershed?" Pairs with already-catalogued layers (CAL FIRE FHSZ / perimeters, HydroBasins, American Rivers, NCP).

## What this PR changes in the repo

- `catalog/epa-sab/k8s/cws/` — generated workflow YAMLs (configmap, workflow orchestrator, setup-bucket, convert, pmtiles, hex, repartition, rbac).
- `catalog/sync/k8s/sync-public-epa-water.yaml` — MinIO mirror job (not yet applied).

STAC and README files live on NRP S3 only, per AGENTS.md hard boundary 1.

## Test plan

- [x] All 5 workflow jobs ran to completion (setup-bucket → convert → pmtiles + hex (200/200) → repartition).
- [x] `cws.parquet`: 44,656 rows, geometry column `geom` typed `GEOMETRY('OGC:CRS84')`.
- [x] `cws/hex/h0=*/data_0.parquet`: 44,128 distinct `_cng_fid`; 95,160,590 total rows; columns include `h10`/`h9`/`h8`/`h0`.
- [x] Sample DuckDB query on parquet returns top-population TX systems as expected.
- [x] STAC tree traverses root → epa-water → epa-sab-v3-cws (parent links all wired).
- [ ] Visual check of PMTiles in MapLibre with `source-layer: cws`.
- [ ] `kubectl apply -f catalog/sync/k8s/sync-public-epa-water.yaml` once ready to mirror to MinIO.