### PR TITLE
#194: NLCD + RAP full-CONUS exact_extract hex rebuild (public-land-cover + public-rap)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 You work in `data-workflows`, which uses `cng-datasets` to convert geospatial data into cloud-native formats on Kubernetes. This file tells you everything you need.
 
+## ⛔ HARD BOUNDARY: Scoping decisions live in the GitHub issue, NEVER in memory
+
+Every decision that defines *what* a dataset task delivers — **spatial extent** (full upstream coverage vs. a regional clip), **H3 resolution**, reducer, source product/version, target bucket and naming, acceptance criteria — MUST be written into the GitHub issue before you act on it. Sessions are disposable: the laptop dies, agent memory is wiped, a different agent picks up the task. The issue is the single source of truth that survives all of that. Treat yourself like any professional developer — nobody is expected to carry scope "in their head," and you must not rely on agent memory (`~/.claude/.../memory`) for scope. Memory is for *how you work*, never *what a task delivers*.
+
+- **Before building:** if the issue does not state the extent, resolution, and acceptance criteria explicitly, the issue is underspecified. **Stop, propose the scope, get agreement, and edit the issue to record it** (`gh issue edit` / a scoping comment) before running cluster jobs. A vague label like "the wyoming group" is not a scope.
+- **When scope changes mid-task** (e.g. "extend to the full upstream extent, not the regional clip"): update the issue body in the same turn you learn it — don't just remember it.
+- **Never infer scope** from the bucket name, an existing clipped COG, or a prior build's resolution. Those are artifacts of how an earlier (possibly wrong) pass happened to run, not statements of intent.
+- A reviewer (human or agent) must be able to read the issue alone and know exactly what to build. If you found yourself reconstructing scope from code, S3 layout, or memory, that is the signal the issue needs updating.
+
 ## ⛔ HARD BOUNDARY 0: Big-data compute runs on the cluster, NOT your laptop
 
 For ANY query/scan/aggregation over S3 parquet — catalog data **and** large intermediate/build files (e.g. a 24 GB consolidated GeoParquet) — use the **`mcp__duckdb-geo__query` MCP server**. It runs on generously-provisioned cluster metal with the **internal NRP S3 endpoint** and a **100 Gb/s** network, and DuckDB **streams** (larger-than-memory spills to disk) — so it does not hit the RAM limits or the slow public endpoint (~12 MB/s) that bottleneck the laptop.
@@ -545,6 +554,19 @@ kubectl -n biodiversity describe pod <pod-name> | grep -A5 "Reason:\|Message:\|E
 | `ContainerStatusUnknown` on shared nodes | Preemption | Pin to Berkeley node |
 
 **DuckDB sort jobs need both big RAM and big ephemeral-storage.** `ORDER BY` over large data spills to disk; low RAM spills more. For 1–15 GB compressed partitions: 120Gi RAM, 50Gi ephemeral-storage. Namespace max for ephemeral-storage is **50Gi** — always request the max for sort-heavy jobs.
+
+**When scratch exceeds 50Gi, mount a PVC — do NOT fight the ephemeral cap.** Ephemeral-storage is hard-capped at 50Gi namespace-wide, so any job whose local scratch exceeds that — a raw download bigger than ~45 GB (e.g. the 35 GB RAP CONUS COG), a multi-tile `preprocess-cog` mosaic, a `raster --local-cache-dir` localization of a large COG — must use a **PersistentVolumeClaim**, not a bigger ephemeral request (which the quota will reject). A shared scratch PVC already exists: **`rechunk-scratch`** (2Ti, `RWX` rook-cephfs) — list with `kubectl -n biodiversity get pvc`.
+- Mount it and redirect the tool's scratch onto it; keep ephemeral small (~10Gi):
+  ```yaml
+  volumeMounts:
+  - {name: scratch, mountPath: /scratch, subPath: <job-name>}   # subPath → per-job isolation on the shared PVC
+  volumes:
+  - {name: scratch, persistentVolumeClaim: {claimName: rechunk-scratch}}
+  env:
+  - {name: TMPDIR, value: /scratch}        # Python tempfile.mkdtemp (mosaic temp) honors TMPDIR
+  # and pass: cng-datasets raster --local-cache-dir /scratch ...   (input localization; CLI default is /tmp/cng-raster-cache)
+  ```
+- **`RWX` + concurrency caveat:** `rechunk-scratch` is ReadWriteMany, but `--local-cache-dir` localizes to a fixed basename, so **N concurrent pods sharing one mountPath collide on the same file**. Use a per-pod `subPath` (or per-pod cache subdir) for fan-out jobs. The 122-pod raster **hex** step localizes a multi-GB COG per pod and is best left on **per-pod ephemeral** (the mosaic COG fits in 50Gi); reserve the PVC for the **single-pod** `preprocess-cog`/download/stage steps where the file genuinely exceeds 50Gi.
 
 **Hex OOM** → regenerate with `--hex-memory 64Gi` and/or more `--max-completions`, delete failed job, reapply.
 

--- a/catalog/land-cover/k8s/nlcd-2024/nlcd-2024-conus-hex.yaml
+++ b/catalog/land-cover/k8s/nlcd-2024/nlcd-2024-conus-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nlcd-2024-conus-hex
+  namespace: biodiversity
+  labels:
+    k8s-app: nlcd-2024-conus-hex
+spec:
+  completions: 3
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 1
+  maxFailedIndexes: 3
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nlcd-2024-conus-hex
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: CNG_HEX_WORKERS
+          value: '8'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(12 50 71)   # remaining CONUS h0 indices (20 done by the probe)
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== NLCD CONUS res-10 mode, h0-index $H0, 256Gi, Berkeley ==="
+          cng-datasets raster \
+            --input "s3://public-wyoming/nlcd-2024-cog-4326.tif" \
+            --output-parquet s3://public-land-cover/nlcd-2024/hex-staging/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,7,6,5,0 \
+            --value-column nlcd --hex-resampling mode --nodata "250"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 256Gi
+            ephemeral-storage: 40Gi
+          limits:
+            cpu: '8'
+            memory: 256Gi
+            ephemeral-storage: 40Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/land-cover/k8s/nlcd-2024/nlcd-2024-reproject.yaml
+++ b/catalog/land-cover/k8s/nlcd-2024/nlcd-2024-reproject.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nlcd-2024-reproject
+  namespace: biodiversity
+  labels: {k8s-app: nlcd-2024-reproject}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata: {labels: {k8s-app: nlcd-2024-reproject}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: reproject
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Annual NLCD ships in Albers Equal-Area; the H3 exact_extract pipeline needs WGS84.
+          # -r near is REQUIRED: bilinear/average would corrupt categorical class codes.
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          [ -n "$PROJ_DB" ] && export PROJ_DATA="$(dirname $PROJ_DB)" PROJ_LIB="$(dirname $PROJ_DB)"
+          rclone copyto nrp:public-wyoming/nlcd-2024-cog.tif /tmp/nlcd-2024-cog.tif -P
+          gdalwarp -t_srs EPSG:4326 -r near -of COG \
+            -srcnodata 250 -dstnodata 250 \
+            -co COMPRESS=DEFLATE -co BLOCKSIZE=512 -co OVERVIEW_RESAMPLING=NEAREST -co NUM_THREADS=4 \
+            /tmp/nlcd-2024-cog.tif /tmp/nlcd-2024-cog-4326.tif
+          # published WGS84 COG (canonical home: public-land-cover/nlcd-2024-cog.tif)
+          rclone copyto /tmp/nlcd-2024-cog-4326.tif nrp:public-land-cover/nlcd-2024-cog.tif -P
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        resources:
+          requests: {cpu: '4', memory: 16Gi, ephemeral-storage: 30Gi}
+          limits:   {cpu: '4', memory: 16Gi, ephemeral-storage: 30Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/rap/k8s/rap-arte/rap-arte-conus-hex.yaml
+++ b/catalog/rap/k8s/rap-arte/rap-arte-conus-hex.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-arte-conus-hex
+  namespace: biodiversity
+  labels: {k8s-app: rap-arte-conus-hex}
+spec:
+  completions: 4
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 1
+  maxFailedIndexes: 4
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels: {k8s-app: rap-arte-conus-hex}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS, value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(12 20 50 71)   # CONUS-bounding h0 indices; tool skips ones the raster doesn't cover
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== rap-arte CONUS res-10 mean, h0-index $H0, 256Gi, Berkeley ==="
+          cng-datasets raster \
+            --input "s3://public-rap/rap-arte-cog.tif" \
+            --output-parquet s3://public-rap/rap-arte/hex-staging/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,0 \
+            --value-column arte --hex-resampling mean --nodata "255"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/rap/k8s/rap-arte/rap-arte-preprocess-cog.yaml
+++ b/catalog/rap/k8s/rap-arte/rap-arte-preprocess-cog.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-arte-preprocess-cog
+  labels:
+    k8s-app: rap-arte-preprocess-cog
+  namespace: biodiversity
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: rap-arte-preprocess-cog
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
+      containers:
+      - name: preprocess-cog
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_CACHEMAX
+          value: '4096'
+        - name: GDAL_HTTP_TIMEOUT
+          value: '60'
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        - name: TMPDIR
+          value: /tmp/cng-raster-cache
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /tmp/cng-raster-cache
+          subPath: rap-arte-preprocess
+        command:
+        - bash
+        - -c
+        - "set -e\n\necho \"Mosaicking 117 tiles \u2192 s3://public-rap/rap-arte-cog.tif\"\n\ncng-datasets raster \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-350000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-425000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-500000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-3925000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4000000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-575000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-3775000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-3850000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-3925000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4000000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-650000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-3700000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-3775000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-3850000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-3925000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4000000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/arte/arte-2025-10-725000-5275000.tif\" \\\n  --output-cog \"s3://public-rap/rap-arte-cog.tif\" \\\n  --target-crs EPSG:4326 \\\n  --resampling bilinear \\\n  --nodata \"255\" \\\n  --hex-resampling mean\n\necho \"\u2713 Preprocess COG complete: s3://public-rap/rap-arte-cog.tif\"\n"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/rap/k8s/rap-arte/rap-arte-setup-bucket.yaml
+++ b/catalog/rap/k8s/rap-arte/rap-arte-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-arte-setup-bucket
+  labels:
+    k8s-app: rap-arte-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: rap-arte-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-rap
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/rap/k8s/rap-arte/workflow-rbac.yaml
+++ b/catalog/rap/k8s/rap-arte/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/rap/k8s/rap-iag/rap-iag-conus-hex.yaml
+++ b/catalog/rap/k8s/rap-iag/rap-iag-conus-hex.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-iag-conus-hex
+  namespace: biodiversity
+  labels: {k8s-app: rap-iag-conus-hex}
+spec:
+  completions: 4
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 1
+  maxFailedIndexes: 4
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels: {k8s-app: rap-iag-conus-hex}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS, value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(12 20 50 71)   # CONUS-bounding h0 indices; tool skips ones the raster doesn't cover
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== rap-iag CONUS res-10 mean, h0-index $H0, 256Gi, Berkeley ==="
+          cng-datasets raster \
+            --input "s3://public-rap/rap-iag-cog.tif" \
+            --output-parquet s3://public-rap/rap-iag/hex-staging/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,0 \
+            --value-column iag --hex-resampling mean --nodata "255"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/rap/k8s/rap-iag/rap-iag-preprocess-cog.yaml
+++ b/catalog/rap/k8s/rap-iag/rap-iag-preprocess-cog.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-iag-preprocess-cog
+  labels:
+    k8s-app: rap-iag-preprocess-cog
+  namespace: biodiversity
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: rap-iag-preprocess-cog
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
+      containers:
+      - name: preprocess-cog
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_CACHEMAX
+          value: '4096'
+        - name: GDAL_HTTP_TIMEOUT
+          value: '60'
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        - name: TMPDIR
+          value: /tmp/cng-raster-cache
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /tmp/cng-raster-cache
+          subPath: rap-iag-preprocess
+        command:
+        - bash
+        - -c
+        - "set -e\n\necho \"Mosaicking 117 tiles \u2192 s3://public-rap/rap-iag-cog.tif\"\n\ncng-datasets raster \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-350000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-425000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-500000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-3925000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4000000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-575000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-3775000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-3850000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-3925000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4000000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-5275000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-5350000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-650000-5425000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-3700000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-3775000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-3850000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-3925000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4000000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4075000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4150000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4225000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4300000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4375000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4450000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4525000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4600000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4675000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4750000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4825000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4900000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-4975000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-5050000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-5125000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-5200000.tif\" \\\n  --input \"s3://public-rap/raw/iag/iag-2025-10-725000-5275000.tif\" \\\n  --output-cog \"s3://public-rap/rap-iag-cog.tif\" \\\n  --target-crs EPSG:4326 \\\n  --resampling bilinear \\\n  --nodata \"255\" \\\n  --hex-resampling mean\n\necho \"\u2713 Preprocess COG complete: s3://public-rap/rap-iag-cog.tif\"\n"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/rap/k8s/rap-iag/rap-iag-setup-bucket.yaml
+++ b/catalog/rap/k8s/rap-iag/rap-iag-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-iag-setup-bucket
+  labels:
+    k8s-app: rap-iag-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: rap-iag-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-rap
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/rap/k8s/rap-iag/workflow-rbac.yaml
+++ b/catalog/rap/k8s/rap-iag/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/rap/k8s/rap-pfg-cover/rap-pfg-cover-conus-hex.yaml
+++ b/catalog/rap/k8s/rap-pfg-cover/rap-pfg-cover-conus-hex.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-pfg-cover-conus-hex
+  namespace: biodiversity
+  labels: {k8s-app: rap-pfg-cover-conus-hex}
+spec:
+  completions: 4
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 1
+  maxFailedIndexes: 4
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels: {k8s-app: rap-pfg-cover-conus-hex}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS, value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(12 20 50 71)   # CONUS-bounding h0 indices; tool skips ones the raster doesn't cover
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== rap-pfg-cover CONUS res-10 mean, h0-index $H0, 256Gi, Berkeley ==="
+          cng-datasets raster \
+            --input "s3://public-rap/rap-pfg-cover-cog.tif" \
+            --output-parquet s3://public-rap/rap-pfg-cover/hex-staging/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,0 \
+            --value-column pfg --hex-resampling mean --nodata "255"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/rap/k8s/rap-pfg-cover/rap-pfg-cover-preprocess-cog.yaml
+++ b/catalog/rap/k8s/rap-pfg-cover/rap-pfg-cover-preprocess-cog.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-pfg-cover-preprocess-cog
+  labels:
+    k8s-app: rap-pfg-cover-preprocess-cog
+  namespace: biodiversity
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: rap-pfg-cover-preprocess-cog
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
+      containers:
+      - name: preprocess-cog
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_CACHEMAX
+          value: '4096'
+        - name: GDAL_HTTP_TIMEOUT
+          value: '60'
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        - name: TMPDIR
+          value: /tmp/cng-raster-cache
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /tmp/cng-raster-cache
+          subPath: rap-pfg-cover-preprocess
+        command:
+        - bash
+        - -c
+        - "set -e\n\necho \"Mosaicking 1 tiles \u2192 s3://public-rap/rap-pfg-cover-cog.tif\"\n\ncng-datasets raster \\\n  --input \"s3://public-rap/raw/vegetation-cover-v3-2025.tif\" \\\n  --output-cog \"s3://public-rap/rap-pfg-cover-cog.tif\" \\\n  --target-crs EPSG:4326 \\\n  --resampling bilinear \\\n  --band 4 \\\n  --nodata \"255\" \\\n  --hex-resampling mean\n\necho \"\u2713 Preprocess COG complete: s3://public-rap/rap-pfg-cover-cog.tif\"\n"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/rap/k8s/rap-pfg-cover/rap-pfg-cover-setup-bucket.yaml
+++ b/catalog/rap/k8s/rap-pfg-cover/rap-pfg-cover-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-pfg-cover-setup-bucket
+  labels:
+    k8s-app: rap-pfg-cover-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: rap-pfg-cover-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-rap
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/rap/k8s/rap-pfg-cover/workflow-rbac.yaml
+++ b/catalog/rap/k8s/rap-pfg-cover/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/rap/k8s/rap-pfg-stage.yaml
+++ b/catalog/rap/k8s/rap-pfg-stage.yaml
@@ -1,0 +1,42 @@
+# Stage RAP Vegetation Cover v3 2025 (CONUS, ~37.6 GB, EPSG:4326) raw to S3.
+# Band 4 (perennial forb & grass) is extracted later by the preprocess-cog step (--band 4).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-pfg-stage
+  namespace: biodiversity
+  labels: {k8s-app: rap-pfg-stage}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: rap-pfg-stage}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # NTSG serves over HTTPS only (port 80 is firewalled from the cluster).
+          NTSG=https://rangeland.ntsg.umt.edu/data/rap/rap-vegetation-cover/v3
+          curl -L --retry 5 --retry-delay 10 -o /tmp/vegetation-cover-v3-2025.tif "$NTSG/vegetation-cover-v3-2025.tif"
+          rclone mkdir nrp:public-rap
+          rclone copyto /tmp/vegetation-cover-v3-2025.tif nrp:public-rap/raw/vegetation-cover-v3-2025.tif -P
+        resources:
+          requests: {cpu: '4', memory: 4Gi, ephemeral-storage: 45Gi}
+          limits:   {cpu: '4', memory: 4Gi, ephemeral-storage: 45Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/rap/k8s/rap-s2-stage.yaml
+++ b/catalog/rap/k8s/rap-s2-stage.yaml
@@ -1,0 +1,51 @@
+# Stage NTSG rangeland-s2 arte (sagebrush) + iag (invasive annual grass) 2025-10 tiles to S3.
+# 117 UTM zone-10N (EPSG:32610) 10 m tiles per layer; mosaicked + reprojected to WGS84 by preprocess-cog.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rap-s2-stage
+  namespace: biodiversity
+  labels: {k8s-app: rap-s2-stage}
+spec:
+  completions: 2
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: rap-s2-stage}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          LAYERS=(arte iag); L=${LAYERS[$JOB_COMPLETION_INDEX]}
+          NTSG=https://rangeland.ntsg.umt.edu/data/rangeland-s2/$L
+          mkdir -p /tmp/$L && cd /tmp/$L
+          curl -sS --max-time 600 --retry 2 "$NTSG/" -o listing.html
+          grep -oE "${L}-2025-10-[0-9]+-[0-9]+\.tif" listing.html | sort -u > tiles.txt
+          echo "$(wc -l < tiles.txt) tiles"
+          cat tiles.txt | xargs -P 8 -I {} curl -sS --max-time 300 --retry 3 -O "$NTSG/{}"
+          rm -f listing.html tiles.txt
+          rclone mkdir nrp:public-rap
+          rclone copy /tmp/$L nrp:public-rap/raw/$L/ --transfers 16 -P
+        resources:
+          requests: {cpu: '4', memory: 8Gi, ephemeral-storage: 30Gi}
+          limits:   {cpu: '4', memory: 8Gi, ephemeral-storage: 30Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/sync/k8s/sync-public-rap.yaml
+++ b/catalog/sync/k8s/sync-public-rap.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-rap
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-rap"
+              echo "Syncing: nrp:public-rap -> minio:public-rap"
+              rclone sync $RCLONE_FLAGS "nrp:public-rap" "minio:public-rap"
+              echo "Done: public-rap"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config


### PR DESCRIPTION
Closes the NLCD + RAP items of #194. Rebuilds the legacy "wyoming group" rasters at the **full upstream extent** on the current `cng-datasets` exact_extract pipeline (one row/cell, correct reducer), and moves them out of `public-wyoming` into product-appropriate national buckets. Scope/decisions/provenance recorded in #194.

## Layers (all built + validated)
| Layer | bucket | extent | reducer | res | cells | validation |
|---|---|---|---|---|---|---|
| `nlcd-2024` | **public-land-cover** | CONUS | `mode` | 10 | 180.6M | rpc=1, mism=0, mode tracks COG histogram |
| `rap-pfg-cover` | **public-rap** | CONUS | `mean` | 10 | 384.9M | rpc=1, mism=0, 0–100, mean≈COG |
| `rap-arte` | public-rap | Pacific-west | `mean` | 10 | 40.0M | rpc=1, mism=0, mean 1.41≈1.42 |
| `rap-iag` | public-rap | Pacific-west | `mean` | 10 | 40.0M | rpc=1, mism=0, mean 4.19≈4.23 |

## Provenance (NTSG / Univ. Montana)
- `nlcd-2024`: Annual NLCD 2024 (MRLC), Albers→WGS84 (`-r near`, preserves class codes), band-extract via the pipeline.
- `rap-pfg-cover`: RAP Vegetation Cover v3 2025, **band 4** (perennial forb & grass), CONUS.
- `rap-arte`/`rap-iag`: rangeland-s2 Sentinel-2 sagebrush / invasive-annual-grass, 2025 month-10, 117 UTM-10N tiles each mosaicked→WGS84 (native Pacific-west extent).

## How
- `cng-datasets raster-workflow` `preprocess-cog` (multi-source mosaic + reproject; `--band 4` for pfg) → targeted res-10 hex over the CONUS-bounding h0 set on the Berkeley node (256Gi; res-10 needs ~150GB RAM/h0 — measured probe peaked 147.7GiB — from the tool's full 282M-cell-per-h0 materialization).
- Big scratch (37GB localize, 61GB mosaic intermediate) on the **`rechunk-scratch` PVC**, not ephemeral.
- STAC collections, root-catalog child links, and MinIO sync published to S3 (STAC/README are S3-canonical, not in-repo).

## Decisions recorded in #194
- Full CONUS upstream extent (not the WY clip); res 10; buckets public-land-cover / public-rap.
- Legacy `public-wyoming` `wyoming-nlcd`/`wyoming-rap-*` entries **kept** alongside the new CONUS layers.

## AGENTS.md
Two hard-won boundaries added: **scoping decisions live in the issue, not agent memory**; and **use a PVC (`rechunk-scratch`), don't fight the 50Gi ephemeral cap** for big scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)