### PR TITLE
ncp-biodiversity: modernize hex to res-7 mean (gap-free, WGS84) (#186)

### DIFF
--- a/catalog/ncp/k8s/ncp-biod-nathab-hex.yaml
+++ b/catalog/ncp/k8s/ncp-biod-nathab-hex.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ncp-biod-nathab-hex
+  labels:
+    k8s-app: ncp-biod-nathab-hex
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: ncp-biod-nathab-hex
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - cph-blade05.humboldt.edu
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then
+            export PROJ_DATA="$(dirname $PROJ_DB)"
+            export PROJ_LIB="$PROJ_DATA"
+          fi
+          cng-datasets raster \
+            --input "s3://public-ncp/NCP_biod_nathab_4326_cog.tif" \
+            --output-parquet "s3://public-ncp/hex/ncp_biod_nathab/" \
+            --h0-index ${JOB_COMPLETION_INDEX} \
+            --resolution 7 --parent-resolutions 6,5,0 \
+            --value-column ncp_biod_nathab --hex-resampling mean
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 50Gi}
+          limits: {cpu: '4', memory: 32Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/ncp/k8s/ncp-only-hex.yaml
+++ b/catalog/ncp/k8s/ncp-only-hex.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ncp-only-hex
+  labels:
+    k8s-app: ncp-only-hex
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: ncp-only-hex
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - cph-blade05.humboldt.edu
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then
+            export PROJ_DATA="$(dirname $PROJ_DB)"
+            export PROJ_LIB="$PROJ_DATA"
+          fi
+          cng-datasets raster \
+            --input "s3://public-ncp/NCP_only_4326_cog.tif" \
+            --output-parquet "s3://public-ncp/hex/ncp_only/" \
+            --h0-index ${JOB_COMPLETION_INDEX} \
+            --resolution 7 --parent-resolutions 6,5,0 \
+            --value-column ncp_only --hex-resampling mean
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 50Gi}
+          limits: {cpu: '4', memory: 32Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/ncp/k8s/ncp-reproject.yaml
+++ b/catalog/ncp/k8s/ncp-reproject.yaml
@@ -1,0 +1,82 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ncp-reproject
+  labels:
+    k8s-app: ncp-reproject
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: ncp-reproject
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      containers:
+      - name: reproject
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: GDAL_CACHEMAX
+          value: '2048'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          [ -n "$PROJ_DB" ] && export PROJ_DATA="$(dirname $PROJ_DB)" PROJ_LIB="$(dirname $PROJ_DB)"
+          process () {
+            local src=$1 dst=$2 ndst=$3
+            rclone copy nrp:public-ncp/${src}.tif /tmp/ --retries 10 --low-level-retries 20
+            echo "=== gdalinfo source $src ==="; gdalinfo /tmp/${src}.tif | grep -E 'Coordinate System|PROJCRS|Pixel Size|Size is' | head
+            gdalwarp -t_srs EPSG:4326 -tr 0.0179331 0.0179331 -r near \
+              -dstnodata ${ndst} -of COG -co COMPRESS=ZSTD -co BIGTIFF=YES \
+              -overwrite /tmp/${src}.tif /tmp/${dst}.tif --config GDAL_CACHEMAX 2048
+            rclone copyto /tmp/${dst}.tif nrp:public-ncp/${dst}.tif --retries 10 --low-level-retries 20
+            python3 - "$dst" "$ndst" <<'PY'
+          import sys, numpy as np
+          from osgeo import gdal
+          gdal.UseExceptions()
+          dst, ndst = sys.argv[1], float(sys.argv[2])
+          ds=gdal.Open(f"/tmp/{dst}.tif"); b=ds.GetRasterBand(1)
+          xs,ys=ds.RasterXSize,ds.RasterYSize; _,by=b.GetBlockSize()
+          vmin=1e30;vmax=-1e30;tot=0.0;n=0
+          for yo in range(0,ys,by):
+              a=b.ReadAsArray(0,yo,xs,min(by,ys-yo)).astype(np.float64)
+              a=a[np.isfinite(a) & (a!=ndst)]
+              if a.size: vmin=min(vmin,float(a.min()));vmax=max(vmax,float(a.max()));tot+=float(a.sum());n+=a.size
+          print(f"TRUTH {dst}: size={xs}x{ys} VALID_PX={n} MIN={vmin:.5f} MAX={vmax:.5f} MEAN={tot/n:.6f}", flush=True)
+          PY
+          }
+          process NCP_biod_nathab_cog NCP_biod_nathab_4326_cog -9999
+          process NCP_only_cog        NCP_only_4326_cog        -128
+          echo "DONE reproject + truth"
+        resources:
+          requests: {cpu: '4', memory: 8Gi, ephemeral-storage: 20Gi}
+          limits: {cpu: '4', memory: 8Gi, ephemeral-storage: 20Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config


### PR DESCRIPTION
**NCP turned out not to be a seam-bug case** — its hex uses point-based `h3_latlng_to_cell` indexing and never crosses ±180°, and it was already ~1 row/cell (not the assumed "~300 rows/h8"). So this is a **quality re-hex**, not a seam fix.

### The real issue
The legacy build point-binned **2 km World Eckert IV** pixels at **res 8** (finer than the pixels) → coverage gaps + ~1 row per pixel, and the COGs were left in a projected CRS.

### What changed
- **Reproject** both projected 2 km COGs → WGS84 (`NCP_{biod_nathab,only}_4326_cog.tif`); `ncp-reproject.yaml`.
- **Re-hex each at res 7** (matching 2 km) via `cng-datasets raster`, `--hex-resampling mean` (exact_extract) → **gap-free, one row per h7 cell, area-weighted**.

### Live on canonical + STAC + README
- `public-ncp/hex/ncp_biod_nathab/` — 26.1M cells [0,20], 95 h0; `public-ncp/hex/ncp_only/` — 18.6M cells [0,19], 76 h0. One row per h7 (was multi-row/gappy).
- Validation truths (reproject job): biod_nathab mean 5.11 (47.5M px), ncp_only mean 4.52 (28.0M px); hex values within COG bounds.
- STAC: COG assets repointed to WGS84 + `raster:bands`; hex assets res-7 + `h3:*` + `table:columns`; **fixed the wrong "~300 rows per h8 … GROUP BY AVG" note** (it's one row per cell); new README.

Closes the ncp box in #186 (as a quality upgrade — not seam-affected).