### PR TITLE
sync: mirror NRP public-* buckets to source.coop

### DIFF
--- a/catalog/sync/k8s/source-sync-ca-dac.yaml
+++ b/catalog/sync/k8s/source-sync-ca-dac.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-ca-dac
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-ca-dac"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/ca-dac"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: ca-dac"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-ca-wolves.yaml
+++ b/catalog/sync/k8s/source-sync-ca-wolves.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-ca-wolves
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-ca-wolves"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/ca-wolves"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: ca-wolves"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-ca30x30.yaml
+++ b/catalog/sync/k8s/source-sync-ca30x30.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-ca30x30
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-ca30x30"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/ca30x30"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: ca30x30"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-calenviroscreen.yaml
+++ b/catalog/sync/k8s/source-sync-calenviroscreen.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-calenviroscreen
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-calenviroscreen"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/calenviroscreen"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: calenviroscreen"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-carbon.yaml
+++ b/catalog/sync/k8s/source-sync-carbon.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-carbon
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-carbon"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/carbon"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: carbon"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-census.yaml
+++ b/catalog/sync/k8s/source-sync-census.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-census
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-census"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/census"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: census"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-cgs.yaml
+++ b/catalog/sync/k8s/source-sync-cgs.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-cgs
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-cgs"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/cgs"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: cgs"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-cpad.yaml
+++ b/catalog/sync/k8s/source-sync-cpad.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-cpad
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-cpad"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/cpad"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: cpad"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-datacenters.yaml
+++ b/catalog/sync/k8s/source-sync-datacenters.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-datacenters
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-datacenters"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/datacenters"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: datacenters"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-ecoregion.yaml
+++ b/catalog/sync/k8s/source-sync-ecoregion.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-ecoregion
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-ecoregion"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/ecoregion"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: ecoregion"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-epa-water.yaml
+++ b/catalog/sync/k8s/source-sync-epa-water.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-epa-water
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-epa-water"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/epa-water"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: epa-water"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-fire.yaml
+++ b/catalog/sync/k8s/source-sync-fire.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-fire
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-fire"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/fire"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: fire"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-gbif.yaml
+++ b/catalog/sync/k8s/source-sync-gbif.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-gbif
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-gbif"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/gbif"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: gbif"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-gfw.yaml
+++ b/catalog/sync/k8s/source-sync-gfw.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-gfw
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-gfw"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/gfw"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: gfw"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-grids.yaml
+++ b/catalog/sync/k8s/source-sync-grids.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-grids
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-grids"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/grids"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: grids"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-high-seas.yaml
+++ b/catalog/sync/k8s/source-sync-high-seas.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-high-seas
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-high-seas"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/high-seas"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: high-seas"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-hydrobasins.yaml
+++ b/catalog/sync/k8s/source-sync-hydrobasins.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-hydrobasins
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-hydrobasins"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/hydrobasins"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: hydrobasins"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-icca.yaml
+++ b/catalog/sync/k8s/source-sync-icca.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-icca
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-icca"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/icca"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: icca"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-im3.yaml
+++ b/catalog/sync/k8s/source-sync-im3.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-im3
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-im3"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/im3"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: im3"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-inat.yaml
+++ b/catalog/sync/k8s/source-sync-inat.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-inat
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-inat"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/inat"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: inat"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-indigenous.yaml
+++ b/catalog/sync/k8s/source-sync-indigenous.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-indigenous
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-indigenous"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/indigenous"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: indigenous"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-iucn.yaml
+++ b/catalog/sync/k8s/source-sync-iucn.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-iucn
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-iucn"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/iucn"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: iucn"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-land-cover.yaml
+++ b/catalog/sync/k8s/source-sync-land-cover.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-land-cover
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-land-cover"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/land-cover"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: land-cover"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-landfire.yaml
+++ b/catalog/sync/k8s/source-sync-landfire.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-landfire
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-landfire"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/landfire"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: landfire"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-mappinginequality.yaml
+++ b/catalog/sync/k8s/source-sync-mappinginequality.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-mappinginequality
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-mappinginequality"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/mappinginequality"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: mappinginequality"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-mobi.yaml
+++ b/catalog/sync/k8s/source-sync-mobi.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-mobi
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-mobi"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/mobi"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: mobi"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-ncp.yaml
+++ b/catalog/sync/k8s/source-sync-ncp.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-ncp
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-ncp"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/ncp"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: ncp"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-overturemaps.yaml
+++ b/catalog/sync/k8s/source-sync-overturemaps.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-overturemaps
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-overturemaps"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/overturemaps"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: overturemaps"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-padus.yaml
+++ b/catalog/sync/k8s/source-sync-padus.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-padus
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-padus"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/padus"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: padus"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-population.yaml
+++ b/catalog/sync/k8s/source-sync-population.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-population
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-population"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/population"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: population"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-rap.yaml
+++ b/catalog/sync/k8s/source-sync-rap.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-rap
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-rap"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/rap"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: rap"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-rivers.yaml
+++ b/catalog/sync/k8s/source-sync-rivers.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-rivers
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-rivers"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/rivers"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: rivers"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-social-vulnerability.yaml
+++ b/catalog/sync/k8s/source-sync-social-vulnerability.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-social-vulnerability
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-social-vulnerability"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/social-vulnerability"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: social-vulnerability"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-tpl.yaml
+++ b/catalog/sync/k8s/source-sync-tpl.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-tpl
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-tpl"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/tpl"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: tpl"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-trails.yaml
+++ b/catalog/sync/k8s/source-sync-trails.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-trails
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-trails"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/trails"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: trails"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-usfws.yaml
+++ b/catalog/sync/k8s/source-sync-usfws.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-usfws
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-usfws"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/usfws"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: usfws"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-wdpa.yaml
+++ b/catalog/sync/k8s/source-sync-wdpa.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-wdpa
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-wdpa"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/wdpa"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: wdpa"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-wetlands.yaml
+++ b/catalog/sync/k8s/source-sync-wetlands.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-wetlands
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-wetlands"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/wetlands"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: wetlands"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-wlfw.yaml
+++ b/catalog/sync/k8s/source-sync-wlfw.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-wlfw
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-wlfw"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/wlfw"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: wlfw"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-working-lands.yaml
+++ b/catalog/sync/k8s/source-sync-working-lands.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-working-lands
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-working-lands"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/working-lands"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: working-lands"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/source-sync-wyoming.yaml
+++ b/catalog/sync/k8s/source-sync-wyoming.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-wyoming
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-wyoming"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/wyoming"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: wyoming"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/source-coop/README.md
+++ b/catalog/sync/source-coop/README.md
@@ -1,0 +1,81 @@
+# source.coop mirror
+
+Mirrors the canonical NRP `public-*` buckets to [Source Cooperative](https://source.coop)
+for discoverability, the same way `catalog/sync/k8s/sync-public-*.yaml` mirrors
+them to MinIO. NRP S3 stays canonical; source.coop is a downstream copy.
+
+## Layout
+
+source.coop data lives in a **shared, multi-tenant** AWS bucket per region. Our
+repos are sub-paths of one bucket:
+
+```
+us-west-2.opendata.source.coop/cboettig/<repo>/      <- one "product" (repo) per NRP bucket
+```
+
+Repo name == NRP bucket minus the `public-` prefix (1:1), e.g.
+`public-wdpa` → `cboettig/wdpa`. Two NRP buckets get a **new** repo while the
+older differently-versioned repo is left untouched:
+
+| NRP bucket | source.coop repo | legacy repo kept as-is |
+|---|---|---|
+| `public-padus` (PAD-US 4.1) | `cboettig/padus` | `cboettig/pad-us-3` |
+| `public-rivers` | `cboettig/rivers` | `cboettig/us-rivers` |
+
+**Excluded** (infra/internal): `public-test`, `public-output`, `public-requests`,
+`public-boettiger-lab`, and `public-data` (the root STAC catalog — its hrefs point
+at NRP URLs, so it would publish broken cross-links). `public-tnc` is empty.
+
+## ⚠️ Credentials are account-wide — handle with care
+
+The `source` rclone remote (in the k8s `rclone-config` secret) is a long-term AWS
+IAM key with access to the **entire** source.coop AWS account, i.e. every tenant's
+data in the shared bucket. The jobs therefore:
+
+- hard-code the full `source:us-west-2.opendata.source.coop/cboettig/<repo>` dest, and
+- include a guard that **refuses to run** unless the dest is a `cboettig/<repo>` sub-path,
+
+so a typo can never `rclone sync` (delete-extras) against the bucket root or another
+account. Always `dry-run-local.sh` a repo before its first real sync.
+
+## Step 1 — create the repos (manual, web UI)
+
+The programmatic create endpoint (`POST /api/v1/products/{account_id}`) is currently
+**`501 Not implemented`** in production (the documented `/repositories/` API is stale).
+So create each repo in the source.coop web UI first (`visibility: public`). The repo
+list with titles/descriptions is generated from each bucket's STAC collection — see
+the PR description / `gen-source-sync.sh` for the canonical set. A sync writes bytes
+to `cboettig/<repo>/`, but the data is only discoverable once the product exists.
+
+## Step 2 — generate / regenerate the jobs
+
+```bash
+./gen-source-sync.sh        # (re)writes ../k8s/source-sync-<repo>.yaml for all in-scope repos
+```
+
+Each job mirrors the MinIO recipe exactly — `--transfers 2 --checkers 4 --bwlimit 50M
+--tpslimit 5 --retries 5`, `priorityClassName: opportunistic`, 2 cpu / 4 Gi, one
+long-running pod per bucket — only the destination differs.
+
+## Step 3 — preview, then sync (sequentially)
+
+```bash
+./dry-run-local.sh wdpa            # preview adds/updates/DELETES (no writes, no cluster)
+./run-source-sync.sh wdpa          # apply one job, wait for completion
+./run-source-sync.sh               # all repos, smallest -> largest (gbif ~1.2 TB last)
+```
+
+**Run sequentially** (the runner does this). 41 jobs at `--bwlimit 50M` in parallel
+would be ~2 GiB/s of NRP egress — the opposite of gentle.
+
+Monitor: `kubectl -n biodiversity get jobs | grep source-sync` /
+`kubectl -n biodiversity logs job/source-sync-<repo>`.
+
+## Notes
+
+- **Mirror-with-delete:** `rclone sync` makes the dest an exact copy, deleting stale
+  source.coop files. For the ~8 repos that predate this mirror (`carbon`, `ca30x30`,
+  `cpad`, `fire`, `gbif`, `mappinginequality`, `mobi`, `social-vulnerability`) this
+  replaces their older structure with NRP-canonical content — dry-run first to see what
+  gets removed.
+- Total in scope ≈ 2.9 TB / ~45 k objects (gbif alone ≈ 1.2 TB).

--- a/catalog/sync/source-coop/dry-run-local.sh
+++ b/catalog/sync/source-coop/dry-run-local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Preview (no writes) what a source.coop mirror sync would change, run locally.
+# rclone --dry-run only lists metadata on both sides, so it's fast and safe and
+# does NOT need the cluster. Shows files that would be copied, updated, or
+# DELETED on source.coop (mirror-with-delete) before you run the real job.
+#
+# Usage:
+#   ./dry-run-local.sh                 # all in-scope repos
+#   ./dry-run-local.sh mobi wdpa       # only the named repos
+#
+# Requires an rclone config that defines the `nrp` and `source` remotes
+# (RCLONE_CONFIG env var, or ~/.config/rclone/rclone.conf). On the cluster the
+# `rclone-config` secret already has both.
+set -euo pipefail
+ACCOUNT="cboettig"
+DEST_BUCKET="us-west-2.opendata.source.coop"
+REPOS=(
+  ca-dac ca-wolves ca30x30 calenviroscreen carbon census cgs cpad datacenters
+  ecoregion epa-water fire gbif gfw grids high-seas hydrobasins icca im3 inat
+  indigenous iucn land-cover landfire mappinginequality mobi ncp overturemaps
+  padus population rap rivers social-vulnerability tpl trails usfws wdpa
+  wetlands wlfw working-lands wyoming
+)
+[ $# -gt 0 ] && REPOS=("$@")
+CFG_FLAG=""; [ -n "${RCLONE_CONFIG:-}" ] && CFG_FLAG="--config ${RCLONE_CONFIG}"
+
+for repo in "${REPOS[@]}"; do
+  echo "=== DRY RUN: nrp:public-${repo} -> source:${DEST_BUCKET}/${ACCOUNT}/${repo} ==="
+  rclone $CFG_FLAG sync --dry-run --tpslimit 5 -v \
+    "nrp:public-${repo}" "source:${DEST_BUCKET}/${ACCOUNT}/${repo}" 2>&1 \
+    | grep -iE 'Skipped|would|delete|copy|error' || echo "(no changes / both sides match)"
+done

--- a/catalog/sync/source-coop/gen-source-sync.sh
+++ b/catalog/sync/source-coop/gen-source-sync.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Generate per-repo k8s Jobs that mirror NRP public-<repo> buckets to
+# source.coop (us-west-2.opendata.source.coop/cboettig/<repo>).
+#
+# Mirrors the minio sync recipe in catalog/sync/k8s/sync-public-*.yaml exactly
+# (gentle egress: --bwlimit 50M --tpslimit 5, opportunistic priority, one
+# long-running pod per bucket). The ONLY differences are the destination
+# remote/path and a safety guard that refuses to run unless the destination is
+# the intended cboettig/<repo> sub-path (the source.coop creds have
+# account-wide access to a SHARED bucket, so a bucket-root sync could delete
+# other tenants' data).
+#
+# Repo name == NRP bucket minus the "public-" prefix (1:1). Run from anywhere;
+# writes YAMLs into the sibling k8s/ directory.
+set -euo pipefail
+OUTDIR="$(cd "$(dirname "$0")/../k8s" && pwd)"
+ACCOUNT="cboettig"
+DEST_BUCKET="us-west-2.opendata.source.coop"
+
+# In-scope repos (== NRP public-<repo>). Excludes infra buckets
+# (test/output/requests/boettiger-lab/data) and the empty public-tnc.
+REPOS=(
+  ca-dac ca-wolves ca30x30 calenviroscreen carbon census cgs cpad datacenters
+  ecoregion epa-water fire gbif gfw grids high-seas hydrobasins icca im3 inat
+  indigenous iucn land-cover landfire mappinginequality mobi ncp overturemaps
+  padus population rap rivers social-vulnerability tpl trails usfws wdpa
+  wetlands wlfw working-lands wyoming
+)
+
+for repo in "${REPOS[@]}"; do
+  src="nrp:public-${repo}"
+  dest="source:${DEST_BUCKET}/${ACCOUNT}/${repo}"
+  cat > "${OUTDIR}/source-sync-${repo}.yaml" <<YAML
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-${repo}
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="${src}"
+              DEST="${dest}"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "\$DEST" in
+                "source:${DEST_BUCKET}/${ACCOUNT}/"?*) : ;;
+                *) echo "REFUSING: dest '\$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "\${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="\$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: \$SRC -> \$DEST  (DRYRUN=\${DRYRUN:-false})"
+              rclone sync \$RCLONE_FLAGS "\$SRC" "\$DEST"
+              echo "Done: ${repo}"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config
+YAML
+  echo "wrote source-sync-${repo}.yaml"
+done
+
+echo "Generated ${#REPOS[@]} jobs into ${OUTDIR}"

--- a/catalog/sync/source-coop/run-source-sync.sh
+++ b/catalog/sync/source-coop/run-source-sync.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Run the source.coop mirror jobs SEQUENTIALLY (one bucket at a time) to keep
+# NRP egress gentle — 41 jobs at --bwlimit 50M in parallel would be ~2 GiB/s.
+# Ordered smallest -> largest so the long pole (gbif, ~1.2 TB) runs last/alone.
+#
+# Usage:
+#   ./run-source-sync.sh                # real sync, all repos, in order
+#   ./run-source-sync.sh mobi wdpa      # only the named repos
+#
+# To preview without writing, dry-run locally first: ./dry-run-local.sh [repos...]
+# (the job YAML also honors a DRYRUN=true env var if you prefer editing it).
+#
+# Prereq: the target source.coop product (repo) must already exist (created in
+# the web UI) — its prefix is cboettig/<repo>/. The API create endpoint is
+# currently 501/disabled.
+set -euo pipefail
+K8S="$(cd "$(dirname "$0")/../k8s" && pwd)"
+NS=biodiversity
+
+ORDER=(
+  im3 datacenters grids ca-wolves wlfw mobi mappinginequality icca cgs ncp
+  usfws calenviroscreen trails tpl working-lands cpad ca-dac gfw epa-water
+  ecoregion rivers fire landfire land-cover indigenous social-vulnerability
+  inat wyoming wdpa hydrobasins population census high-seas padus overturemaps
+  iucn rap wetlands ca30x30 carbon gbif
+)
+
+REPOS=("$@"); [ ${#REPOS[@]} -eq 0 ] && REPOS=("${ORDER[@]}")
+
+for repo in "${REPOS[@]}"; do
+  job="source-sync-${repo}"
+  yaml="${K8S}/${job}.yaml"
+  [ -f "$yaml" ] || { echo "SKIP: no $yaml" >&2; continue; }
+  echo "=== ${job} ==="
+  kubectl -n "$NS" delete job "$job" --ignore-not-found
+  kubectl -n "$NS" apply -f "$yaml"
+  kubectl -n "$NS" wait --for=condition=complete --timeout=86400s "job/${job}" \
+    || { echo "FAILED/timeout: ${job} — inspect: kubectl -n $NS logs job/${job}" >&2; exit 1; }
+  echo "--- completed ${job} ---"
+done
+echo "All requested source.coop syncs complete."


### PR DESCRIPTION
Mirrors the canonical NRP `public-*` buckets to [Source Cooperative](https://source.coop), the same way we already mirror to MinIO. NRP stays canonical; source.coop is a downstream copy for discoverability.

## What's here
- **`catalog/sync/source-coop/gen-source-sync.sh`** — generates one k8s Job per in-scope bucket into `catalog/sync/k8s/source-sync-<repo>.yaml` (41 jobs).
- **`run-source-sync.sh`** — runs them **sequentially**, smallest→largest (gbif ~1.2 TB last), so NRP egress stays gentle (41× `--bwlimit 50M` in parallel ≈ 2 GiB/s otherwise).
- **`dry-run-local.sh`** — previews adds/updates/**deletes** per repo with `rclone --dry-run` (metadata only, no writes, no cluster).
- **`README.md`** — layout, creds caveat, run order.

Each job mirrors the MinIO recipe exactly (`--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5`, `opportunistic` priority, 2 cpu / 4 Gi, one long-running pod per bucket); only the destination differs.

## Mapping
Repo name == bucket minus `public-` (1:1). New `padus`/`rivers` repos; legacy `pad-us-3`/`us-rivers` left untouched. **Excluded** (infra): `public-test`, `public-output`, `public-requests`, `public-boettiger-lab`, `public-data` (root STAC; NRP-pointing hrefs). `public-tnc` empty. Total ≈ **2.9 TB / ~45 k objects**.

## ⚠️ Safety
The `source` rclone remote (k8s `rclone-config` secret) has **account-wide** access to source.coop's **shared** multi-tenant bucket. Every job hard-codes the `cboettig/<repo>` dest and **refuses to run** against any other path (bucket root, other accounts). `sync` is mirror-with-delete — dry-run first.

## Operator prerequisite (manual)
The create-repo API (`POST /api/v1/products/{account_id}`) is currently **`501 Not implemented`** in production (the documented `/repositories/` API is stale). So the ~33 new repos must be **created in the source.coop web UI first** (`visibility: public`); titles/descriptions were drafted from each bucket's STAC collection. 8 repos already exist (`carbon, ca30x30, cpad, fire, gbif, mappinginequality, mobi, social-vulnerability`) and will be refreshed.