### PR TITLE
glwd: seam-fixed res-8 re-hex + new wetland-area hex layer (#186/#183)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,6 +450,16 @@ Counterintuitive result: 10,000 small features at 8Gi can be fine, while a singl
 
 Raster completions are always **122** — not configurable.
 
+### Re-hexing an existing raster (campaign-style reprocessing)
+
+Most rework here comes from skipped pre-flight checks, not hard problems. Do, in order:
+
+1. **Pre-flight the COG** with one GDAL job (rclone-localize → read; never `/vsis3` for GDAL — it's flaky/node-dependent). Report size, dtype, **real nodata** (published STAC nodata is often wrong), and the value summary that becomes your validation truth (class histogram for `mode`; pixel-SUM for `sum`; min/max/mean for `mean`). **Confirm the COG is non-empty** — published "total" COGs have shipped 100% nodata.
+2. **Resolution = match the source pixel** (≈100 m → res 9; ≈500 m → res 8). Don't bump blindly; res finer than the pixel is 7× cost for no gain.
+3. **Hex job musts:** mount the `rclone-config` secret (the tool localizes the COG via rclone first; generated YAML omits it → fails), `backoffLimitPerIndex: 2` + `maxFailedIndexes` (not `backoffLimit: 0`), output to a **staging** prefix. `:latest` has the seam fix — no runtime clone.
+4. **Validate value AND coverage.** `sum`: hex `SUM` == COG pixel-SUM. Note `sum`/area layers are a **full h0 grid** (one row per cell, `value = 0` where the feature is absent) — same shape as carbon/ghs-pop; that's expected, not bloat. Check that the count of **nonzero** cells matches the feature extent, not the total. `mode`: sparse (cells with no valid pixel are dropped); only canonical codes + distribution tracks the histogram. **Seam (all reducers):** dateline h0 `576707042908045311` — fixed builds span ±180°, buggy ones are bloated and miss the dateline.
+5. **Flip: purge-and-VERIFY-empty, then sync.** `cng-datasets raster` overwrites the partition for each h0 it produces, but does **not** remove partitions for h0s that now yield no data — so reprocessing to a smaller/different domain (e.g. all-land → wetland-only) leaves **stale partitions** behind that corrupt aggregates. And `rclone purge` can silently no-op under S3 load. So purge staging **and confirm it's empty** before any re-hex. `kubectl apply` on a completed Job is a no-op; `delete`+`apply` to rerun. Jobs TTL-GC 3 h after completion — validate before then.
+
 ## Namespace Pod Quota (`biodiversity`)
 
 **Hard limit: 200 pods total** across all simultaneous jobs. Applies to **k8s backend only** — armada queues externally and is not constrained.

--- a/catalog/wetlands/k8s/glwd-area-hex.yaml
+++ b/catalog/wetlands/k8s/glwd-area-hex.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-area-hex
+  labels:
+    k8s-app: glwd-area-hex
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-area-hex
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - cph-blade05.humboldt.edu
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then
+            export PROJ_DATA="$(dirname $PROJ_DB)"
+            export PROJ_LIB="$PROJ_DATA"
+          fi
+          cng-datasets raster \
+            --input "s3://public-wetlands/glwd/glwd-area-cog.tif" \
+            --output-parquet "s3://public-wetlands/glwd/area-hex/" \
+            --h0-index ${JOB_COMPLETION_INDEX} \
+            --resolution 8 --parent-resolutions 7,6,5,0 \
+            --value-column area_ha_x10 --hex-resampling sum
+        resources:
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+          limits: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/glwd-area-reconstruct.yaml
+++ b/catalog/wetlands/k8s/glwd-area-reconstruct.yaml
@@ -1,0 +1,95 @@
+# Reconstructs the GLWD v2.0 total wetland-area COG from the 34 per-class area
+# rasters (classes 1-33 summed; class 0 = Dryland excluded), wetland-only
+# (no-wetland pixels -> nodata). The GLWD distribution's single
+# GLWD_v2_0_area_ha_x10_cog.tif is empty, so this rebuilds it.
+# Output: s3://public-wetlands/glwd/glwd-area-cog.tif (UInt16 ha x10, nodata 65535).
+# Global sum = 18,187,432,309 ha x10 = 1,818,743,231 ha (~18.2 Mkm^2).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-area-reconstruct
+  labels:
+    k8s-app: glwd-area-reconstruct
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-area-reconstruct
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      containers:
+      - name: reconstruct
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: GDAL_CACHEMAX
+          value: '2048'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          mkdir -p /tmp/cls
+          rclone copy nrp:public-wetlands/GLWD_v2_0/GLWD_v2_0_area_by_class_ha/ /tmp/cls/ \
+            --include "*_ha_x10.tif" --retries 10 --low-level-retries 20 --transfers 8
+          python3 - <<'PY'
+          import numpy as np
+          from osgeo import gdal
+          gdal.UseExceptions()
+          NOD_IN = 255; NOD_OUT = 65535
+          paths = {c: f"/tmp/cls/GLWD_v2_0_class_{c:02d}_ha_x10.tif" for c in range(34)}
+          dss = {c: gdal.Open(p) for c, p in paths.items()}   # keep Datasets alive
+          bands = {c: dss[c].GetRasterBand(1) for c in range(34)}
+          ref = dss[1]; xs, ys = ref.RasterXSize, ref.RasterYSize
+          out = gdal.GetDriverByName("GTiff").Create(
+              "/tmp/total.tif", xs, ys, 1, gdal.GDT_UInt16,
+              options=["TILED=YES","COMPRESS=ZSTD","BIGTIFF=YES","BLOCKXSIZE=256","BLOCKYSIZE=256"])
+          out.SetGeoTransform(ref.GetGeoTransform()); out.SetProjection(ref.GetProjection())
+          ob = out.GetRasterBand(1); ob.SetNoDataValue(NOD_OUT)
+          total = 0.0
+          for yo in range(0, ys, 512):
+              h = min(512, ys - yo)
+              acc = np.zeros((h, xs), dtype=np.float64)
+              for c in range(1, 34):  # wetland classes only (skip 0 = Dryland)
+                  a = bands[c].ReadAsArray(0, yo, xs, h).astype(np.float64)
+                  acc += np.where(a == NOD_IN, 0.0, a)
+              acc_i = np.rint(acc).astype(np.int32)
+              outarr = np.where(acc_i > 0, acc_i, NOD_OUT).astype(np.uint16)  # wetland-only
+              ob.WriteArray(outarr, 0, yo)
+              total += float(acc_i[acc_i > 0].sum())
+          ob.FlushCache(); out.FlushCache(); out = None
+          print(f"AREA_TOTAL_ha_x10: {total:.0f}  ha: {total/10.0:.1f}", flush=True)
+          PY
+          gdal_translate /tmp/total.tif /tmp/glwd-area-cog.tif \
+            -of COG -co COMPRESS=ZSTD -co BIGTIFF=YES -co BLOCKSIZE=512 --config GDAL_CACHEMAX 2048
+          rclone copyto /tmp/glwd-area-cog.tif nrp:public-wetlands/glwd/glwd-area-cog.tif \
+            --retries 10 --low-level-retries 20
+        resources:
+          requests: {cpu: '4', memory: 16Gi, ephemeral-storage: 50Gi}
+          limits: {cpu: '4', memory: 16Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/glwd-main-class-hex.yaml
+++ b/catalog/wetlands/k8s/glwd-main-class-hex.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-main-class-hex
+  labels:
+    k8s-app: glwd-main-class-hex
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-main-class-hex
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - cph-blade05.humboldt.edu
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then
+            export PROJ_DATA="$(dirname $PROJ_DB)"
+            export PROJ_LIB="$PROJ_DATA"
+          fi
+          cng-datasets raster \
+            --input "s3://public-wetlands/glwd/glwd-main-class-cog.tif" \
+            --output-parquet "s3://public-wetlands/glwd/hex/" \
+            --h0-index ${JOB_COMPLETION_INDEX} \
+            --resolution 8 --parent-resolutions 7,6,5,0 \
+            --value-column Z --hex-resampling mode
+        resources:
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+          limits: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config


### PR DESCRIPTION
Reprocesses **GLWD v2.0** on the antimeridian/polar-fixed pipeline (datasets #88/#92/#93) and delivers the wetland-**area** hex layer #183 asked for. Both layers are live on canonical + STAC.

### main-class hex (#186 seam fix)
Re-hexed at **res 8 / mode** → `public-wetlands/glwd/hex/` (181.9M cells, 98 partitions, **only classes 0–33**, dateline h0 spans ±180°). Schema enriched to `Z, h8, h7, h6, h5, h0` (was `Z, h8, h0`). GLWD is ~500 m, so res 8 (not 9) is the right pixel match.

### wetland-area hex (#183 — the layer that makes "acres of wetland in <AOI>" answerable)
New `sum` layer → `public-wetlands/glwd/area-hex/`: `area_ha_x10` per cell (wetland ha = `/10`). **`SUM(area_ha_x10)/10` = 1,818,743,231 ha (~18.2 Mkm²)** — matches GLWD's published global wetland extent, exact vs the COG. Full res-8 grid (`0` where no wetland), same shape as the carbon/ghs-pop sum layers; 95.9M of 668.7M cells are wetland-bearing.

**Source data fix:** the GLWD distribution's `GLWD_v2_0_area_ha_x10_cog.tif` is **empty (100% nodata)**. I reconstructed the correct total-wetland-area COG by summing the 34 per-class rasters over classes 1–33 (class 0 = Dryland excluded) → `public-wetlands/glwd/glwd-area-cog.tif`; the `glwd-cog-area` STAC asset is repointed to it. `glwd-area-reconstruct.yaml` documents the rebuild.

### STAC / docs
- New `glwd-area-hex` asset + repointed `glwd-cog-area`; main-class hex updated (res-8 schema, `h3:*`, class 0=Dryland, nodata 0→255).
- Fixed the collection's wrong "~300 rows per h8 … GROUP BY MODE(Z)" note (it's one row per h8).
- New `README.md`; both hex recipes carry the `rclone-config` mount + per-index backoff.

### AGENTS.md
Added a compact **raster re-hex checklist** (pre-flight COG truth → match res to pixel → rclone-mount + staging → validate value *and* coverage, noting `sum` layers are full-grid → purge-and-verify before re-hex). Captures the edge cases from cgls + glwd so the rest of #186 is mechanical.

Closes the glwd box in #186; delivers #183.