### PR TITLE
Add MyST website for Agentic Data Workflows

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,52 @@
+name: Deploy MyST site to GitHub Pages
+
+# Build the Agentic Data Workflows site with mystmd and publish to GitHub Pages.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'myst.yml'
+      - '*.md'
+      - '.github/workflows/deploy-site.yml'
+  workflow_dispatch:
+
+# GitHub Pages needs pages + id-token; contents:read to checkout.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  # Served at https://boettiger-lab.github.io/data-workflows/
+  BASE_URL: /data-workflows
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install mystmd
+        run: npm install -g mystmd
+      - name: Build HTML
+        run: myst build --html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# MyST site build artifacts
+_build/
+node_modules/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/catalog.md
+++ b/catalog.md
@@ -1,0 +1,44 @@
+---
+title: The catalog
+subtitle: Proven at scale on real, open datasets
+---
+
+The pipeline produces a growing, public catalog of cloud-native datasets, each
+described by STAC and queryable without download. The geospatial collections below
+are the proven track record — the same machinery now extends to other domains.
+
+[**Browse the full catalog in STAC Browser →**](https://radiantearth.github.io/stac-browser/#/external/s3-west.nrp-nautilus.io/public-data/stac/catalog.json)
+
+## What's published
+
+Datasets are hosted on [NRP Nautilus](https://nrp.ai) object storage and span
+biodiversity, protected areas, census geographies, carbon, and earth-observation
+rasters — produced in partnership with **NASA**, **The Nature Conservancy**, and
+**California Fish & Wildlife**, among others.
+
+Each collection ships with:
+
+- **Cloud-native data** — columnar Parquet for tables, COG/Zarr for rasters and arrays.
+- **Derived spatial indexes** — for fast joins and aggregation across datasets.
+- **STAC metadata** — schemas, asset roles, units, coded-value definitions, and provenance.
+
+## Query without downloading
+
+Because outputs are cloud-native and streamed by range-request, you can query a
+multi-gigabyte dataset directly from a notebook — pulling only the rows and columns a
+query touches:
+
+```python
+import duckdb
+
+con = duckdb.connect()
+con.execute("INSTALL httpfs; LOAD httpfs;")
+con.execute("""
+    SELECT COUNT(*)
+    FROM read_parquet('https://s3-west.nrp-nautilus.io/<bucket>/<dataset>.parquet')
+""").fetchall()
+```
+
+An AI agent connected through [`mcp-data-server`](ecosystem.md) does the same — but
+reads the STAC metadata first, so it knows which dataset to open and what each column
+means before it writes the query.

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -1,0 +1,61 @@
+---
+title: The ecosystem
+subtitle: Teaching agents to drive data at scale
+---
+
+`data-workflows` is one of three open-source components that together let
+researchers and their AI agents work with terabyte-scale data through the tools they
+already use. Each is independently useful; together they form an **AI-native bridge**
+to the mature cloud-native stack the sciences are converging on.
+
+::::{grid} 1 1 3 3
+
+:::{card} data-workflows
+:link: https://github.com/boettiger-lab/data-workflows
+**Prepares the data.** The pipeline on this site — transforms legacy and proprietary
+sources into AI-ready Parquet/Zarr with rich STAC metadata, run locally, on private
+clouds, or on public object stores.
+:::
+
+:::{card} mcp-data-server
+:link: https://boettiger-lab.github.io/mcp-data-server/
+**Connects the agents.** An open [Model Context Protocol](https://modelcontextprotocol.io)
+server that points coding agents at a collection's STAC metadata and exposes
+cloud-native engines (DuckDB, hardware-accelerated Polars) — so the model uses them
+instead of in-memory libraries. Runs locally for sensitive data or on autoscaling
+Kubernetes for scale.
+:::
+
+:::{card} jupyter-geoagent
+:link: https://jupyter-geoagent.readthedocs.io/
+**Meets researchers where they work.** A JupyterLab extension integrating with
+Jupyter-AI — a data persona users drive with commercial *or* fully open models run
+locally, keeping data on the researcher's own hardware.
+:::
+
+::::
+
+## Why a bridge, not a fork
+
+The components this connects — [Zarr](https://zarr.dev), xarray,
+[Parquet](https://parquet.apache.org), [DuckDB](https://duckdb.org), Polars,
+[STAC](https://stacspec.org), [Jupyter](https://jupyter.org), and the
+[Model Context Protocol](https://modelcontextprotocol.io) — are individually mature
+open-source projects with wide adoption. What is new is the **AI-native layer** that
+lets researchers and their agents drive them *together*, at scale.
+
+The leverage is that Jupyter and agentic coding assistants are already the field's
+everyday tools. The bridge meets that existing base without asking anyone to learn a
+new toolchain: the agent a scientist already uses makes the move from in-memory
+libraries to the cloud-native stack on the user's behalf. And because the MCP layer
+works with small, locally-run open models, it reduces dependence on closed models and
+keeps sensitive data — clinical, patient, controlled-access — on local hardware.
+
+## From earth observation to the life sciences
+
+These methods were built and proven at the largest earth-observation scales. The same
+architecture extends to the life sciences, where spatially-resolved data — 3D-genome
+imaging, spatial transcriptomics, whole-slide microscopy — now arrives at terabyte
+scale, well beyond the in-memory tools most researchers rely on. The cloud-native
+foundation to handle it is mature; the missing piece is the agentic layer that makes
+it reachable. That is what this ecosystem provides.

--- a/features.md
+++ b/features.md
@@ -1,0 +1,63 @@
+---
+title: Features
+subtitle: What makes the pipeline AI-native and scalable
+---
+
+## An AI-driven pipeline
+
+The workflow is built to be **driven by agents**, not just usable by experts. Each
+step — selecting a cloud-native engine, generating conversion jobs, writing the
+catalog entry — is something a coding assistant can do on a researcher's behalf.
+The point is not to add a chatbot, but to make the underlying stack *legible* to the
+models scientists already use, so they reach for streaming engines instead of the
+in-memory libraries that silently break at scale.
+
+## `cng-datasets` as the embedded core
+
+All of the conversion logic lives in one open-source Python package,
+[`cng-datasets`](https://github.com/boettiger-lab/datasets): format readers, the
+chunking and indexing strategy, the memory model, and the job-generation. Because the
+logic is packaged rather than scattered across scripts, the same recipe runs
+identically on a laptop, a private cloud, or a public cluster — and a single command
+expresses the whole transformation.
+
+## Cloud-native, AI-ready outputs
+
+Outputs are open, cloud-optimized serializations that stream by range-request:
+
+- **Parquet** — columnar tables for out-of-core query engines (DuckDB, Polars).
+- **Zarr** — chunked, compressed arrays for imaging and gridded data.
+- **Derived indexes** — spatial and hierarchical indexes for fast joins and aggregation.
+
+Nothing is downloaded to be read; a query pulls only the bytes it needs. This is what
+makes terabyte datasets usable from an ordinary notebook.
+
+## Rich STAC metadata
+
+Every dataset ships with [STAC](https://stacspec.org) metadata — the
+SpatioTemporal Asset Catalog standard — describing each asset's schema, role, units,
+coded-value definitions, and provenance. This metadata is the difference between an
+agent that *finds and correctly reads* a dataset and one that guesses. It also makes
+collections discoverable and composable across the whole catalog.
+
+## Autoscaling on Kubernetes
+
+Heavy compute runs on the cluster. Jobs fan out across many pods, each processing a
+slice of the data in parallel, with memory and parallelism tuned per job. Larger-than-
+memory inputs spill to disk rather than exhausting RAM, and individual failed slices
+are reprocessed in isolation. The same workflow scales from one small file to a
+catalog of terabyte-scale datasets.
+
+## General-purpose, beyond geo
+
+The architecture is **domain-agnostic**. Any data with a tabular or array structure —
+and some indexable dimension to partition on — fits the same pipeline. We proved it
+first at earth-observation scale; the identical machinery extends to the life sciences:
+
+- **Spatial transcriptomics** and image-based assays
+- **Whole-slide microscopy** and other large image stacks
+- **3D-genome imaging** and other terabyte array data
+
+The cloud-native foundation it builds on — Parquet, Zarr, DuckDB, Polars, STAC — is
+already mature and widely adopted across domains. What this project adds is the
+**AI-native layer** that lets researchers and their agents drive it together, at scale.

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -1,0 +1,69 @@
+---
+title: How it works
+subtitle: From a legacy source file to AI-ready data and a catalog entry
+---
+
+The pipeline has one job: take data in whatever format it arrives in and produce
+**cloud-native, AI-ready artifacts plus the metadata that describes them** — with
+the actual compute running on autoscaling infrastructure rather than a workstation.
+
+## The pipeline
+
+```{mermaid}
+flowchart LR
+    A[Legacy / proprietary source<br/>GDB · Shapefile · GeoTIFF<br/>instrument exports · image stacks] --> B
+    B[cng-datasets<br/>embeds the core logic] --> C[Kubernetes jobs<br/>autoscale the compute]
+    C --> D[Cloud-native outputs<br/>Parquet · Zarr · derived indexes]
+    C --> E[STAC metadata<br/>schemas · assets · provenance]
+    D --> F[Object store<br/>streamed by range-request]
+    E --> F
+    F --> G[Agents & researchers<br/>query at scale, no download]
+```
+
+### 1. Describe the dataset
+
+You point the [`cng-datasets`](https://github.com/boettiger-lab/datasets) CLI at a
+source and describe how it should be indexed. The package **embeds the core
+conversion logic** — the format readers, the chunking and indexing strategy, the
+memory model — so a single command captures the whole recipe. It does not process
+data locally; it *generates* the Kubernetes job manifests that will.
+
+### 2. Autoscale the compute
+
+You apply those manifests to a **Kubernetes** cluster. The work fans out across
+many pods, each handling a slice of the data, and streams larger-than-memory
+inputs by spilling to disk instead of loading everything into RAM. A dataset that
+would never fit on a laptop is processed in parallel on cluster metal. Memory and
+parallelism are tuned per job; failed slices are reprocessed in isolation.
+
+### 3. Produce cloud-native, AI-ready outputs
+
+Outputs land on an **object store** in open, cloud-optimized formats — columnar
+**Parquet** for tables, chunked **Zarr** for arrays, plus derived spatial indexes.
+These are read by **range-request**: a query streams only the bytes it needs
+rather than downloading the whole file, which is what makes terabyte data tractable
+from a notebook.
+
+### 4. Describe it with STAC
+
+Alongside the data, the pipeline records **STAC** (SpatioTemporal Asset Catalog)
+metadata: the column schema of each asset, its role and format, units, coded-value
+definitions, and provenance. This is the layer that lets an AI agent **find** the
+right dataset and **interpret it correctly** — without it, a model has to guess at
+column meanings and silently returns wrong answers.
+
+## Why "agentic"
+
+As coding assistants become the everyday interface for analysis, they reach by
+default for the in-memory libraries they know best (e.g. `pandas`) — which fail at
+scale and, lacking metadata, misread the data. This pipeline closes that gap from
+both ends:
+
+- It **produces** the cloud-native artifacts and the STAC metadata an agent needs.
+- Companion tooling (see [the ecosystem](ecosystem.md)) then **points agents at that
+  metadata** and confines them to validated cloud-native engines, so the agent a
+  scientist already uses makes the move from in-memory tools to the streaming stack
+  on the user's behalf.
+
+The result is an AI-driven path from a raw legacy file to data that researchers and
+their agents can query at scale — with no new toolchain to learn.

--- a/index.md
+++ b/index.md
@@ -1,0 +1,54 @@
+---
+title: Agentic Data Workflows
+subtitle: AI-ready, cloud-native data with rich metadata — from any legacy source
+site:
+  hide_outline: true
+---
+
++++ {"class": "col-page text-center"}
+
+# Agentic Data Workflows
+
+### Turn disparate legacy and proprietary data into **AI-ready, cloud-native** data with rich **STAC** metadata.
+
+An AI-driven pipeline that converts the formats science actually ships in — geodatabases, shapefiles, proprietary instrument exports, terabyte image stacks — into open, cloud-optimized serializations (Parquet, Zarr) described by machine-readable metadata, so that researchers *and their AI agents* can query data at scale without first downloading it or mastering a new toolchain.
+
+The core conversion logic lives in our Python package, [**`cng-datasets`**](https://github.com/boettiger-lab/datasets); the heavy compute autoscales on **Kubernetes**. You describe the dataset; the pipeline produces the cloud-native artifacts and the catalog entry.
+
+[**See how it works →**](how-it-works.md) &nbsp;·&nbsp; [Quickstart](quickstart.md) &nbsp;·&nbsp; [GitHub](https://github.com/boettiger-lab/data-workflows)
+
++++
+
+## What it gives you
+
+::::{grid} 1 1 2 2
+
+:::{card} 🤖 An AI-driven pipeline
+:link: features.md
+Agents drive the workflow end to end — selecting the right cloud-native engine, generating the conversion jobs, and writing the metadata — instead of reaching for in-memory libraries that silently fail at scale.
+:::
+
+:::{card} 📦 `cng-datasets` at the core
+:link: how-it-works.md
+A single Python package embeds the conversion logic. One command turns a source dataset into Parquet/Zarr plus a catalog entry, and emits the Kubernetes jobs that do the work.
+:::
+
+:::{card} 🗂️ Rich STAC metadata
+:link: features.md
+Every output is described with the SpatioTemporal Asset Catalog standard: column schemas, asset roles, and provenance that let agents *find* and *correctly interpret* the data.
+:::
+
+:::{card} ☁️ Autoscaled on Kubernetes
+:link: how-it-works.md
+Compute runs on the cluster, not your laptop. Jobs fan out across hundreds of pods and stream larger-than-memory data, so terabyte datasets are routine.
+:::
+
+::::
+
++++
+
+## General-purpose, proven at scale
+
+The approach is **domain-agnostic** — any tabular or array data with a spatial, temporal, or otherwise indexable structure fits. We built and proved these methods at the largest **earth-observation** scales (working with NASA, The Nature Conservancy, and California Fish & Wildlife), and are extending them to the **life sciences**: spatial transcriptomics, whole-slide microscopy, and 3D-genome imaging at terabyte scale.
+
+[**Browse the live catalog →**](catalog.md)

--- a/myst.yml
+++ b/myst.yml
@@ -1,0 +1,49 @@
+version: 1
+project:
+  id: agentic-data-workflows
+  title: Agentic Data Workflows
+  description: >-
+    Turn disparate legacy and proprietary data into AI-ready, cloud-native
+    data with rich STAC metadata — through an AI-driven pipeline powered by
+    cng-datasets and autoscaled on Kubernetes.
+  github: https://github.com/boettiger-lab/data-workflows
+  license:
+    content: CC-BY-4.0
+    code: BSD-3-Clause
+  authors:
+    - name: Carl Boettiger
+      orcid: 0000-0002-1642-628X
+      affiliation: University of California, Berkeley
+  keywords:
+    - cloud-native
+    - AI-ready data
+    - STAC
+    - Kubernetes
+    - agentic workflows
+    - data engineering
+  toc:
+    - file: index.md
+    - file: how-it-works.md
+    - file: features.md
+    - file: quickstart.md
+    - file: ecosystem.md
+    - file: catalog.md
+site:
+  template: book-theme
+  options:
+    favicon: ''
+    logo_text: Agentic Data Workflows
+  nav:
+    - title: How it works
+      url: /how-it-works
+    - title: Features
+      url: /features
+    - title: Quickstart
+      url: /quickstart
+    - title: Ecosystem
+      url: /ecosystem
+    - title: Catalog
+      url: /catalog
+  actions:
+    - title: GitHub
+      url: https://github.com/boettiger-lab/data-workflows

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,0 +1,64 @@
+---
+title: Quickstart
+subtitle: Generate a pipeline on your laptop, run it on the cluster
+---
+
+The CLI runs on your laptop and only ever **generates** Kubernetes job manifests.
+The cluster does all the processing; your laptop just talks to `kubectl`. Outputs
+land on object storage as cloud-native Parquet and derived indexes, described by STAC.
+
+:::{tip} The mental model
+You never process data locally. `cng-datasets` turns a dataset description into
+job YAML; `kubectl apply` hands that work to the cluster, which autoscales across
+many pods.
+:::
+
+## 1. Install the CLI
+
+```bash
+pip install cng-datasets
+```
+
+## 2. Generate a processing pipeline
+
+Point the CLI at a source and describe how it should be indexed. This writes a set
+of Kubernetes manifests to `--output-dir` — it does not move any data yet.
+
+```bash
+cng-datasets workflow \
+  --dataset my-dataset \
+  --source-url https://example.com/data.gdb \
+  --bucket public-mydata \
+  --layer MyLayer \
+  --output-dir catalog/mydata/k8s/mylayer
+```
+
+## 3. Apply the workflow to the cluster
+
+```bash
+# One-time RBAC setup (per cluster/namespace; often already done)
+kubectl apply -f catalog/mydata/k8s/mylayer/workflow-rbac.yaml
+
+# Run the workflow
+kubectl apply \
+  -f catalog/mydata/k8s/mylayer/configmap.yaml \
+  -f catalog/mydata/k8s/mylayer/workflow.yaml
+```
+
+## 4. Monitor
+
+```bash
+kubectl get jobs | grep my-dataset
+kubectl logs job/my-dataset-workflow
+```
+
+The cluster converts the source, writes the cloud-native outputs to the object
+store, and the catalog entry is published alongside them. When it finishes, the
+dataset is ready to query at scale — and ready for agents to discover via its STAC
+metadata.
+
+:::{seealso} Full documentation
+The complete operator's guide — parameter tuning, memory and chunking, multi-layer
+and raster sources, troubleshooting — lives in the repository's
+[`AGENTS.md`](https://github.com/boettiger-lab/data-workflows/blob/main/AGENTS.md).
+:::


### PR DESCRIPTION
A six-page [mystmd](https://mystmd.org) site (book-theme) for the project's official name, **Agentic Data Workflows**.

## What it says
The big picture: this project turns disparate **legacy and proprietary** data into **AI-ready, cloud-native** data (Parquet/Zarr) with **rich STAC metadata** — through an **AI-driven pipeline** powered by the **`cng-datasets`** Python package (which embeds the core logic) and **autoscaled on Kubernetes**. Framed general-purpose with a life-science-forward emphasis; the geospatial catalog is presented as the proven track record.

## Pages
- **Landing** — hero + a feature card grid (the four key features)
- **How it works** — source → cng-datasets → Kubernetes → cloud-native outputs + STAC (mermaid diagram)
- **Features** — AI-driven, cng-datasets core, cloud-native/AI-ready, STAC, autoscaling, general-purpose
- **Quickstart** — install → generate workflow → `kubectl apply` → monitor
- **Ecosystem** — data-workflows + mcp-data-server + jupyter-geoagent context (the OS4LS framing)
- **Catalog** — links to the live STAC catalog; query-without-download example

## Deploy
`.github/workflows/deploy-site.yml` builds with `mystmd` and publishes to GitHub Pages on push to `main` (served at `/data-workflows`). **Requires enabling Pages with source = GitHub Actions** in repo settings.

Built and verified locally: 6 pages render, no directive errors, mermaid + cards + grid present, BASE_URL correct.