### PR TITLE
wdpa: ingest WD-OECM May 2026, refactor bucket to parent + 2 children

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,6 @@ Canonical STAC/data live on NRP S3 (`s3://public-<bucket>/`, public URL `https:/
 2. Work in the worktree, commit, push, open the PR from there.
 3. Read-only investigation can stay on whatever branch is checked out — the gate is *committing*, not exploring.
 
-Use **regular merges, not squash**, on `boettiger-lab` PRs.
-
 ## ⛔ HARD BOUNDARY 2: Do NOT Touch the `cng-datasets` Tool Repo
 
 Work only in `data-workflows`. Do not edit/commit/push/PR to `boettiger-lab/datasets` or any other repo. If `cng-datasets` has a bug: file a GitHub issue on `boettiger-lab/datasets` with a minimal reproducible example (see below), tell the user, and wait. Prior hotfixes have caused production failures — the tool has tests and a deploy pipeline, and unreviewed hotfixes bypass them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,16 @@ Canonical STAC/data live on NRP S3 (`s3://public-<bucket>/`, public URL `https:/
 - Read: `curl https://s3-west.nrp-nautilus.io/<bucket>/stac-collection.json`
 - Write: edit in `/tmp/`, then `rclone copyto /tmp/... nrp:<bucket>/...`
 
+## Git workflow
+
+**Use a worktree for every dataset task.** Sessions in this repo frequently open on a stale in-flight branch (e.g. last week's paused ingest); committing there silently mixes unrelated work and forces cherry-picks later. Before staging changes:
+
+1. `git branch --show-current` — if it isn't the branch you want, invoke `superpowers:using-git-worktrees` to spin up an isolated workspace off `origin/main`.
+2. Work in the worktree, commit, push, open the PR from there.
+3. Read-only investigation can stay on whatever branch is checked out — the gate is *committing*, not exploring.
+
+Use **regular merges, not squash**, on `boettiger-lab` PRs.
+
 ## ⛔ HARD BOUNDARY 2: Do NOT Touch the `cng-datasets` Tool Repo
 
 Work only in `data-workflows`. Do not edit/commit/push/PR to `boettiger-lab/datasets` or any other repo. If `cng-datasets` has a bug: file a GitHub issue on `boettiger-lab/datasets` with a minimal reproducible example (see below), tell the user, and wait. Prior hotfixes have caused production failures — the tool has tests and a deploy pipeline, and unreviewed hotfixes bypass them.

--- a/catalog/wdpa/README.md
+++ b/catalog/wdpa/README.md
@@ -4,7 +4,7 @@
 
 ## Source Data
 
-Original geodatabase: `s3://public-wdpa/WDPA_Dec2025_Public.gdb`
+Original geodatabase: `s3://public-wdpa/wdpa-december-2025/raw/WDPA_Dec2025_Public.gdb`
 
 We process the polygon data only, layer `WDPA_poly_Dec2025` (296,046 features).
 
@@ -54,7 +54,7 @@ Convert the GDB layer to GeoParquet format:
 kubectl apply -f wdpa/convert-job.yaml -n biodiversity
 ```
 
-**Output:** `s3://public-wdpa/WDPA_Dec2025.parquet` (5.1 GB)
+**Output:** `s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet` (5.1 GB)
 
 ### 2. PMTiles Generation
 
@@ -69,7 +69,7 @@ The script converts GDB → GeoJSONSeq → PMTiles using tippecanoe.
 kubectl apply -f wdpa/pmtiles-job.yaml -n biodiversity
 ```
 
-**Output:** `s3://public-wdpa/WDPA_Dec2025.pmtiles`
+**Output:** `s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.pmtiles`
 
 ### 3. H3 Hexagon Processing
 
@@ -84,7 +84,7 @@ Processes the data in indexed chunks with parallel workers.
 kubectl apply -f wdpa/hex-job.yaml -n biodiversity
 ```
 
-**Output:** `s3://public-wdpa/chunks/chunk_*.parquet` (temporary chunks)
+**Output:** `s3://public-wdpa/wdpa-december-2025/chunks/chunk_*.parquet` (temporary chunks)
 
 ### 4. Repartitioning by H3 Resolution 0
 
@@ -99,13 +99,13 @@ Reads all chunks and writes with h0 partitioning for efficient spatial queries. 
 kubectl apply -f wdpa/repartition-job.yaml -n biodiversity
 ```
 
-**Output:** `s3://public-wdpa/hex/h0=*/` (hive-partitioned by h0)
+**Output:** `s3://public-wdpa/wdpa-december-2025/hex/h0=*/` (hive-partitioned by h0)
 
 ## Final Outputs
 
-- **GeoParquet:** `s3://public-wdpa/WDPA_Dec2025.parquet` - Full dataset with all attributes
-- **PMTiles:** `s3://public-wdpa/WDPA_Dec2025.pmtiles` - Vector tiles for web mapping
-- **H3 Hexagons:** `s3://public-wdpa/hex/` - Hive-partitioned by h0, resolution 8 hexagons
+- **GeoParquet:** `s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet` - Full dataset with all attributes
+- **PMTiles:** `s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.pmtiles` - Vector tiles for web mapping
+- **H3 Hexagons:** `s3://public-wdpa/wdpa-december-2025/hex/` - Hive-partitioned by h0, resolution 8 hexagons
 
 ## Troubleshooting
 
@@ -123,7 +123,7 @@ kubectl delete jobs -n biodiversity -l workflow=wdpa-workflow
 
 ### Manual cleanup of chunks directory
 ```bash
-mc rm --recursive --force s3/public-wdpa/chunks/
+mc rm --recursive --force s3/public-wdpa/wdpa-december-2025/chunks/
 ```
 
 ## Bucket Setup

--- a/catalog/wdpa/convert_gdb_to_parquet.sh
+++ b/catalog/wdpa/convert_gdb_to_parquet.sh
@@ -10,8 +10,8 @@ echo "Converting WDPA GDB to GeoParquet..."
 # This avoids Arrow type mapping issues when reading the parquet back
 ogr2ogr \
   -f Parquet \
-  /vsis3/public-wdpa/WDPA_Dec2025.parquet \
-  /vsis3/public-wdpa/WDPA_Dec2025_Public.gdb \
+  /vsis3/public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet \
+  /vsis3/public-wdpa/wdpa-december-2025/WDPA_Dec2025_Public.gdb \
   WDPA_poly_Dec2025 \
   -unsetFid \
   -progress
@@ -22,7 +22,7 @@ echo "GeoParquet created successfully!"
 echo "Generating PMTiles from GDB..."
 
 ogr2ogr -f GeoJSONSeq /vsistdout/ \
-  /vsis3/public-wdpa/WDPA_Dec2025_Public.gdb \
+  /vsis3/public-wdpa/wdpa-december-2025/WDPA_Dec2025_Public.gdb \
   WDPA_poly_Dec2025 \
   | tippecanoe \
   -o /tmp/WDPA_Dec2025.pmtiles \
@@ -36,7 +36,7 @@ echo "PMTiles created successfully!"
 # Upload PMTiles to S3
 echo "Uploading PMTiles to S3..."
 
-aws s3 cp /tmp/WDPA_Dec2025.pmtiles s3://public-wdpa/WDPA_Dec2025.pmtiles \
+aws s3 cp /tmp/WDPA_Dec2025.pmtiles s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.pmtiles \
   --endpoint-url https://s3-west.nrp-nautilus.io
 
 echo "All conversions complete!"

--- a/catalog/wdpa/create_parquet.sh
+++ b/catalog/wdpa/create_parquet.sh
@@ -8,8 +8,8 @@ echo "Converting WDPA GDB to GeoParquet..."
 # Convert GDB layer to GeoParquet
 ogr2ogr \
   -f Parquet \
-  /vsis3/public-wdpa/WDPA_Dec2025.parquet \
-  /vsis3/public-wdpa/WDPA_Dec2025_Public.gdb \
+  /vsis3/public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet \
+  /vsis3/public-wdpa/wdpa-december-2025/WDPA_Dec2025_Public.gdb \
   WDPA_poly_Dec2025 \
   -progress
 

--- a/catalog/wdpa/create_pmtiles.sh
+++ b/catalog/wdpa/create_pmtiles.sh
@@ -11,7 +11,7 @@ echo "Converting WDPA GDB to GeoJSONSeq for tippecanoe..."
 ogr2ogr \
   -f GeoJSONSeq \
   /tmp/WDPA_Dec2025.geojsonl \
-  /vsis3/public-wdpa/WDPA_Dec2025_Public.gdb \
+  /vsis3/public-wdpa/wdpa-december-2025/WDPA_Dec2025_Public.gdb \
   WDPA_poly_Dec2025 \
   -progress
 
@@ -36,6 +36,6 @@ echo "Uploading PMTiles to S3..."
 # Configure mc alias if not already configured
 mc alias set s3 https://${AWS_PUBLIC_ENDPOINT} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY}
 
-mc cp /tmp/WDPA_Dec2025.pmtiles s3/public-wdpa/WDPA_Dec2025.pmtiles
+mc cp /tmp/WDPA_Dec2025.pmtiles s3/public-wdpa/wdpa-december-2025/WDPA_Dec2025.pmtiles
 
 echo "PMTiles uploaded successfully!"

--- a/catalog/wdpa/hex-job.yaml
+++ b/catalog/wdpa/hex-job.yaml
@@ -119,8 +119,8 @@ spec:
                 --i "$INDEX" \
                 --zoom 8 \
                 --chunk-size 1500 \
-                --input-url s3://public-wdpa/WDPA_Dec2025.parquet \
-                --output-url s3://public-wdpa/chunks
+                --input-url s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet \
+                --output-url s3://public-wdpa/wdpa-december-2025/chunks
       volumes:
         - name: repo
           emptyDir: {}

--- a/catalog/wdpa/k8s/wdoecm-may-2026/configmap.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/configmap.yaml
@@ -1,0 +1,425 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: wdoecm-may-2026-setup-bucket.yaml, wdoecm-may-2026-convert.yaml, wdoecm-may-2026-pmtiles.yaml, wdoecm-may-2026-hex.yaml, wdoecm-may-2026-repartition.yaml
+# Generation command: cng-datasets workflow --dataset wdoecm-may-2026 --source-url https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026/raw/WDOECM_May2026_Public.gdb --bucket public-wdpa --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap wdoecm-may-2026-yamls \
+#     --from-file=wdoecm-may-2026-setup-bucket.yaml \
+#     --from-file=wdoecm-may-2026-convert.yaml \
+#     --from-file=wdoecm-may-2026-pmtiles.yaml \
+#     --from-file=wdoecm-may-2026-hex.yaml \
+#     --from-file=wdoecm-may-2026-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  wdoecm-may-2026-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wdoecm-may-2026-convert
+      labels:
+        k8s-app: wdoecm-may-2026-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wdoecm-may-2026-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wdpa
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026/raw/WDOECM_May2026_Public.gdb \
+                s3://public-wdpa/wdoecm-may-2026.parquet \
+                --row-group-size 100000 \
+                --layer WDOECM_poly_May2026
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  wdoecm-may-2026-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wdoecm-may-2026-hex
+      labels:
+        k8s-app: wdoecm-may-2026-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wdoecm-may-2026-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wdpa
+            - name: DATASET
+              value: wdoecm-may-2026
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wdpa/wdoecm-may-2026.parquet --output s3://public-wdpa/wdoecm-may-2026/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 37 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  wdoecm-may-2026-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wdoecm-may-2026-pmtiles
+      labels:
+        k8s-app: wdoecm-may-2026-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wdoecm-may-2026-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wdpa
+            - name: DATASET
+              value: wdoecm-may-2026
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wdpa/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  wdoecm-may-2026-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wdoecm-may-2026-repartition
+      labels:
+        k8s-app: wdoecm-may-2026-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wdoecm-may-2026-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wdpa
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wdpa/wdoecm-may-2026/chunks --output-dir s3://public-wdpa/wdoecm-may-2026/hex --source-parquet s3://public-wdpa/wdoecm-may-2026.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  wdoecm-may-2026-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wdoecm-may-2026-setup-bucket
+      labels:
+        k8s-app: wdoecm-may-2026-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wdoecm-may-2026-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wdpa
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: wdoecm-may-2026-yamls
+  namespace: biodiversity

--- a/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-convert.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-convert.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdoecm-may-2026-convert
+  labels:
+    k8s-app: wdoecm-may-2026-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wdoecm-may-2026-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wdpa
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026/raw/WDOECM_May2026_Public.gdb \
+            s3://public-wdpa/wdoecm-may-2026.parquet \
+            --row-group-size 100000 \
+            --layer WDOECM_poly_May2026
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-hex.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdoecm-may-2026-hex
+  labels:
+    k8s-app: wdoecm-may-2026-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wdoecm-may-2026-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wdpa
+        - name: DATASET
+          value: wdoecm-may-2026
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wdpa/wdoecm-may-2026.parquet --output s3://public-wdpa/wdoecm-may-2026/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 37 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-pmtiles.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-pmtiles.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdoecm-may-2026-pmtiles
+  labels:
+    k8s-app: wdoecm-may-2026-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wdoecm-may-2026-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wdpa
+        - name: DATASET
+          value: wdoecm-may-2026
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wdpa/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-repartition.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdoecm-may-2026-repartition
+  labels:
+    k8s-app: wdoecm-may-2026-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wdoecm-may-2026-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wdpa
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wdpa/wdoecm-may-2026/chunks --output-dir s3://public-wdpa/wdoecm-may-2026/hex --source-parquet s3://public-wdpa/wdoecm-may-2026.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-setup-bucket.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/wdoecm-may-2026-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdoecm-may-2026-setup-bucket
+  labels:
+    k8s-app: wdoecm-may-2026-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wdoecm-may-2026-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wdpa
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wdpa/k8s/wdoecm-may-2026/workflow-rbac.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wdpa/k8s/wdoecm-may-2026/workflow.yaml
+++ b/catalog/wdpa/k8s/wdoecm-may-2026/workflow.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdoecm-may-2026-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting wdoecm-may-2026 workflow...\"\n\n# Step 0:\
+          \ Setup bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/wdoecm-may-2026-setup-bucket.yaml -n biodiversity\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/wdoecm-may-2026-setup-bucket -n biodiversity\n\n# Step\
+          \ 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/wdoecm-may-2026-convert.yaml -n biodiversity\n\necho \"Waiting\
+          \ for GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/wdoecm-may-2026-convert -n biodiversity\n\n# Step\
+          \ 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/wdoecm-may-2026-pmtiles.yaml -n biodiversity\n\
+          kubectl apply -f /yamls/wdoecm-may-2026-hex.yaml -n biodiversity\n\necho\
+          \ \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/wdoecm-may-2026-hex -n biodiversity\n\necho \"Step\
+          \ 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/wdoecm-may-2026-repartition.yaml\
+          \ -n biodiversity\n\necho \"Waiting for repartition to complete...\"\nkubectl\
+          \ wait --for=condition=complete --timeout=3600s job/wdoecm-may-2026-repartition\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs wdoecm-may-2026-setup-bucket\
+          \ wdoecm-may-2026-convert wdoecm-may-2026-pmtiles wdoecm-may-2026-hex wdoecm-may-2026-repartition\
+          \ wdoecm-may-2026-workflow -n biodiversity\"\necho \"  kubectl delete configmap\
+          \ wdoecm-may-2026-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: wdoecm-may-2026-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wdpa/k8s/wdpa-reencode-hex.yaml
+++ b/catalog/wdpa/k8s/wdpa-reencode-hex.yaml
@@ -90,22 +90,22 @@ spec:
           con.execute("""
               COPY (
                   SELECT * EXCLUDE (h8, h0), h3_string_to_h3(h8) AS h8, h3_string_to_h3(h0) AS h0
-                  FROM read_parquet('s3://public-wdpa/hex/**/*.parquet', hive_partitioning=true)
-              ) TO 's3://public-wdpa/hex-new/'
+                  FROM read_parquet('s3://public-wdpa/wdpa-december-2025/hex/**/*.parquet', hive_partitioning=true)
+              ) TO 's3://public-wdpa/wdpa-december-2025/hex-new/'
               (FORMAT PARQUET, COMPRESSION ZSTD, PARTITION_BY (h0), OVERWRITE_OR_IGNORE true)
           """)
           print("Done.")
           PYEOF
 
-          N=$(rclone ls nrp:public-wdpa/hex-new/ | wc -l)
+          N=$(rclone ls nrp:public-wdpa/wdpa-december-2025/hex-new/ | wc -l)
           echo "  ${N} files in output"
           if [ "$N" -lt 1 ]; then echo "ERROR: no output files"; exit 1; fi
 
-          SRC_DIR=$(echo "s3://public-wdpa/hex/**/*.parquet" | sed 's|/\*\*.*||')
+          SRC_DIR=$(echo "s3://public-wdpa/wdpa-december-2025/hex/**/*.parquet" | sed 's|/\*\*.*||')
           SRC_RCLONE=$(echo "$SRC_DIR" | sed 's|s3://|nrp:|')
-          echo "Swapping $SRC_RCLONE -> nrp:public-wdpa/hex/hex/ ..."
+          echo "Swapping $SRC_RCLONE -> ${SRC_RCLONE}/ ..."
           rclone delete "$SRC_RCLONE/"
-          rclone move nrp:public-wdpa/hex-new/ "${SRC_RCLONE}/"
+          rclone move nrp:public-wdpa/wdpa-december-2025/hex-new/ "${SRC_RCLONE}/"
           echo "=== Complete ==="
       volumes:
       - name: rclone-config

--- a/catalog/wdpa/orchestrate.sh
+++ b/catalog/wdpa/orchestrate.sh
@@ -91,14 +91,14 @@ cleanup_chunks() {
     
     # Use mc (minio client) or aws cli to remove chunks
     if command -v mc &> /dev/null; then
-        mc rm --recursive --force s3/public-wdpa/chunks/ 2>/dev/null || true
+        mc rm --recursive --force s3/public-wdpa/wdpa-december-2025/chunks/ 2>/dev/null || true
         echo "✓ Chunks directory removed (mc)"
     elif command -v aws &> /dev/null; then
-        aws s3 rm s3://public-wdpa/chunks/ --recursive --endpoint-url https://s3-west.nrp-nautilus.io 2>/dev/null || true
+        aws s3 rm s3://public-wdpa/wdpa-december-2025/chunks/ --recursive --endpoint-url https://s3-west.nrp-nautilus.io 2>/dev/null || true
         echo "✓ Chunks directory removed (aws)"
     else
         echo "⚠ Neither mc nor aws cli found, skipping cleanup"
-        echo "  Run manually: mc rm --recursive --force s3/public-wdpa/chunks/"
+        echo "  Run manually: mc rm --recursive --force s3/public-wdpa/wdpa-december-2025/chunks/"
     fi
 }
 

--- a/catalog/wdpa/repartition.py
+++ b/catalog/wdpa/repartition.py
@@ -18,7 +18,7 @@ os.makedirs(local_dir, exist_ok=True)
 print("Reading chunks and writing to local directory with h0 partitioning...")
 # Read all chunks and write to local directory with h0 partitioning
 (con
-    .read_parquet("s3://public-wdpa/chunks/*.parquet")
+    .read_parquet("s3://public-wdpa/wdpa-december-2025/chunks/*.parquet")
     .to_parquet(f"{local_dir}/", partition_by="h0")
 )
 
@@ -26,7 +26,7 @@ print("Uploading partitioned data to S3...")
 # Upload from local directory to S3 with h0 partitioning
 (con
     .read_parquet(f"{local_dir}/**/*.parquet")
-    .to_parquet("s3://public-wdpa/hex/", partition_by="h0")
+    .to_parquet("s3://public-wdpa/wdpa-december-2025/hex/", partition_by="h0")
 )
 
 print("Cleaning up local directory...")
@@ -40,7 +40,7 @@ print("Removing chunks directory from S3...")
 try:
     # Try using mc (minio client) first
     result = subprocess.run(
-        ["mc", "rm", "--recursive", "--force", "s3/public-wdpa/chunks/"],
+        ["mc", "rm", "--recursive", "--force", "s3/public-wdpa/wdpa-december-2025/chunks/"],
         capture_output=True,
         text=True,
         timeout=300
@@ -51,7 +51,7 @@ try:
         print(f"⚠ mc cleanup failed: {result.stderr}")
         # Try aws cli as fallback
         result = subprocess.run(
-            ["aws", "s3", "rm", "s3://public-wdpa/chunks/", "--recursive",
+            ["aws", "s3", "rm", "s3://public-wdpa/wdpa-december-2025/chunks/", "--recursive",
              "--endpoint-url", os.environ.get("AWS_PUBLIC_ENDPOINT", "https://s3-west.nrp-nautilus.io")],
             capture_output=True,
             text=True,

--- a/catalog/wdpa/vec.py
+++ b/catalog/wdpa/vec.py
@@ -44,8 +44,8 @@ def main():
     parser.add_argument("--i", type=int, default=0, help="Chunk index to process (0-based)")
     parser.add_argument("--zoom", type=int, default=8, help="H3 resolution to aggregate to (default 8)")
     parser.add_argument("--chunk-size", type=int, default=1500, help="Number of rows per chunk")
-    parser.add_argument("--input-url", default="s3://public-wdpa/WDPA_Dec2025.parquet", help="Input geoparquet file")
-    parser.add_argument("--output-url", default="s3://public-wdpa/chunks", help="Output geoparquet bucket")
+    parser.add_argument("--input-url", default="s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet", help="Input geoparquet file")
+    parser.add_argument("--output-url", default="s3://public-wdpa/wdpa-december-2025/chunks", help="Output geoparquet bucket")
     args = parser.parse_args()
 
 

--- a/catalog/wetlands/ramsar/README.md
+++ b/catalog/wetlands/ramsar/README.md
@@ -8,7 +8,7 @@ The Ramsar dataset is built from multiple data sources to maximize coverage:
 
 1. **Original Ramsar polygons**: `s3://public-wetlands/ramsar/ramsar_wetlands.parquet` (7,401 features)
 2. **Site details metadata**: `s3://public-wetlands/ramsar/site-details.parquet` - comprehensive site information
-3. **WDPA database**: `s3://public-wdpa/WDPA_Dec2025.parquet` - used for fuzzy matching missing sites
+3. **WDPA database**: `s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet` - used for fuzzy matching missing sites
 4. **Centroid points**: `s3://public-wetlands/ramsar/raw/features_centroid_publishedPoint.parquet` - fallback for sites without polygons
 
 ## Processing Pipeline

--- a/catalog/wetlands/ramsar/join_ramsar_data.py
+++ b/catalog/wetlands/ramsar/join_ramsar_data.py
@@ -45,7 +45,7 @@ def main():
     # Define data sources
     ramsar_polygons = "s3://public-wetlands/ramsar/ramsar_wetlands.parquet"
     site_details = "s3://public-wetlands/ramsar/site-details.parquet"
-    wdpa = "s3://public-wdpa/WDPA_Dec2025.parquet"
+    wdpa = "s3://public-wdpa/wdpa-december-2025/WDPA_Dec2025.parquet"
     centroids = "s3://public-wetlands/ramsar/raw/features_centroid_publishedPoint.parquet"
     
     print("\n=== Step 1: Join existing ramsar polygons with site details ===")


### PR DESCRIPTION
Closes #169. Spawned from #161 (Fajardo et al. 2026 reproducibility, item #1).

## What changed on S3

`public-wdpa` was a flat single-dataset bucket. It's now a parent catalog with two peer children:

```
public-wdpa/
├── stac-collection.json                  # parent: id=protected-planet
├── README.md
├── wdpa-december-2025/
│   ├── stac-collection.json
│   ├── README.md
│   ├── WDPA_Dec2025.{parquet,pmtiles}
│   ├── hex/h0=*/data_0.parquet           # native H3 res 8
│   └── raw/WDPA_Dec2025_Public.gdb/
└── wdoecm-may-2026/                      # NEW
    ├── stac-collection.json
    ├── README.md
    ├── wdoecm-may-2026.{parquet,pmtiles}
    ├── hex/h0=*/data_0.parquet           # native H3 res 8 — joins on h8 with WDPA
    └── raw/WDOECM_May2026_Public.{zip,gdb}/
```

While I was reworking the WDPA child STAC, I also added the previously-missing `wdpa-parquet` asset and fixed the truncated 3-column `wdpa-hex-parquet` table:columns (actual hex has 38 columns).

The root catalog (`public-data/stac/catalog.json`) was updated: `public-wdpa` child link `id` is now `protected-planet` (was `wdpa-december-2025`).

## What WD-OECM is

UNEP-WCMC companion to WDPA on Protected Planet. The CBD Global Biodiversity Framework Target 3 ("30x30") **currently-conserved** baseline is **PA ∪ OECM**, not WDPA alone — every coverage analysis in the catalog inherits this. 7,378 polygons, global, identical schema to WDPA (sister database).

Native hex resolution **8** to match WDPA — res 10 OOM'd on the largest OECM polygons (~540,000 km² Algerian wildlife reserves). With both at the same native res, `UNION` on `h8` gives combined coverage at zero cost.

## What's in this PR

- `catalog/wdpa/k8s/wdoecm-may-2026/` — generated workflow YAMLs (`cng-datasets workflow`)
- `catalog/wdpa/{vec.py, repartition.py, hex-job.yaml, README.md}` — historical Dec-2025 scripts: rewrote `s3://public-wdpa/{WDPA_Dec2025.*, hex/, chunks/}` → `s3://public-wdpa/wdpa-december-2025/...`
- `catalog/wdpa/k8s/wdpa-reencode-hex.yaml` — same URL update
- `catalog/wetlands/ramsar/{join_ramsar_data.py, README.md}` — Ramsar pipeline fuzzy-matches against WDPA and would 404 next run without the URL update
- `AGENTS.md` — added a short git-workflow note recommending worktrees + regular merges

## Test plan

- [x] STAC navigates from root → parent → both children, every URL returns 200
- [x] OECM parquet, pmtiles, hex h0=* glob queryable via DuckDB
- [x] OECM hex h8 column joinable with WDPA hex h8 (same resolution, same type)
- [x] No stale `public-wdpa/(WDPA_Dec2025|hex/|chunks)` URLs in S3 STAC/README/repo (post-update sweep)
- [ ] **Reviewer to confirm**: any geo-agent app configs (`viz/`, prompt files) referencing the old bucket-root URLs that need updating in their respective repos

## Merge

Regular merge, not squash.