### PR TITLE
trails: fix preprocess — S3-raw cache, GEOMETRY_NAME, USFS NTS code mapping

### DIFF
--- a/catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
@@ -76,52 +76,79 @@ spec:
           rclone mkdir nrp:public-trails 2>/dev/null || true
           rclone mkdir nrp:public-trails/raw 2>/dev/null || true
 
+          # Raw source-of-truth is s3://public-trails/raw/ once first run lands.
+          # Re-downloads from upstream are slow and flaky (NPS REST returned 504
+          # mid-pagination on a recent run); prefer S3 raw, fall back to upstream
+          # with retry/backoff.
+          have_s3() { local k="$1"; [ -n "$(rclone lsf nrp:public-trails/raw/$k 2>/dev/null)" ]; }
+
           # ── 1. USFS National Forest System Trails (NFST) ──────────────────────
           echo "=== USFS NFST ==="
-          curl -sSL --retry 5 -o usfs.gdb.zip \
-            "https://data.fs.usda.gov/geodata/edw/edw_resources/fc/S_USA.TrailNFS_Publish.gdb.zip"
-          rclone copyto usfs.gdb.zip nrp:public-trails/raw/S_USA.TrailNFS_Publish.gdb.zip
-
+          if have_s3 S_USA.TrailNFS_Publish.gdb.zip; then
+              echo "  ↓ from S3"
+              rclone copyto nrp:public-trails/raw/S_USA.TrailNFS_Publish.gdb.zip usfs.gdb.zip
+          else
+              echo "  ↓ from upstream"
+              curl -sSL --retry 5 --retry-delay 5 -o usfs.gdb.zip \
+                "https://data.fs.usda.gov/geodata/edw/edw_resources/fc/S_USA.TrailNFS_Publish.gdb.zip"
+              rclone copyto usfs.gdb.zip nrp:public-trails/raw/S_USA.TrailNFS_Publish.gdb.zip
+          fi
           unzip -q usfs.gdb.zip
           USFS_GDB=$(find . -maxdepth 2 -type d -name '*.gdb' | head -1)
           echo "USFS GDB: $USFS_GDB"
 
-          # ── 2. NPS Trails — paginate FeatureServer ────────────────────────────
+          # ── 2. NPS Trails ─────────────────────────────────────────────────────
           echo "=== NPS Trails ==="
-          python3 <<'PYEOF'
-          import urllib.request, json, time
+          if have_s3 NPS_Public_Trails_2026.geojson; then
+              echo "  ↓ from S3"
+              rclone copyto nrp:public-trails/raw/NPS_Public_Trails_2026.geojson /tmp/trails/nps.geojson
+          else
+              echo "  ↓ from upstream FeatureServer (paginated, retry/backoff)"
+              python3 <<'PYEOF'
+          import urllib.request, json, time, sys
           BASE = 'https://mapservices.nps.gov/arcgis/rest/services/NationalDatasets/NPS_Public_Trails_Geographic/FeatureServer/0/query'
-          all_features = []
-          offset = 0
-          PAGE = 2000
+          all_features, offset, PAGE = [], 0, 2000
           while True:
               url = (f"{BASE}?where=1%3D1&outFields=*&f=geojson"
                      f"&resultOffset={offset}&resultRecordCount={PAGE}"
                      f"&returnGeometry=true&outSR=4326")
-              with urllib.request.urlopen(url, timeout=120) as r:
-                  data = json.load(r)
+              data = None
+              for attempt in range(1, 7):
+                  try:
+                      with urllib.request.urlopen(url, timeout=120) as r:
+                          data = json.load(r)
+                      break
+                  except Exception as e:
+                      wait = 5 * (2 ** (attempt - 1))
+                      print(f"  attempt {attempt} failed ({e}); sleeping {wait}s", flush=True)
+                      time.sleep(wait)
+              if data is None:
+                  print(f"  giving up at offset={offset}", flush=True); sys.exit(1)
               feats = data.get('features', [])
-              if not feats:
-                  break
+              if not feats: break
               all_features.extend(feats)
               offset += len(feats)
               print(f"  fetched {offset}", flush=True)
-              if len(feats) < PAGE:
-                  break
-              time.sleep(0.3)
-          with open('/tmp/trails/nps.geojson', 'w') as f:
+              if len(feats) < PAGE: break
+              time.sleep(0.5)
+          with open('/tmp/trails/nps.geojson','w') as f:
               json.dump({'type':'FeatureCollection','features': all_features}, f)
           print(f"NPS total features: {len(all_features)}", flush=True)
           PYEOF
-          rclone copyto /tmp/trails/nps.geojson nrp:public-trails/raw/NPS_Public_Trails_2026.geojson
+              rclone copyto /tmp/trails/nps.geojson nrp:public-trails/raw/NPS_Public_Trails_2026.geojson
+          fi
 
           # ── 3. Each source → parquet via ogr2ogr (with WGS84 reprojection) ─────
+          # GEOMETRY_NAME=geometry forces a consistent column name across sources
+          # (GDB defaults to SHAPE; GeoJSON to geometry).
           echo "=== ogr2ogr to parquet ==="
           ogr2ogr -f Parquet -t_srs EPSG:4326 \
+            -lco GEOMETRY_NAME=geometry \
             -nln usfs /tmp/trails/usfs.parquet \
             "$USFS_GDB" TrailNFS_Publish
 
           ogr2ogr -f Parquet -t_srs EPSG:4326 \
+            -lco GEOMETRY_NAME=geometry \
             -nln nps /tmp/trails/nps.parquet \
             /tmp/trails/nps.geojson
 
@@ -133,32 +160,49 @@ spec:
           con.execute("INSTALL spatial; LOAD spatial;")
 
           # NTS designation logic shared between sources.
-          # USFS NATIONAL_TRAIL_DESIGNATION enum: 0=none, 1=NST, 2=NHT, 3=NRT, 4=connector.
-          # Specific named NSTs are derived from TRAIL_NAME / TRLNAME.
+          # USFS NATIONAL_TRAIL_DESIGNATION enum (verified empirically against the Dec 2025 publish):
+          #   0 = unknown / no name        (4,222 segments)
+          #   1 = NOT a national trail     (74,386 segments — the vast majority; regular USFS trails)
+          #   2 = National Recreation Trail (NRT)  (1,903 segments)
+          #   3 = National Scenic / Historic Trail (NST/NHT)  (2,176 segments — PCT/AT/CDT/etc.)
+          # Specific named NSTs/NHTs are derived from TRAIL_NAME / TRLNAME patterns
+          # (USFS uses many name variants per trail — PCT, PCNST, "Pacific Crest", "PCT:", etc.).
           con.execute("""
               CREATE MACRO derive_nts(code, name) AS CASE
-                  WHEN name IS NULL THEN
-                      CASE code
-                          WHEN 1 THEN 'NST'
-                          WHEN 2 THEN 'NHT'
-                          WHEN 3 THEN 'NRT'
-                          ELSE NULL
-                      END
-                  WHEN UPPER(name) LIKE '%PACIFIC CREST%' THEN 'PCT'
-                  WHEN UPPER(name) LIKE '%CONTINENTAL DIVIDE%' THEN 'CDT'
-                  WHEN UPPER(name) LIKE '%APPALACHIAN%' THEN 'AT'
-                  WHEN UPPER(name) LIKE '%PACIFIC NORTHWEST%' THEN 'PNT'
-                  WHEN UPPER(name) LIKE '%ARIZONA%TRAIL%' THEN 'ANT'
-                  WHEN UPPER(name) LIKE '%IDITAROD%' THEN 'INHT'
-                  WHEN UPPER(name) LIKE '%NEW ENGLAND%' THEN 'NET'
-                  WHEN UPPER(name) LIKE '%FLORIDA%' THEN 'FNST'
-                  WHEN UPPER(name) LIKE '%ICE AGE%' THEN 'IANST'
-                  WHEN UPPER(name) LIKE '%NORTH COUNTRY%' THEN 'NCT'
-                  WHEN UPPER(name) LIKE '%NATCHEZ TRACE%' THEN 'NTNST'
-                  WHEN UPPER(name) LIKE '%POTOMAC HERITAGE%' THEN 'PHT'
-                  WHEN code = 1 THEN 'NST'
-                  WHEN code = 2 THEN 'NHT'
-                  WHEN code = 3 THEN 'NRT'
+                  -- Pacific Crest NST
+                  WHEN UPPER(name) LIKE '%PACIFIC CREST%'          THEN 'PCT'
+                  WHEN UPPER(name) LIKE 'PCT %' OR UPPER(name) LIKE 'PCT:%' OR UPPER(name) LIKE 'PCT-%' OR UPPER(name) = 'PCT' THEN 'PCT'
+                  WHEN UPPER(name) LIKE 'PCNST%'                    THEN 'PCT'
+                  -- Continental Divide NST
+                  WHEN UPPER(name) LIKE '%CONTINENTAL DIVIDE%'     THEN 'CDT'
+                  WHEN UPPER(name) LIKE 'CDNST%' OR UPPER(name) LIKE 'CDT %' OR UPPER(name) LIKE 'CDT:%' OR UPPER(name) LIKE 'CDT-%' OR UPPER(name) = 'CDT' THEN 'CDT'
+                  -- Appalachian NST
+                  WHEN UPPER(name) LIKE '%APPALACHIAN%'            THEN 'AT'
+                  -- North Country NST
+                  WHEN UPPER(name) LIKE '%NORTH COUNTRY%'          THEN 'NCT'
+                  WHEN UPPER(name) LIKE 'NCT %' OR UPPER(name) LIKE 'NCNST%' THEN 'NCT'
+                  -- Pacific Northwest NST
+                  WHEN UPPER(name) LIKE '%PACIFIC NORTHWEST%'      THEN 'PNT'
+                  WHEN UPPER(name) LIKE 'PNT %' OR UPPER(name) LIKE 'PNNST%' THEN 'PNT'
+                  -- Arizona NST
+                  WHEN UPPER(name) LIKE '%ARIZONA NATIONAL%' OR UPPER(name) LIKE '%ARIZONA SCENIC%' THEN 'ANT'
+                  -- Iditarod NHT
+                  WHEN UPPER(name) LIKE '%IDITAROD%' OR UPPER(name) LIKE 'INHT%' THEN 'INHT'
+                  -- New England NST
+                  WHEN UPPER(name) LIKE '%NEW ENGLAND%NATIONAL%' OR UPPER(name) LIKE '%NEW ENGLAND%SCENIC%' THEN 'NET'
+                  -- Florida NST
+                  WHEN UPPER(name) LIKE '%FLORIDA NATIONAL%' OR UPPER(name) LIKE 'FNST%' THEN 'FNST'
+                  -- Ice Age NST
+                  WHEN UPPER(name) LIKE '%ICE AGE%'                THEN 'IANST'
+                  -- Natchez Trace NST
+                  WHEN UPPER(name) LIKE '%NATCHEZ TRACE%'          THEN 'NTNST'
+                  -- Potomac Heritage NST
+                  WHEN UPPER(name) LIKE '%POTOMAC HERITAGE%'       THEN 'PHT'
+                  -- Pony Express NHT
+                  WHEN UPPER(name) LIKE '%PONY EXPRESS%'           THEN 'PENHT'
+                  -- Fallbacks by USFS code (NPS rows pass NULL for code so they skip these)
+                  WHEN code = 3                                    THEN 'NST'
+                  WHEN code = 2                                    THEN 'NRT'
                   ELSE NULL
               END;
           """)
@@ -177,7 +221,7 @@ spec:
                       TRAIL_CLASS                                       AS trail_class,
                       TRAIL_SURFACE                                     AS trail_surface,
                       'USFS NFST'                                       AS source_dataset,
-                      ST_GeomFromWKB(geometry)                          AS geom
+                      geometry                                          AS geom
                   FROM read_parquet('/tmp/trails/usfs.parquet')
               ),
               nps AS (
@@ -191,7 +235,7 @@ spec:
                       TRLCLASS                                          AS trail_class,
                       TRLSURFACE                                        AS trail_surface,
                       'NPS Public Trails'                               AS source_dataset,
-                      ST_GeomFromWKB(geometry)                          AS geom
+                      geometry                                          AS geom
                   FROM read_parquet('/tmp/trails/nps.parquet')
                   WHERE COALESCE(DATAACCESS, 'Unrestricted') = 'Unrestricted'
                     AND COALESCE(PUBLICDISPLAY, 'Public Map Display') = 'Public Map Display'


### PR DESCRIPTION
Three fixes after first-run debugging on #174 (closes the gaps before we run the rest of the workflow).

1. **S3-raw cache for restart-friendly preprocess.** First run hit a 504 mid-NPS-pagination and crashed; second run had to re-fetch the full 184 MB GeoJSON from the flaky FeatureServer. Preprocess now reads raw from `s3://public-trails/raw/` when present, with upstream + retry/backoff as fallback. Restarts are minutes, not hours.

2. **ogr2ogr geometry-column name + native GEOMETRY type.** USFS GDB → Parquet defaults to `SHAPE` (GDB convention); NPS GeoJSON → Parquet defaults to `geometry`. Harmonize SQL was hardcoded to `geometry` and failed on USFS. Forced `-lco GEOMETRY_NAME=geometry` on both; also dropped the `ST_GeomFromWKB` wrap since ogr2ogr writes a native GEOMETRY type (not WKB BLOB) when the format supports it.

3. **USFS `NATIONAL_TRAIL_DESIGNATION` code mapping.** The first run tagged 74,368 segments as "NST" — 90% of all USFS trails — which is clearly wrong (only ~11 National Scenic Trails exist totaling ~18,000 mi). Verified the actual code semantics against the Dec 2025 publish:

   | Code | Count | Meaning |
   |---:|---:|---|
   | 0 | 4,222 | unknown / no name |
   | **1** | **74,386** | **NOT a national trail — regular USFS trail** (was bogus 'NST') |
   | 2 | 1,903 | National Recreation Trail (NRT) |
   | 3 | 2,176 | National Scenic / Historic Trail (NST/NHT) |

   Macro updated. Also expanded trail-name patterns to catch USFS variants — PCT: prefix, "PCT BADEN-POWELL", "PCNST", "CDNST", "CONTINENTAL DIVIDE NST", "CDT SEGMENT A", etc. — so named-NST segments don't fall through to the generic NST bucket.

## Verification

| Designation | Count | Miles | Notes |
|---|---:|---:|---|
| PCT  | 680  | 2,261 | ~85% of the 2,650 mi true total (USFS + NPS-public portions) |
| CDT  | 422  | 1,664 | USFS+NPS portion of the ~3,100 mi true total |
| AT   | 226  | 925   | USFS portion + a few NPS; AT is mostly ATC/NPS-administered land not in either source |
| NCT  | 213  | 702   | USFS portion only; NCT is mostly state/local outside this scope |
| NRT  | 1,890 | 4,311 | many small NRTs |
| NST  | 786  | 1,922 | unidentified NST/NHT (fall-through bucket) |
| FNST, INHT, IANST, PENHT, PHT, NTNST | small | small | each match one or two trails by name |

Total: 108,515 features written to `s3://public-trails/federal-trails-2026.parquet` (318 MB). Bucket public-read + CORS set via the setup-bucket job.

## Test plan

- [x] Preprocess completes end-to-end
- [x] `s3://public-trails/federal-trails-2026.parquet` exists
- [x] NTS distribution plausible (no bogus 74k NST)
- [x] Bucket is publicly readable
- [ ] PMTiles + hex + repartition (next step, post-merge)
- [ ] STAC + README uploaded (post-merge, once schema verified against output)