### PR TITLE
Modernize raster hexes to exact_extract (mobi + iucn-richness) (#194)

### DIFF
--- a/catalog/iucn/k8s/richness-2025/iucn-richness-hex.yaml
+++ b/catalog/iucn/k8s/richness-2025/iucn-richness-hex.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: iucn-rich-hex
+  labels:
+    k8s-app: iucn-rich-hex
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: iucn-rich-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then export PROJ_DATA="$(dirname $PROJ_DB)"; export PROJ_LIB="$PROJ_DATA"; fi
+          IDX=${JOB_COMPLETION_INDEX}
+          COGS=(Amphibians_SR_2025 Birds_SR_2025 Mammals_SR_2025 Reptiles_SR_2025 FW_Fish_SR_2025 Combined_SR_2025 Amphibians_THR_SR_2025 Birds_THR_SR_2025 Mammals_THR_SR_2025 Reptiles_THR_SR_2025 FW_Fish_THR_SR_2025 Combined_THR_SR_2025 Combined_RWR_2025 Combined_THR_RWR_2025)
+          LAYERS=(amphibians_sr birds_sr mammals_sr reptiles_sr fw_fish_sr combined_sr amphibians_thr_sr birds_thr_sr mammals_thr_sr reptiles_thr_sr fw_fish_thr_sr combined_thr_sr combined_rwr combined_thr_rwr)
+          for k in ${!COGS[@]}; do
+            N=${COGS[$k]}; L=${LAYERS[$k]}
+            echo "===== h0-index $IDX  layer $L ($N) ====="
+            cng-datasets raster \
+              --input "s3://public-iucn/cog/richness/${N}_4326.tif" \
+              --output-parquet "s3://public-iucn/hex/${L}/" \
+              --h0-index ${IDX} --resolution 5 --parent-resolutions 4,3,0 \
+              --value-column ${L} --hex-resampling max --nodata 0
+          done
+          echo "index $IDX done"
+        resources:
+          requests: {cpu: '4', memory: 16Gi, ephemeral-storage: 30Gi}
+          limits:   {cpu: '4', memory: 16Gi, ephemeral-storage: 30Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/iucn/k8s/richness-2025/iucn-richness-reproject.yaml
+++ b/catalog/iucn/k8s/richness-2025/iucn-richness-reproject.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: iucn-reproject
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']
+      containers:
+      - name: reproject
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then export PROJ_DATA="$(dirname $PROJ_DB)"; export PROJ_LIB="$PROJ_DATA"; fi
+          NAMES="Amphibians_SR_2025 Birds_SR_2025 Mammals_SR_2025 Reptiles_SR_2025 FW_Fish_SR_2025 Combined_SR_2025 Amphibians_THR_SR_2025 Birds_THR_SR_2025 Mammals_THR_SR_2025 Reptiles_THR_SR_2025 FW_Fish_THR_SR_2025 Combined_THR_SR_2025 Combined_RWR_2025 Combined_THR_RWR_2025"
+          for N in $NAMES; do
+            echo "===== reprojecting $N ====="
+            rclone copyto nrp:public-iucn/cog/richness/${N}.tif /tmp/${N}.tif
+            gdalwarp -t_srs EPSG:4326 -r near -of COG \
+              -srcnodata 0 -dstnodata 0 \
+              -co COMPRESS=DEFLATE -co BLOCKSIZE=512 -co OVERVIEW_RESAMPLING=NEAREST -co NUM_THREADS=4 \
+              /tmp/${N}.tif /tmp/${N}_4326.tif
+            gdalinfo /tmp/${N}_4326.tif | grep -iE "Size is|ID\[\"EPSG|Pixel Size|NoData|Type=" | head -6
+            rclone copyto /tmp/${N}_4326.tif nrp:public-iucn/cog/richness/${N}_4326.tif
+            rm -f /tmp/${N}.tif /tmp/${N}_4326.tif
+          done
+          echo "ALL 14 REPROJECTED"
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        resources:
+          requests: {cpu: '4', memory: 16Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 16Gi, ephemeral-storage: 20Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/mobi/k8s/species-richness-all/mobi-species-richness-all-hex.yaml
+++ b/catalog/mobi/k8s/species-richness-all/mobi-species-richness-all-hex.yaml
@@ -6,9 +6,10 @@ metadata:
     k8s-app: mobi-species-richness-all-hex
 spec:
   completions: 122
-  parallelism: 61
+  parallelism: 30
   completionMode: Indexed
-  backoffLimit: 0
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
   podFailurePolicy:
     rules:
     - action: Ignore
@@ -50,6 +51,12 @@ spec:
           value: /usr/lib/python3/dist-packages
         - name: BUCKET
           value: public-mobi
+        # rclone-config is required: the tool localizes the COG to local NVMe
+        # (rclone copy nrp:...) before hexing; without it localization fails.
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
         command:
         - bash
         - -c
@@ -63,7 +70,10 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "https://minio.carlboettiger.info/public-biodiversity/mobi/species-richness-all/SpeciesRichness_All.tif" --output-parquet s3://public-mobi/mobi-species-richness-all/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column species_richness --nodata -128.0
+          # exact-extract, one row per cell, `max` reducer: species richness is a
+          # count, so each cell stores the peak (not the average) modeled richness
+          # among the source pixels covering it. Hexed from the WGS84 COG on NRP S3.
+          cng-datasets raster --input "s3://public-mobi/mobi-species-richness-all-cog.tif" --output-parquet s3://public-mobi/mobi-species-richness-all/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column species_richness --hex-resampling max --nodata -128
         resources:
           requests:
             cpu: '4'
@@ -73,6 +83,10 @@ spec:
             cpu: '4'
             memory: 32Gi
             ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Modernizes legacy / point-binned raster hexes to the current `cng-datasets raster` exact_extract pipeline (one row per cell, correct reducer), per #194. **Data + STAC are already live on S3 and validated** — this PR carries the build YAMLs.

## Done in this PR
- **mobi-species-richness-all** — exact_extract `max`, res 8, hexed from the WGS84 COG. Fixes legacy multi-row (~3.6 rows/cell) **and** broken h0 partitioning (10 of 16 legacy partitions were bogus — h8 cells filed under wrong res-0 parents). Validated: rpc 1.0, `partition_mismatch=0`, MAX==COG (32), gap-free CONUS. Canonical `public-mobi/.../hex/` + STAC/README flipped.
- **iucn-richness-2025 ×14** — reprojected the 10 km World Mollweide COGs → WGS84, exact_extract `max` at **res 5** (first H3 res finer than the 10 km pixel; legacy point-binned at zoom 8 left coverage gaps). Validated all 14: rpc 1.0, `partition_mismatch=0`, combined_sr max 1813==COG, combined_rwr 8.857==COG, full antimeridian coverage (Chukotka h0 spans ±180). STAC rewritten 5→14 layers with `h3:*` + per-asset `table:columns`; WGS84 COGs published.

## Still open on #194 (not in this PR)
- **gfw-fishing-effort** — deferred pending an accuracy discussion (multi-dim point-sum).
- **wyoming nlcd/rap ×4** — to be re-processed to full upstream (national) extent into a new bucket structure; tracked locally (`catalog/wyoming/` is gitignored).

Refs #194.
