### PR TITLE
docs: README + AGENTS point to sync/backup/source.coop recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,17 @@ kubectl delete job sync-<bucket> -n biodiversity && kubectl apply -f .../sync-<b
 kubectl logs job/sync-<bucket>                        # monitor
 ```
 
+MinIO is the **private backup** of every `public-*` bucket — and the *only* off-NRP copy for datasets whose license forbids public redistribution.
+
+### Step 7b: source.coop public mirror
+
+Public datasets are *also* mirrored to **Source Cooperative** (`us-west-2.opendata.source.coop/cboettig/<repo>`) for discoverability. This is a **license-gated** campaign — **do not** add a bucket without reading the plan first:
+
+- **`catalog/sync/source-coop/README.md`** — campaign plan: scope policy (catalogued **and** license-clear only), the add-a-repo loop, the **account-wide-credentials safety guard**, and the phase-2 STAC href-rewrite.
+- **`gen-source-sync.sh`** (`REPOS` + `EXCLUDES`) is the scope source-of-truth; **`license-inventory.md`** has per-collection license verdicts; **`new-repos.md`** lists repos still to create (creation is manual in the web UI — the API is disabled).
+- Some datasets **must not** be mirrored — WDPA/WD-OECM/ICCA/IUCN/HydroBASINS forbid redistribution (MinIO-only). Every collection needs a correct STAC `license` (see the License requirement above) before it can be classified.
+- Status & decisions: **issue #158**.
+
 ## Memory and Chunking Mental Model
 
 **RAM is driven by the H3 cell count of the single largest feature in a chunk — not dataset size or bounding box.**

--- a/README.md
+++ b/README.md
@@ -84,29 +84,38 @@ Key commands:
 | `kubectl get jobs` | Monitors job status | Your laptop |
 | Everything else | Processing, S3 uploads, etc. | Kubernetes pods |
 
-## MinIO Backup Sync
+## Sync, Backup & Public Mirror
 
-All NRP S3 buckets are mirrored to a MinIO backup server. Per-bucket sync jobs live in `catalog/sync/k8s/`:
+NRP S3 is canonical. Two off-NRP destinations, both driven by per-bucket k8s Jobs under `catalog/sync/`:
+
+| Destination | Purpose | Scope | Jobs |
+|---|---|---|---|
+| **MinIO** (`minio.carlboettiger.info`) | **private backup** of every public bucket (and the only off-NRP copy for license-restricted data) | all `public-*` | `catalog/sync/k8s/sync-public-*.yaml` |
+| **Source Cooperative** (`source.coop`) | **public mirror** for discoverability | catalogued **and** license-clear datasets only | `catalog/sync/k8s/source-sync-*.yaml` |
 
 ```bash
-# Sync all buckets
-kubectl apply -f catalog/sync/k8s/
+# MinIO backup (private)
+kubectl apply -f catalog/sync/k8s/sync-public-census.yaml      # one bucket
+kubectl apply -f catalog/sync/k8s/                             # all
 
-# Sync a single bucket
-kubectl apply -f catalog/sync/k8s/sync-public-census.yaml
+# source.coop public mirror — see the campaign docs first (scope is license-gated)
+catalog/sync/source-coop/dry-run-local.sh census               # preview (no writes)
+catalog/sync/source-coop/run-source-sync.sh census             # one repo (sequential runner)
 
-# Monitor
-kubectl get jobs | grep sync
+kubectl get jobs | grep -E 'sync-public|source-sync'           # monitor
 ```
 
-Each job auto-creates the destination bucket on MinIO if needed, then runs `rclone sync` with bandwidth throttling. When adding a new NRP bucket, add a corresponding sync job (see [AGENTS.md](AGENTS.md) Step 7).
+Each job runs `rclone sync` with bandwidth throttling. When adding a new NRP bucket, add a MinIO sync job (see [AGENTS.md](AGENTS.md) Step 7).
+
+**source.coop mirror — read before touching it:** [`catalog/sync/source-coop/README.md`](catalog/sync/source-coop/README.md) is the campaign plan (scope policy, the add-a-repo loop, account-wide-credentials safety, phase-2 STAC). Scope is the `REPOS`/`EXCLUDES` arrays in `gen-source-sync.sh`; per-collection license verdicts are in `license-inventory.md`; repos still to create are in `new-repos.md`. Some datasets **cannot** be mirrored (license forbids redistribution — WDPA/IUCN/ICCA/HydroBASINS) and stay MinIO-only. Tracking + status: **issue #158**.
 
 ## Infrastructure
 
 - **Cluster:** NRP Nautilus, namespace `biodiversity`
 - **S3:** Ceph object storage (S3-compatible, not AWS)
 - **Public endpoint:** `https://s3-west.nrp-nautilus.io/<bucket>/<path>`
-- **MinIO backup:** `minio.carlboettiger.info` (synced via `catalog/sync/k8s/` jobs)
-- **Secrets:** `aws` and `rclone-config` are pre-configured in the namespace
+- **MinIO backup:** `minio.carlboettiger.info` (private backup; synced via `catalog/sync/k8s/sync-public-*.yaml`)
+- **Source Cooperative:** `us-west-2.opendata.source.coop/cboettig/<repo>` (public mirror, license-gated; see `catalog/sync/source-coop/`)
+- **Secrets:** `aws` and `rclone-config` are pre-configured in the namespace (`rclone-config` has `nrp`, `minio`, and `source` remotes)
 
 See [.github/copilot-instructions.md](.github/copilot-instructions.md) for detailed infrastructure context.


### PR DESCRIPTION
Make the sync/backup/source.coop entry points discoverable for users and agents (follow-up to #224; campaign #158).

- **Top-level `README.md`:** `MinIO Backup Sync` → **Sync, Backup & Public Mirror** — a table distinguishing the **MinIO private backup** (all `public-*`) from the **source.coop public mirror** (catalogued + license-clear only), with dry-run/run recipes and a prominent pointer to `catalog/sync/source-coop/` + #158. source.coop added to the Infrastructure list.
- **`AGENTS.md` Step 7:** notes MinIO is the only off-NRP copy for non-redistributable data, and adds **Step 7b (source.coop public mirror)** pointing agents to the campaign plan, the `gen-source-sync.sh` scope source-of-truth, `license-inventory.md`, and the license gate (WDPA/IUCN/ICCA/HydroBASINS must not be mirrored) before adding a bucket.

✅ Validated: the `census` test mirror completed end-to-end — 127/127 objects, 32.2 GiB on `cboettig/census`.