### PR TITLE
trails: add BLM GTLF Managed Trails as third source

### DIFF
--- a/catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
+++ b/catalog/trails/k8s/federal-trails-2026/preprocess-federal-trails-2026.yaml
@@ -138,6 +138,50 @@ spec:
               rclone copyto /tmp/trails/nps.geojson nrp:public-trails/raw/NPS_Public_Trails_2026.geojson
           fi
 
+          # ── 2b. BLM National GTLF Public Managed Trails ───────────────────────
+          # Master national BLM trail dataset (19k segments). The five sibling
+          # GTLF feeds (Motorized/Nonmechanized/Nonmotorized/Not-Assessed/Limited)
+          # are use-type subsets of this one; we don't need them.
+          echo "=== BLM GTLF Public Managed Trails ==="
+          if have_s3 BLM_Natl_GTLF_Public_Managed_Trails_2026.geojson; then
+              echo "  ↓ from S3"
+              rclone copyto nrp:public-trails/raw/BLM_Natl_GTLF_Public_Managed_Trails_2026.geojson /tmp/trails/blm.geojson
+          else
+              echo "  ↓ from upstream FeatureServer (paginated, retry/backoff)"
+              python3 <<'PYEOF'
+          import urllib.request, json, time, sys
+          BASE = 'https://services1.arcgis.com/KbxwQRRfWyEYLgp4/arcgis/rest/services/BLM_Natl_GTLF_Public_Managed_Trails/FeatureServer/2/query'
+          all_features, offset, PAGE = [], 0, 2000
+          while True:
+              url = (f"{BASE}?where=1%3D1&outFields=*&f=geojson"
+                     f"&resultOffset={offset}&resultRecordCount={PAGE}"
+                     f"&returnGeometry=true&outSR=4326")
+              data = None
+              for attempt in range(1, 7):
+                  try:
+                      with urllib.request.urlopen(url, timeout=120) as r:
+                          data = json.load(r)
+                      break
+                  except Exception as e:
+                      wait = 5 * (2 ** (attempt - 1))
+                      print(f"  attempt {attempt} failed ({e}); sleeping {wait}s", flush=True)
+                      time.sleep(wait)
+              if data is None:
+                  print(f"  giving up at offset={offset}", flush=True); sys.exit(1)
+              feats = data.get('features', [])
+              if not feats: break
+              all_features.extend(feats)
+              offset += len(feats)
+              print(f"  fetched {offset}", flush=True)
+              if len(feats) < PAGE: break
+              time.sleep(0.5)
+          with open('/tmp/trails/blm.geojson','w') as f:
+              json.dump({'type':'FeatureCollection','features': all_features}, f)
+          print(f"BLM total features: {len(all_features)}", flush=True)
+          PYEOF
+              rclone copyto /tmp/trails/blm.geojson nrp:public-trails/raw/BLM_Natl_GTLF_Public_Managed_Trails_2026.geojson
+          fi
+
           # ── 3. Each source → parquet via ogr2ogr (with WGS84 reprojection) ─────
           # GEOMETRY_NAME=geometry forces a consistent column name across sources
           # (GDB defaults to SHAPE; GeoJSON to geometry).
@@ -151,6 +195,11 @@ spec:
             -lco GEOMETRY_NAME=geometry \
             -nln nps /tmp/trails/nps.parquet \
             /tmp/trails/nps.geojson
+
+          ogr2ogr -f Parquet -t_srs EPSG:4326 \
+            -lco GEOMETRY_NAME=geometry \
+            -nln blm /tmp/trails/blm.parquet \
+            /tmp/trails/blm.geojson
 
           # ── 4. Harmonize schemas + compute length_miles via DuckDB ─────────────
           echo "=== DuckDB harmonize + merge ==="
@@ -200,7 +249,13 @@ spec:
                   WHEN UPPER(name) LIKE '%POTOMAC HERITAGE%'       THEN 'PHT'
                   -- Pony Express NHT
                   WHEN UPPER(name) LIKE '%PONY EXPRESS%'           THEN 'PENHT'
-                  -- Fallbacks by USFS code (NPS rows pass NULL for code so they skip these)
+                  -- Juan Bautista de Anza NHT
+                  WHEN UPPER(name) LIKE '%ANZA TRAIL%' OR UPPER(name) LIKE '%JUAN BAUTISTA%' THEN 'ANZA'
+                  -- Old Spanish NHT
+                  WHEN UPPER(name) LIKE '%OLD SPANISH%'            THEN 'OSNHT'
+                  -- Generic National Recreation Trail (catches BLM NRTs named in alt_name)
+                  WHEN UPPER(name) LIKE '%NATIONAL RECREATION TRAIL%' THEN 'NRT'
+                  -- Fallbacks by USFS code (NPS/BLM rows pass NULL for code so they skip these)
                   WHEN code = 3                                    THEN 'NST'
                   WHEN code = 2                                    THEN 'NRT'
                   ELSE NULL
@@ -239,10 +294,32 @@ spec:
                   FROM read_parquet('/tmp/trails/nps.parquet')
                   WHERE COALESCE(DATAACCESS, 'Unrestricted') = 'Unrestricted'
                     AND COALESCE(PUBLICDISPLAY, 'Public Map Display') = 'Public Map Display'
+              ),
+              -- BLM GTLF schema: ROUTE_PRMRY_NM (primary name),
+              -- ROUTE_SCNDRY_SPCL_DSGNTN_NM (special-designation name — often the NST name like 'CDNST'),
+              -- ADMIN_ST (2-letter state code), OBSRVE_ROUTE_USE_CLASS, OBSRVE_SRFCE_TYPE.
+              -- For nts_designation, prefer the secondary special-designation name when present;
+              -- fall through to primary name (same derive_nts macro handles both).
+              blm AS (
+                  SELECT
+                      ROUTE_PRMRY_NM                                                       AS trail_name,
+                      ROUTE_SCNDRY_SPCL_DSGNTN_NM                                          AS alt_name,
+                      'BLM'                                                                AS admin_agency,
+                      ADMIN_ST                                                             AS admin_unit,
+                      COALESCE(derive_nts(NULL::INTEGER, ROUTE_SCNDRY_SPCL_DSGNTN_NM),
+                               derive_nts(NULL::INTEGER, ROUTE_PRMRY_NM))                  AS nts_designation,
+                      OBSRVE_ROUTE_USE_CLASS                                               AS trail_type,
+                      PLAN_ASSET_CLASS                                                     AS trail_class,
+                      OBSRVE_SRFCE_TYPE                                                    AS trail_surface,
+                      'BLM GTLF Managed Trails'                                            AS source_dataset,
+                      geometry                                                             AS geom
+                  FROM read_parquet('/tmp/trails/blm.parquet')
               )
               SELECT * FROM usfs
               UNION ALL BY NAME
-              SELECT * FROM nps;
+              SELECT * FROM nps
+              UNION ALL BY NAME
+              SELECT * FROM blm;
           """)
 
           # Compute length_miles: reproject WGS84 → EPSG:5070 (USA Contiguous Albers Equal Area, meters)


### PR DESCRIPTION
Closes the BLM scope gap from #167. v1 (PRs #174, #175) shipped USFS + NPS only after I prematurely concluded BLM had no clean national source — that was wrong. The BLM ArcGIS Hub DCAT catalog lists six \"BLM Natl GTLF Public * Trails\" feeds; **\"Managed Trails\"** is the 19,104-segment superset (the other five are use-class subsets and not separately included).

## What changed on S3

`federal-trails-2026.parquet` regenerated from the new preprocess, and the full downstream pipeline re-ran (convert + pmtiles + hex + repartition). All artifacts at the same URLs as v1; consumers see no API change, just a richer table.

| Asset | URL | Size / count |
|---|---|---|
| GeoParquet | `s3://public-trails/federal-trails-2026.parquet` | 348 MB, **127,619 segments** (USFS 82,687 + NPS 31,386 + BLM 19,104) |
| PMTiles | `s3://public-trails/federal-trails-2026.pmtiles` | 190 MB; source-layer `federal-trails-2026` |
| H3 hex (native res 8) | `s3://public-trails/federal-trails-2026/hex/h0=*/data_0.parquet` | 13 partitions; 122,063 segments survived to hex (5,556 dropped for empty/invalid geometry) |
| STAC | `s3://public-trails/federal-trails-2026/stac-collection.json` | updated with BLM in agency/source enums; new NTS values |
| README | `s3://public-trails/federal-trails-2026/README.md` | updated with BLM source + methods |

## NTS-designation table — what BLM added

| Designation | v1 segs / mi | v2 (with BLM) segs / mi | Δ |
|---|---:|---:|---:|
| PCT  | 680 / 2,261 | **794 / 2,397** | +114 / +136 mi (BLM Sierra & desert portions) |
| CDT  | 422 / 1,664 | 423 / 1,666 | +1 / +2 mi |
| AT   | 226 / 925 | 226 / 925 | — |
| NCT  | 213 / 702 | 213 / 702 | — |
| NRT  | 1,890 / 4,311 | **1,928 / 4,353** | +38 / +42 mi (BLM-named NRTs) |
| NST (generic) | 786 / 1,922 | 786 / 1,922 | — |
| **ANZA** | — | **45 / 18 mi** | new — Juan Bautista de Anza NHT |
| ANT  | — | **12 / 5 mi** | new — Arizona NST (BLM segments) |
| **OSNHT** | — | **5 / 1 mi** | new — Old Spanish NHT |
| **PNT** | — | **2 / 1 mi** | new — Pacific Northwest NST |
| Others (INHT, PENHT, FNST, IANST, NTNST, PHT) | unchanged | unchanged | — |

CDT mileage barely moved because BLM's CDT-named segments turn out to be sparse (~1 segment with explicit CDT name in BLM data). Most BLM trail miles are local recreation trails, not long-distance NSTs — which is correct: BLM's mandate centers on land management rather than long-distance trail administration.

## Pipeline changes

- Added BLM paginated fetch (1 of 6 GTLF feeds — the superset) with retry/backoff and S3-raw cache.
- ogr2ogr → parquet with `-lco GEOMETRY_NAME=geometry` (same convention as USFS/NPS).
- DuckDB harmonize CTE: BLM rows aliased to the common schema. `ROUTE_PRMRY_NM` → `trail_name`; `ROUTE_SCNDRY_SPCL_DSGNTN_NM` → `alt_name` (and is also fed into the NTS-designation derivation since BLM uses this field to flag national-trail segments).
- NTS-derivation macro extended:
  - **Anza NHT** — `'%ANZA TRAIL%'` / `'%JUAN BAUTISTA%'`
  - **Old Spanish NHT** — `'%OLD SPANISH%'`
  - **Generic NRT** — `'%NATIONAL RECREATION TRAIL%'` (catches BLM's named NRTs like Rogue River NRT, Old Growth Ridge NRT)

## Test plan

- [x] BLM raw cached to `s3://public-trails/raw/BLM_Natl_GTLF_Public_Managed_Trails_2026.geojson`
- [x] Full preprocess succeeds end-to-end, log shows BLM 19,104 features
- [x] convert + pmtiles + hex + repartition all complete on cluster
- [x] DuckDB-MCP confirms 127,619 segments in parquet, 122,063 in hex, with admin_agency split USFS/NPS/BLM
- [x] PCT total now 2,397 mi (within 10% of canonical 2,650), ANZA / ANT / PNT / OSNHT appear in nts_designation
- [x] STAC + README updated on S3 with BLM in enums + per-NST counts
- [x] Bucket public-read still works (HTTP 200 on STAC + README URLs)

(Per the workflow established with the user mid-session: no PR until k8s pipeline finishes and STAC + data are live on S3. All boxes checked before this PR was opened.)