### PR TITLE
AGENTS: flag the density-vs-amount reducer trap (sum on Mg/ha rasters)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Differences from vector:
 - Defaults: `--h3-resolution` 8, `--parent-resolutions "0"`, `--hex-memory 32Gi`, `--max-parallelism 61`
 - `--value-column` — raster band name in output (default `value`)
 - `--nodata` — value to exclude (auto from metadata)
-- `--hex-resampling` — **how pixels aggregate into each cell (`sum`/`mean`/`mode`, default `mean`). Picking the wrong one silently corrupts the data — see "Choosing the aggregation reducer" below. As important as `--value-column`.**
+- `--hex-resampling` — **how pixels aggregate into each cell (`sum`/`mean`/`mode`/`max`/`min`, default `mean`). Picking the wrong one silently corrupts the data — see "Choosing the aggregation reducer" below. As important as `--value-column`.**
 - Always creates a WGS84 COG on NRP S3 first; hex reads from that COG
 
 **Multi-tile rasters** (e.g. multiple UTM zones): repeat `--source-url`. Adds `preprocess-cog` step that mosaics into one WGS84 COG:
@@ -179,7 +179,7 @@ Extra options: `--target-extent "xmin,ymin,xmax,ymax"` (EPSG:4326 clip), `--targ
 
 #### ⚠️ Choosing the aggregation reducer (`--hex-resampling`)
 
-`--hex-resampling` controls how source pixels collapse into each H3 cell. **The right reducer depends entirely on what the pixel value *means*, and the wrong one silently produces nonsense** (summing land-cover class codes, averaging species counts). Decide this per dataset, every time. Supported: `sum`, `mean`, `mode` (default `mean`).
+`--hex-resampling` controls how source pixels collapse into each H3 cell. **The right reducer depends entirely on what the pixel value *means*, and the wrong one silently produces nonsense** (summing land-cover class codes, averaging species counts). Decide this per dataset, every time. Supported: `sum`, `mean`, `mode`, `max`, `min` (default `mean`).
 
 | Pixel value is… | Reducer | Examples |
 |---|---|---|
@@ -193,7 +193,7 @@ To get a **total from a density raster**: use `mean` (area-weighted mean density
 
 **Correctness check:** for an amount-per-pixel `sum`, the catalog-wide `SUM(value)` over the hex parquet MUST equal the source COG's pixel sum within sub-pixel rounding (compute the COG sum with a GDAL block-sum job; query the hex sum via the MCP). **For a density layer, the COG pixel-sum is itself *not* a total — validate the area-corrected `SUM` against the published global total instead** (e.g. irrecoverable carbon 2018 ≈ 137 Gt vs Noon et al. 139.1 Gt). `mean`/`mode` have no global invariant — spot-check the hex against the COG over a known region.
 
-**Species richness / "peak" quantities** (MOBI, IUCN richness): the correct reducer is `max` — **not** `sum` (double-counts species) and **not** `mean` (averages away hotspots). `max` is **not yet supported** (only `sum`/`mean`/`mode`) — tracked in [`boettiger-lab/datasets#95`](https://github.com/boettiger-lab/datasets/issues/95). Until it lands, use `mean` and document the limitation, or hold the dataset.
+**Species richness / "peak" quantities** (MOBI, IUCN richness): the correct reducer is `max` — **not** `sum` (double-counts species) and **not** `mean` (averages away hotspots). `max` (and `min`) are supported as of [`boettiger-lab/datasets#95`](https://github.com/boettiger-lab/datasets/issues/95) (closed 2026-06-01); MOBI and IUCN-richness were rebuilt with `max` at res 8/5 (data-workflows #194). Validate: hex `MAX(value)` == COG max, and every cell value within `[COG min, COG max]` (roll up to coarser resolutions with `GROUP BY h<parent> + MAX`, never `AVG`/`SUM`).
 
 **`mode` keeps only the *dominant* class** per cell; the class mix is discarded. Fine for "dominant class" maps, but **inadequate for area-accounting** ("how much wetland?"), which then undercounts to plurality cells only. Per-class fractional coverage (one column per class) is not produced by the current pipeline — flag it if a use case needs class areas.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,11 +183,15 @@ Extra options: `--target-extent "xmin,ymin,xmax,ymax"` (EPSG:4326 clip), `--targ
 
 | Pixel value is… | Reducer | Examples |
 |---|---|---|
-| **Extensive / stock / count** — a total that must be conserved | `sum` | population (GHS-POP), carbon stock, fishing-effort hours, counts |
-| **Intensive / index / rate / fraction** — a per-area quantity | `mean` | NDVI, % cover (RAP), bathymetry depth (GEBCO), habitat indices (NCP) |
+| **Amount already integrated *per pixel*** — each pixel holds the whole-pixel total | `sum` | population *per pixel* (GHS-POP persons/cell), fishing-effort hours per cell, counts |
+| **Density / intensity / rate / fraction** — a *per-area* or normalized quantity | `mean` | carbon **density** (Mg C **ha⁻¹** — Noon irrecoverable/vulnerable/manageable carbon), NDVI, % cover (RAP), depth (GEBCO), indices (NCP) |
 | **Categorical** — discrete class codes | `mode` | land cover (CGLS-LC100, NLCD), wetland class (GLWD) |
 
-**Correctness check:** for `sum`, the catalog-wide `SUM(value)` over the hex parquet MUST equal the source COG's pixel sum within sub-pixel rounding (compute the COG sum with a GDAL block-sum job; query the hex sum via the MCP). `mean`/`mode` have no global invariant — spot-check the hex against the COG over a known region.
+**⛔ The density-vs-amount trap (the #1 way `sum` goes wrong) — check the source UNITS before choosing the reducer.** `sum` is correct *only* when each pixel value is an amount **already integrated over the pixel** (GHS-POP stores persons *per pixel*, so `sum` recovers the population total). If the value is a **density** — a per-area quantity like Mg C **ha⁻¹**, t km⁻², persons km⁻² — then `sum` produces a meaningless *sum of densities*, off from the true total by roughly the pixel area (carbon was ~7× low; data-workflows #171/#202). **A stock can be a density:** "carbon stock" is conceptually extensive, but the Noon et al. carbon rasters store Mg C **per hectare**, so they need area-integration, *not* `sum`. The reducer follows the **units**, not the conceptual quantity — read the source READMEs / band metadata / paper to confirm whether a value is per-pixel or per-area.
+
+To get a **total from a density raster**: use `mean` (area-weighted mean density per cell), then multiply by the H3 cell ground area downstream — `total = mean_density × cell_area` (h3 `cell_area`; cells are ~equal-area per resolution). There is no one-step density→total reducer yet ([`boettiger-lab/datasets#105`](https://github.com/boettiger-lab/datasets/issues/105)). For an existing density-`sum` build, the equivalent correction is `value × pixel_area_ha` per cell (pixel area is latitude-dependent on a WGS84 grid, ≈ `9·cos(lat)` ha for a ~300 m grid).
+
+**Correctness check:** for an amount-per-pixel `sum`, the catalog-wide `SUM(value)` over the hex parquet MUST equal the source COG's pixel sum within sub-pixel rounding (compute the COG sum with a GDAL block-sum job; query the hex sum via the MCP). **For a density layer, the COG pixel-sum is itself *not* a total — validate the area-corrected `SUM` against the published global total instead** (e.g. irrecoverable carbon 2018 ≈ 137 Gt vs Noon et al. 139.1 Gt). `mean`/`mode` have no global invariant — spot-check the hex against the COG over a known region.
 
 **Species richness / "peak" quantities** (MOBI, IUCN richness): the correct reducer is `max` — **not** `sum` (double-counts species) and **not** `mean` (averages away hotspots). `max` is **not yet supported** (only `sum`/`mean`/`mode`) — tracked in [`boettiger-lab/datasets#95`](https://github.com/boettiger-lab/datasets/issues/95). Until it lands, use `mean` and document the limitation, or hold the dataset.
 


### PR DESCRIPTION
Sharpens the `--hex-resampling` reducer guidance after the carbon density-units bug (#202).

The table listed **"carbon stock" under `sum`**, but the Noon et al. carbon rasters store carbon as **Mg C per hectare** (density), so `sum` produced a sum-of-densities ~6–7× below the true total (irrecoverable-2018: 21 Gt vs published 139 Gt). Root issue: the reducer must follow the **source units**, not the conceptual quantity — a stock *expressed as a density* needs area-integration, never `sum`.

Changes:
- Reframe the table: `sum` = amount **already integrated per pixel** (GHS-POP persons/cell); `mean` = **density/per-area** (carbon Mg C/ha, NDVI, % cover, depth).
- Add a ⛔ "density-vs-amount trap" callout: check units first; density→total = `mean × cell_area`; note the `value × pixel_area_ha` correction for existing density-`sum` builds.
- Fix the correctness check: for a density layer the COG pixel-sum is **not** a total — validate the area-corrected SUM against the published global total.
- Cross-ref [`datasets#105`](https://github.com/boettiger-lab/datasets/issues/105) (optional one-step density-aware reducer).

Docs-only. Resolves the decision-making half of #202.
