### PR TITLE
site: add Cassie Buhler as co-author

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -14,6 +14,7 @@ project:
     - name: Carl Boettiger
       orcid: 0000-0002-1642-628X
       affiliation: University of California, Berkeley
+    - name: Cassie Buhler
   keywords:
     - cloud-native
     - AI-ready data


### PR DESCRIPTION
Adds Cassie Buhler to the author list in `myst.yml` for the Agentic Data Workflows site.