### PR TITLE
trails: ingest federal trails (USFS NFST + NPS Trails) at H3 res 8

### DIFF
--- a/catalog/sync/k8s/sync-public-trails.yaml
+++ b/catalog/sync/k8s/sync-public-trails.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-trails
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-trails"
+              echo "Syncing: nrp:public-trails -> minio:public-trails"
+              rclone sync $RCLONE_FLAGS "nrp:public-trails" "minio:public-trails"
+              echo "Done: public-trails"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/trails/k8s/federal-trails-2026/configmap.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/configmap.yaml
@@ -1,0 +1,424 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: federal-trails-2026-setup-bucket.yaml, federal-trails-2026-convert.yaml, federal-trails-2026-pmtiles.yaml, federal-trails-2026-hex.yaml, federal-trails-2026-repartition.yaml
+# Generation command: cng-datasets workflow --dataset federal-trails-2026 --source-url s3://public-trails/federal-trails-2026.parquet --bucket public-trails --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap federal-trails-2026-yamls \
+#     --from-file=federal-trails-2026-setup-bucket.yaml \
+#     --from-file=federal-trails-2026-convert.yaml \
+#     --from-file=federal-trails-2026-pmtiles.yaml \
+#     --from-file=federal-trails-2026-hex.yaml \
+#     --from-file=federal-trails-2026-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  federal-trails-2026-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: federal-trails-2026-convert
+      labels:
+        k8s-app: federal-trails-2026-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: federal-trails-2026-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-trails
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-trails/federal-trails-2026.parquet \
+                s3://public-trails/federal-trails-2026.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  federal-trails-2026-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: federal-trails-2026-hex
+      labels:
+        k8s-app: federal-trails-2026-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: federal-trails-2026-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-trails
+            - name: DATASET
+              value: federal-trails-2026
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-trails/federal-trails-2026.parquet --output s3://public-trails/federal-trails-2026/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  federal-trails-2026-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: federal-trails-2026-pmtiles
+      labels:
+        k8s-app: federal-trails-2026-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: federal-trails-2026-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-trails
+            - name: DATASET
+              value: federal-trails-2026
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-trails/federal-trails-2026.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-trails/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  federal-trails-2026-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: federal-trails-2026-repartition
+      labels:
+        k8s-app: federal-trails-2026-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: federal-trails-2026-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-trails
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-trails/federal-trails-2026/chunks --output-dir s3://public-trails/federal-trails-2026/hex --source-parquet s3://public-trails/federal-trails-2026.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  federal-trails-2026-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: federal-trails-2026-setup-bucket
+      labels:
+        k8s-app: federal-trails-2026-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: federal-trails-2026-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-trails
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: federal-trails-2026-yamls
+  namespace: biodiversity

--- a/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-convert.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-convert
+  labels:
+    k8s-app: federal-trails-2026-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: federal-trails-2026-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-trails
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-trails/federal-trails-2026.parquet \
+            s3://public-trails/federal-trails-2026.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-hex.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-hex
+  labels:
+    k8s-app: federal-trails-2026-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: federal-trails-2026-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-trails
+        - name: DATASET
+          value: federal-trails-2026
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-trails/federal-trails-2026.parquet --output s3://public-trails/federal-trails-2026/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-pmtiles.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-pmtiles.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-pmtiles
+  labels:
+    k8s-app: federal-trails-2026-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: federal-trails-2026-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-trails
+        - name: DATASET
+          value: federal-trails-2026
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-trails/federal-trails-2026.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-trails/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-repartition.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-repartition
+  labels:
+    k8s-app: federal-trails-2026-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: federal-trails-2026-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-trails
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-trails/federal-trails-2026/chunks --output-dir s3://public-trails/federal-trails-2026/hex --source-parquet s3://public-trails/federal-trails-2026.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-setup-bucket.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/federal-trails-2026-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-setup-bucket
+  labels:
+    k8s-app: federal-trails-2026-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: federal-trails-2026-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-trails
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
@@ -1,0 +1,250 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-preprocess
+  namespace: biodiversity
+  labels:
+    k8s-app: federal-trails-2026-preprocess
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: federal-trails-2026-preprocess
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - "true"
+      containers:
+      - name: preprocess
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "16Gi"
+            cpu: "4"
+            ephemeral-storage: "30Gi"
+          limits:
+            memory: "16Gi"
+            cpu: "4"
+            ephemeral-storage: "30Gi"
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: "rook-ceph-rgw-nautiluss3.rook"
+        - name: AWS_PUBLIC_ENDPOINT
+          value: "s3-west.nrp-nautilus.io"
+        - name: AWS_HTTPS
+          value: "false"
+        - name: AWS_VIRTUAL_HOSTING
+          value: "FALSE"
+        - name: BUCKET
+          value: "public-trails"
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+
+          mkdir -p /tmp/trails && cd /tmp/trails
+
+          # Ensure target bucket exists
+          rclone mkdir nrp:public-trails 2>/dev/null || true
+          rclone mkdir nrp:public-trails/raw 2>/dev/null || true
+
+          # ── 1. USFS National Forest System Trails (NFST) ──────────────────────
+          echo "=== USFS NFST ==="
+          curl -sSL --retry 5 -o usfs.gdb.zip \
+            "https://data.fs.usda.gov/geodata/edw/edw_resources/fc/S_USA.TrailNFS_Publish.gdb.zip"
+          rclone copyto usfs.gdb.zip nrp:public-trails/raw/S_USA.TrailNFS_Publish.gdb.zip
+
+          unzip -q usfs.gdb.zip
+          USFS_GDB=$(find . -maxdepth 2 -type d -name '*.gdb' | head -1)
+          echo "USFS GDB: $USFS_GDB"
+
+          # ── 2. NPS Trails — paginate FeatureServer ────────────────────────────
+          echo "=== NPS Trails ==="
+          python3 <<'PYEOF'
+          import urllib.request, json, time
+          BASE = 'https://mapservices.nps.gov/arcgis/rest/services/NationalDatasets/NPS_Public_Trails_Geographic/FeatureServer/0/query'
+          all_features = []
+          offset = 0
+          PAGE = 2000
+          while True:
+              url = (f"{BASE}?where=1%3D1&outFields=*&f=geojson"
+                     f"&resultOffset={offset}&resultRecordCount={PAGE}"
+                     f"&returnGeometry=true&outSR=4326")
+              with urllib.request.urlopen(url, timeout=120) as r:
+                  data = json.load(r)
+              feats = data.get('features', [])
+              if not feats:
+                  break
+              all_features.extend(feats)
+              offset += len(feats)
+              print(f"  fetched {offset}", flush=True)
+              if len(feats) < PAGE:
+                  break
+              time.sleep(0.3)
+          with open('/tmp/trails/nps.geojson', 'w') as f:
+              json.dump({'type':'FeatureCollection','features': all_features}, f)
+          print(f"NPS total features: {len(all_features)}", flush=True)
+          PYEOF
+          rclone copyto /tmp/trails/nps.geojson nrp:public-trails/raw/NPS_Public_Trails_2026.geojson
+
+          # ── 3. Each source → parquet via ogr2ogr (with WGS84 reprojection) ─────
+          echo "=== ogr2ogr to parquet ==="
+          ogr2ogr -f Parquet -t_srs EPSG:4326 \
+            -nln usfs /tmp/trails/usfs.parquet \
+            "$USFS_GDB" TrailNFS_Publish
+
+          ogr2ogr -f Parquet -t_srs EPSG:4326 \
+            -nln nps /tmp/trails/nps.parquet \
+            /tmp/trails/nps.geojson
+
+          # ── 4. Harmonize schemas + compute length_miles via DuckDB ─────────────
+          echo "=== DuckDB harmonize + merge ==="
+          python3 <<'PYEOF'
+          import duckdb
+          con = duckdb.connect()
+          con.execute("INSTALL spatial; LOAD spatial;")
+
+          # NTS designation logic shared between sources.
+          # USFS NATIONAL_TRAIL_DESIGNATION enum: 0=none, 1=NST, 2=NHT, 3=NRT, 4=connector.
+          # Specific named NSTs are derived from TRAIL_NAME / TRLNAME.
+          con.execute("""
+              CREATE MACRO derive_nts(code, name) AS CASE
+                  WHEN name IS NULL THEN
+                      CASE code
+                          WHEN 1 THEN 'NST'
+                          WHEN 2 THEN 'NHT'
+                          WHEN 3 THEN 'NRT'
+                          ELSE NULL
+                      END
+                  WHEN UPPER(name) LIKE '%PACIFIC CREST%' THEN 'PCT'
+                  WHEN UPPER(name) LIKE '%CONTINENTAL DIVIDE%' THEN 'CDT'
+                  WHEN UPPER(name) LIKE '%APPALACHIAN%' THEN 'AT'
+                  WHEN UPPER(name) LIKE '%PACIFIC NORTHWEST%' THEN 'PNT'
+                  WHEN UPPER(name) LIKE '%ARIZONA%TRAIL%' THEN 'ANT'
+                  WHEN UPPER(name) LIKE '%IDITAROD%' THEN 'INHT'
+                  WHEN UPPER(name) LIKE '%NEW ENGLAND%' THEN 'NET'
+                  WHEN UPPER(name) LIKE '%FLORIDA%' THEN 'FNST'
+                  WHEN UPPER(name) LIKE '%ICE AGE%' THEN 'IANST'
+                  WHEN UPPER(name) LIKE '%NORTH COUNTRY%' THEN 'NCT'
+                  WHEN UPPER(name) LIKE '%NATCHEZ TRACE%' THEN 'NTNST'
+                  WHEN UPPER(name) LIKE '%POTOMAC HERITAGE%' THEN 'PHT'
+                  WHEN code = 1 THEN 'NST'
+                  WHEN code = 2 THEN 'NHT'
+                  WHEN code = 3 THEN 'NRT'
+                  ELSE NULL
+              END;
+          """)
+
+          # Harmonize each source to common schema. Filter NPS by public-display flags.
+          con.execute("""
+              CREATE TABLE harmonized AS
+              WITH usfs AS (
+                  SELECT
+                      TRAIL_NAME                                        AS trail_name,
+                      NULL                                              AS alt_name,
+                      'USFS'                                            AS admin_agency,
+                      ADMIN_ORG                                         AS admin_unit,
+                      derive_nts(NATIONAL_TRAIL_DESIGNATION, TRAIL_NAME) AS nts_designation,
+                      TRAIL_TYPE                                        AS trail_type,
+                      TRAIL_CLASS                                       AS trail_class,
+                      TRAIL_SURFACE                                     AS trail_surface,
+                      'USFS NFST'                                       AS source_dataset,
+                      ST_GeomFromWKB(geometry)                          AS geom
+                  FROM read_parquet('/tmp/trails/usfs.parquet')
+              ),
+              nps AS (
+                  SELECT
+                      TRLNAME                                           AS trail_name,
+                      TRLALTNAME                                        AS alt_name,
+                      'NPS'                                             AS admin_agency,
+                      UNITNAME                                          AS admin_unit,
+                      derive_nts(NULL::INTEGER, TRLNAME)                AS nts_designation,
+                      TRLTYPE                                           AS trail_type,
+                      TRLCLASS                                          AS trail_class,
+                      TRLSURFACE                                        AS trail_surface,
+                      'NPS Public Trails'                               AS source_dataset,
+                      ST_GeomFromWKB(geometry)                          AS geom
+                  FROM read_parquet('/tmp/trails/nps.parquet')
+                  WHERE COALESCE(DATAACCESS, 'Unrestricted') = 'Unrestricted'
+                    AND COALESCE(PUBLICDISPLAY, 'Public Map Display') = 'Public Map Display'
+              )
+              SELECT * FROM usfs
+              UNION ALL BY NAME
+              SELECT * FROM nps;
+          """)
+
+          # Compute length_miles: reproject WGS84 → EPSG:5070 (USA Contiguous Albers Equal Area, meters)
+          # for accurate planar length, divide by 1609.344 m/mi.
+          # 5070 only covers CONUS — for AK/HI/PR/VI, length is approximate but acceptable.
+          con.execute("""
+              ALTER TABLE harmonized ADD COLUMN length_miles DOUBLE;
+              UPDATE harmonized SET length_miles =
+                  ST_Length(ST_Transform(geom, 'EPSG:4326', 'EPSG:5070', always_xy := TRUE)) / 1609.344;
+          """)
+
+          # Counts for sanity logging
+          for r in con.execute("""
+              SELECT admin_agency, COUNT(*) AS n, ROUND(SUM(length_miles), 0) AS total_miles
+              FROM harmonized GROUP BY admin_agency ORDER BY n DESC
+          """).fetchall():
+              print('  ', r, flush=True)
+
+          for r in con.execute("""
+              SELECT nts_designation, COUNT(*) AS n, ROUND(SUM(length_miles), 0) AS miles
+              FROM harmonized WHERE nts_designation IS NOT NULL
+              GROUP BY nts_designation ORDER BY miles DESC
+          """).fetchall():
+              print('  NTS:', r, flush=True)
+
+          # Write final GeoParquet — geom column named 'geometry' (GeoPandas standard)
+          con.execute("""
+              COPY (
+                  SELECT * EXCLUDE (geom), geom AS geometry
+                  FROM harmonized
+                  WHERE geom IS NOT NULL AND NOT ST_IsEmpty(geom)
+              )
+              TO '/tmp/trails/federal-trails-2026.parquet'
+              (FORMAT PARQUET, COMPRESSION 'zstd', COMPRESSION_LEVEL 15, ROW_GROUP_SIZE 100000);
+          """)
+
+          n = con.execute("SELECT COUNT(*) FROM read_parquet('/tmp/trails/federal-trails-2026.parquet')").fetchone()[0]
+          print(f"Final feature count: {n}", flush=True)
+          PYEOF
+
+          # ── 5. Upload to s3 ───────────────────────────────────────────────────
+          rclone copyto /tmp/trails/federal-trails-2026.parquet \
+            nrp:public-trails/federal-trails-2026.parquet
+
+          echo "✓ Preprocess complete"
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/trails/k8s/federal-trails-2026/workflow-rbac.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/trails/k8s/federal-trails-2026/workflow.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: federal-trails-2026-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting federal-trails-2026 workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/federal-trails-2026-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/federal-trails-2026-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/federal-trails-2026-convert.yaml -n biodiversity\n\
+          \necho \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait\
+          \ --for=condition=complete --timeout=3600s job/federal-trails-2026-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/federal-trails-2026-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/federal-trails-2026-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/federal-trails-2026-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/federal-trails-2026-repartition.yaml -n biodiversity\n\necho\
+          \ \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/federal-trails-2026-repartition -n biodiversity\n\n\
+          echo \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still be\
+          \ running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs federal-trails-2026-setup-bucket federal-trails-2026-convert\
+          \ federal-trails-2026-pmtiles federal-trails-2026-hex federal-trails-2026-repartition\
+          \ federal-trails-2026-workflow -n biodiversity\"\necho \"  kubectl delete\
+          \ configmap federal-trails-2026-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: federal-trails-2026-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #167.

## What this adds

New `public-trails` bucket with `federal-trails-2026`:

- **GeoParquet** (`s3://public-trails/federal-trails-2026.parquet`): harmonized USFS NFST + NPS Public Trails with one row per line segment.
- **PMTiles** for MapLibre rendering.
- **H3 hex (native res 8)** with line buffering — each segment is buffered by the H3 circumradius at res 8 before polyfill (the line-geom path added to cng-datasets in PR #69).

## Harmonized schema

| Column | USFS source | NPS source | Notes |
|---|---|---|---|
| `trail_name`       | `TRAIL_NAME`                       | `TRLNAME`                      |   |
| `alt_name`         | (null)                             | `TRLALTNAME`                   |   |
| `admin_agency`     | `'USFS'`                           | `'NPS'`                        | enum: USFS, NPS |
| `admin_unit`       | `ADMIN_ORG`                        | `UNITNAME`                     | National Forest or NPS park name |
| `nts_designation`  | derived from `NATIONAL_TRAIL_DESIGNATION` + name | derived from `TRLNAME` | enum: PCT, CDT, AT, PNT, ANT, INHT, NET, FNST, IANST, NCT, NTNST, PHT, NST, NHT, NRT, NULL |
| `trail_type`       | `TRAIL_TYPE`                       | `TRLTYPE`                      |   |
| `trail_class`      | `TRAIL_CLASS`                      | `TRLCLASS`                     |   |
| `trail_surface`    | `TRAIL_SURFACE`                    | `TRLSURFACE`                   |   |
| `source_dataset`   | `'USFS NFST'`                      | `'NPS Public Trails'`          |   |
| `length_miles`     | computed via EPSG:5070 (USA Albers EA, m) ÷ 1609.344 | same | recomputed, not from source field |
| `geometry`         | `MultiLineString @ EPSG:4326`      | `MultiLineString @ EPSG:4326`  |   |

NPS source is filtered to `DATAACCESS = 'Unrestricted'` AND `PUBLICDISPLAY = 'Public Map Display'` to respect community-controlled visibility flags.

## Pipeline shape

```
preprocess  →  cng-datasets convert  →  pmtiles + hex  →  repartition
   ↑                                                          ↓
download USFS GDB                                  s3://public-trails/
+ page NPS REST                                    federal-trails-2026/
+ harmonize via DuckDB                             hex/h0=*/data_0.parquet
+ length via EPSG:5070
```

## v2 deferrals (not in this PR)

- **BLM Recreation Trails** — no clean unified national source found; per-state BLM data is fragmented and not pipeline-automatable. Will revisit if a national feature service appears, or add per-state datasets case-by-case.
- **PCTA centerline** — USFS NFST is treated as the authoritative PCT centerline for now. Issue #167 notes PCTA may have its own download; not investigated.

## How to deploy (after merge)

```bash
kubectl apply -f catalog/trails/k8s/federal-trails-2026/workflow-rbac.yaml      # one-time RBAC
kubectl apply -f catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
kubectl wait --for=condition=complete --timeout=3600s job/federal-trails-2026-preprocess
kubectl apply -f catalog/trails/k8s/federal-trails-2026/configmap.yaml \
              -f catalog/trails/k8s/federal-trails-2026/workflow.yaml
kubectl apply -f catalog/sync/k8s/sync-public-trails.yaml                       # MinIO sync
```

STAC + README will be written to `s3://public-trails/` after the run completes and we've verified the output schema.

## Test plan

- [ ] Preprocess job completes; `s3://public-trails/federal-trails-2026.parquet` exists with `~114K` features (~83K USFS + ~31K NPS minus restricted)
- [ ] Schema matches the table above; `length_miles` plausible (PCT total ≈ 2,650 mi, AT ≈ 2,190 mi)
- [ ] Workflow run produces `pmtiles`, `hex/h0=*/data_0.parquet`
- [ ] STAC collection + README written (post-merge)
- [ ] root catalog updated to link `public-trails`