### PR TITLE
cgls-lc100-2019: re-hex at H3 res 9 on seam-fixed pipeline (#186)

### DIFF
--- a/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex.yaml
@@ -6,9 +6,10 @@ metadata:
     k8s-app: cgls-lc100-2019-hex
 spec:
   completions: 122
-  parallelism: 61
+  parallelism: 30
   completionMode: Indexed
-  backoffLimit: 0
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
   podFailurePolicy:
     rules:
     - action: Ignore
@@ -50,6 +51,12 @@ spec:
           value: /usr/lib/python3/dist-packages
         - name: BUCKET
           value: public-land-cover
+        # rclone-config is required: the current tool localizes the COG to local
+        # NVMe (rclone copy nrp:...) before hexing; without it localization fails.
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
         command:
         - bash
         - -c
@@ -63,16 +70,20 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column lc_class --hex-resampling mode
+          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling mode
         resources:
           requests:
             cpu: '4'
-            memory: 32Gi
+            memory: 128Gi
             ephemeral-storage: 50Gi
           limits:
             cpu: '4'
-            memory: 32Gi
+            memory: 128Gi
             ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:

--- a/catalog/land-cover/k8s/cgls-lc100/configmap.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/configmap.yaml
@@ -1,5 +1,7 @@
 # Auto-generated ConfigMap for raster workflow
-# Generation command: cng-datasets raster-workflow --dataset cgls-lc100-2019 --source-url "s3://public-land-cover/cgls-lc100-2019-cog.tif" --bucket public-land-cover --h3-resolution 8 --parent-resolutions "5,6,7,0"
+# Generation command: cng-datasets raster-workflow --dataset cgls-lc100-2019 --source-url "s3://public-land-cover/cgls-lc100-2019-cog.tif" --bucket public-land-cover --h3-resolution 9 --parent-resolutions "8,7,6,5,0" --value-column lc_class --hex-resampling mode --hex-memory 128Gi
+# Re-hexed at resolution 9 on the antimeridian/polar-fixed pipeline (datasets #88/#92/#93, data-workflows #186).
+# rclone-config mount added: the current tool localizes the COG to local NVMe before hexing.
 apiVersion: v1
 data:
   cgls-lc100-2019-hex.yaml: |
@@ -11,9 +13,10 @@ data:
         k8s-app: cgls-lc100-2019-hex
     spec:
       completions: 122
-      parallelism: 61
+      parallelism: 30
       completionMode: Indexed
-      backoffLimit: 0
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 122
       podFailurePolicy:
         rules:
         - action: Ignore
@@ -55,6 +58,12 @@ data:
               value: /usr/lib/python3/dist-packages
             - name: BUCKET
               value: public-land-cover
+            # rclone-config is required: the current tool localizes the COG to local
+            # NVMe (rclone copy nrp:...) before hexing; without it localization fails.
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
             command:
             - bash
             - -c
@@ -68,16 +77,20 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column lc_class --hex-resampling mode
+              cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling mode
             resources:
               requests:
                 cpu: '4'
-                memory: 32Gi
+                memory: 128Gi
                 ephemeral-storage: 50Gi
               limits:
                 cpu: '4'
-                memory: 32Gi
+                memory: 128Gi
                 ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:


### PR DESCRIPTION
Re-processes **Copernicus Global Land Cover 100m v3.0.1 (2019)** hex layer on the antimeridian/polar-fixed `cng-datasets` pipeline (boettiger-lab/datasets #88, #92, #93). Part of the raster reprocessing campaign, data-workflows #186.

### Why
The pre-fix raster→H3 pipeline mishandled the ±180° seam. The old resolution-8 build was catastrophically broken at the dateline:

| h0 (dateline) | old res-8 | new res-9 |
|---|---|---|
| Chukotka | 127.2M rows (22× the 5.76M max distinct res-8 cells), no cells beyond ±175.7° | 40.35M cells, full ±180°, realistic tundra (herbaceous + moss/lichen) |
| Fiji | 240.1M rows (42×), no dateline cells | 40,353,607 cells (=7⁹), 1.8M dateline cells |

i.e. the buggy build both **inflated** cells into round-the-world ribbons and **dropped** the true dateline land. (The old res-8 build was 8.9 GiB; the fixed res-9 build is *smaller* at 6.9 GiB despite 7× finer resolution — the difference was seam bloat.)

### What changed
- **resolution 8 → 9** (`--parent-resolutions 5,6,7,0` → `8,7,6,5,0`), much closer to the 100 m source
- **rclone-config mount added** — the current tool localizes the COG to local NVMe (`rclone copy nrp:…`) before hexing; without the mount localization fails
- **`backoffLimit: 0` → `backoffLimitPerIndex: 2` + `maxFailedIndexes: 122`** so one transient pod failure no longer kills the whole 122-way indexed run
- **hex-memory 32Gi → 128Gi**, parallelism 61 → 30

### Results (live on canonical + STAC)
- `public-land-cover/cgls-lc100-2019/hex/` — **4.49e9 cells, 119 h0 partitions, 0 non-canonical class values**, one row per h9
- Cell-weighted class distribution tracks the COG pixel histogram closely (ocean 71.9 vs 69.8 %, herbaceous 6.0 vs 6.8 %, …)
- STAC `cgls-lc100-2019-hex` asset updated to res 9 (`h3:native_resolution: 9`, parents `[8,7,6,5,0]`, full categorical `table:columns` + `values`); classification extension declared; COG `color-hint`→`color_hint`; new `README.md`

Closes the cgls-lc100-2019 checkbox in #186.

> Note for the campaign: the `cng-datasets raster-workflow` generator does not emit the `rclone-config` mount that the new localization step needs — the other raster datasets (gebco, gfw, ncp, glwd) will hit the same failure when regenerated. Worth a datasets issue.