### PR TITLE
gebco-2025: re-hex (mean, res 8) on seam-fixed pipeline (#186)

### DIFF
--- a/catalog/high-seas/k8s/gebco/configmap.yaml
+++ b/catalog/high-seas/k8s/gebco/configmap.yaml
@@ -1,5 +1,7 @@
 # Auto-generated ConfigMap for raster workflow
-# Generation command: cng-datasets raster-workflow --dataset gebco-2025 --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w-180.0_e-90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w-90.0_e0.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w0.0_e90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w90.0_e180.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w-180.0_e-90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w-90.0_e0.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w0.0_e90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w90.0_e180.0.tif" --bucket public-high-seas --h3-resolution 8 --parent-resolutions "5,6,7,0"
+# Generation command: cng-datasets raster-workflow --dataset gebco-2025 --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w-180.0_e-90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w-90.0_e0.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w0.0_e90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n0.0_s-90.0_w90.0_e180.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w-180.0_e-90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w-90.0_e0.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w0.0_e90.0.tif" --source-url "s3://public-high-seas/raw/gebco-2025/gebco_2025_sub_ice_n90.0_s0.0_w90.0_e180.0.tif" --bucket public-high-seas --h3-resolution 8 --parent-resolutions "7,6,5,0" --value-column elevation --hex-resampling mean --hex-memory 64Gi
+# Re-hexed at res 8 (mean) on the antimeridian/polar-fixed pipeline (datasets #88/#92/#93, data-workflows #186).
+# rclone-config mount added: the current tool localizes the COG to local NVMe before hexing.
 apiVersion: v1
 data:
   gebco-2025-hex.yaml: |
@@ -11,9 +13,10 @@ data:
         k8s-app: gebco-2025-hex
     spec:
       completions: 122
-      parallelism: 61
+      parallelism: 30
       completionMode: Indexed
-      backoffLimit: 0
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 122
       podFailurePolicy:
         rules:
         - action: Ignore
@@ -55,6 +58,12 @@ data:
               value: /usr/lib/python3/dist-packages
             - name: BUCKET
               value: public-high-seas
+            # rclone-config is required: the current tool localizes the COG to local
+            # NVMe (rclone copy nrp:...) before hexing; without it localization fails.
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
             command:
             - bash
             - -c
@@ -68,16 +77,20 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column elevation
+              cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column elevation --hex-resampling mean
             resources:
               requests:
                 cpu: '4'
-                memory: 32Gi
+                memory: 64Gi
                 ephemeral-storage: 50Gi
               limits:
                 cpu: '4'
-                memory: 32Gi
+                memory: 64Gi
                 ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:

--- a/catalog/high-seas/k8s/gebco/gebco-2025-hex.yaml
+++ b/catalog/high-seas/k8s/gebco/gebco-2025-hex.yaml
@@ -6,9 +6,10 @@ metadata:
     k8s-app: gebco-2025-hex
 spec:
   completions: 122
-  parallelism: 61
+  parallelism: 30
   completionMode: Indexed
-  backoffLimit: 0
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
   podFailurePolicy:
     rules:
     - action: Ignore
@@ -50,6 +51,12 @@ spec:
           value: /usr/lib/python3/dist-packages
         - name: BUCKET
           value: public-high-seas
+        # rclone-config is required: the current tool localizes the COG to local
+        # NVMe (rclone copy nrp:...) before hexing; without it localization fails.
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
         command:
         - bash
         - -c
@@ -63,16 +70,20 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column elevation
+          cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column elevation --hex-resampling mean
         resources:
           requests:
             cpu: '4'
-            memory: 32Gi
+            memory: 64Gi
             ephemeral-storage: 50Gi
           limits:
             cpu: '4'
-            memory: 32Gi
+            memory: 64Gi
             ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Re-processes **GEBCO_2025** (global bathymetry/elevation, 15 arc-sec) on the antimeridian/polar-fixed pipeline (datasets #88/#92/#93). Drop-in: the hex schema is unchanged (`elevation, h8, h7, h6, h5, h0`).

### What changed
- explicit **`--hex-resampling mean`** (elevation is an intensity); parents `5,6,7,0` → `7,6,5,0`
- **rclone-config mount** added (the tool localizes the COG to NVMe before hexing)
- `backoffLimit: 0` → `backoffLimitPerIndex: 2` + `maxFailedIndexes: 122`; mem 32→64Gi; parallelism 61→30

### Live on canonical + STAC + README
- `public-high-seas/gebco-2025/hex/` — **691.8M cells (full global res-8 grid, 122 h0)**, one row per h8.
- Pre-flight COG truth: complete coverage, no nodata, ELEV min −10,930 (Mariana Trench) / max 8,627 / pixel-mean −2,128.
- Hex `elevation` within COG bounds (−10,913.8 / 8,472.6 — cell-means smooth the extremes); area-weighted mean **−2,473 m** (correct equal-area mean; differs from the EPSG:4326 pixel-mean because that over-weights the poles).
- **Seam fixed:** Chukotka dateline h0 spans ±180° with a realistic local range (−3,970 m Aleutian trench → +1,424 m mountains), not a ribbon-average.
- STAC gained `stac_extensions`, `h3:native_resolution`/`h3:parent_resolutions`, `table:columns` (elevation = mean, intensity — never SUM), and COG `raster:bands`; new `README.md`.

Closes the gebco box in #186.