### PR TITLE
AGENTS: document raster --hex-resampling reducer selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ Differences from vector:
 - Defaults: `--h3-resolution` 8, `--parent-resolutions "0"`, `--hex-memory 32Gi`, `--max-parallelism 61`
 - `--value-column` — raster band name in output (default `value`)
 - `--nodata` — value to exclude (auto from metadata)
+- `--hex-resampling` — **how pixels aggregate into each cell (`sum`/`mean`/`mode`, default `mean`). Picking the wrong one silently corrupts the data — see "Choosing the aggregation reducer" below. As important as `--value-column`.**
 - Always creates a WGS84 COG on NRP S3 first; hex reads from that COG
 
 **Multi-tile rasters** (e.g. multiple UTM zones): repeat `--source-url`. Adds `preprocess-cog` step that mosaics into one WGS84 COG:
@@ -175,6 +176,24 @@ cng-datasets raster-workflow --dataset wyoming/rap-arte \
   --output-dir catalog/wyoming/k8s/rap-arte
 ```
 Extra options: `--target-extent "xmin,ymin,xmax,ymax"` (EPSG:4326 clip), `--target-resolution <degrees>`, `--band <n>` (1-indexed), `--output-cog-name <key>`.
+
+#### ⚠️ Choosing the aggregation reducer (`--hex-resampling`)
+
+`--hex-resampling` controls how source pixels collapse into each H3 cell. **The right reducer depends entirely on what the pixel value *means*, and the wrong one silently produces nonsense** (summing land-cover class codes, averaging species counts). Decide this per dataset, every time. Supported: `sum`, `mean`, `mode` (default `mean`).
+
+| Pixel value is… | Reducer | Examples |
+|---|---|---|
+| **Extensive / stock / count** — a total that must be conserved | `sum` | population (GHS-POP), carbon stock, fishing-effort hours, counts |
+| **Intensive / index / rate / fraction** — a per-area quantity | `mean` | NDVI, % cover (RAP), bathymetry depth (GEBCO), habitat indices (NCP) |
+| **Categorical** — discrete class codes | `mode` | land cover (CGLS-LC100, NLCD), wetland class (GLWD) |
+
+**Correctness check:** for `sum`, the catalog-wide `SUM(value)` over the hex parquet MUST equal the source COG's pixel sum within sub-pixel rounding (compute the COG sum with a GDAL block-sum job; query the hex sum via the MCP). `mean`/`mode` have no global invariant — spot-check the hex against the COG over a known region.
+
+**Species richness / "peak" quantities** (MOBI, IUCN richness): the correct reducer is `max` — **not** `sum` (double-counts species) and **not** `mean` (averages away hotspots). `max` is **not yet supported** (only `sum`/`mean`/`mode`) — tracked in [`boettiger-lab/datasets#95`](https://github.com/boettiger-lab/datasets/issues/95). Until it lands, use `mean` and document the limitation, or hold the dataset.
+
+**`mode` keeps only the *dominant* class** per cell; the class mix is discarded. Fine for "dominant class" maps, but **inadequate for area-accounting** ("how much wetland?"), which then undercounts to plurality cells only. Per-class fractional coverage (one column per class) is not produced by the current pipeline — flag it if a use case needs class areas.
+
+**Reducer choice is independent of geometry correctness.** The raster pipeline integrates each cell's true footprint, including the antimeridian/poles (fixed in `cng-datasets` #88/#92). But any **global** raster hexed before that fix is inflated at the ±180/pole seam and must be re-hexed regardless of reducer.
 
 #### How `--dataset` controls naming
 


### PR DESCRIPTION
## What

Adds raster **aggregation-reducer guidance** to `AGENTS.md`. The raster section documented `--value-column` and `--nodata` but never `--hex-resampling`, and gave no rule for choosing `sum`/`mean`/`mode` — so an agent processing the next raster had nothing preventing a categorical layer from being summed or a richness layer from being averaged.

## Adds

- `--hex-resampling` to the raster options list, flagged as correctness-critical.
- A **reducer-selection table**: extensive/stock/count → `sum`; intensive/index/fraction → `mean`; categorical → `mode`.
- The **correctness check** for `sum` (hex `SUM` must equal the COG pixel-sum within rounding).
- The **richness/`max`** case — the correct reducer for MOBI/IUCN richness, currently unsupported (tracked in boettiger-lab/datasets#95).
- The **`mode` dominant-class limitation** (inadequate for per-class area-accounting).
- A note that reducer choice is **independent of** the antimeridian/polar geometry fix (datasets #88/#92), and that pre-fix global rasters must be re-hexed regardless.

Docs-only; no code or pipeline changes.
