### PR TITLE
Add CDFW ACE v3.0 Terrestrial Biodiversity Summary (ds2739)

### DIFF
--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/BUILD-NOTES.md
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/BUILD-NOTES.md
@@ -1,0 +1,61 @@
+# Build notes — ACE v3.0 Terrestrial Biodiversity Summary (ds2739)
+
+Issue: boettiger-lab/data-workflows#228. Locked scope lives in that issue.
+
+Dataset: `ace/terrestrial-biodiversity-summary` → `s3://public-cdfw/ace/terrestrial-biodiversity-summary`
+(new bucket `public-cdfw`). Vector, **63,890** statewide ACE hexagons. H3 native res **8**, parent **0**.
+License **CC-BY-4.0** (confirmed from the ArcGIS Hub dataset record; see issue comment).
+
+## Run order (this is what actually built the dataset)
+
+```bash
+D=catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary
+kubectl apply -f $D/workflow-rbac.yaml                                            # once
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-setup-bucket.yaml        # create bucket
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-stage-raw.yaml           # curl zip -> s3 raw/
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-convert.yaml             # raw zip -> GeoParquet
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-clean-columns.yaml       # drop OBJECTID, OGC_FID
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-pmtiles.yaml             # PMTiles
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-hex.yaml                 # H3 hex (chunk-size 320)
+# wait for hex, then repartition merges chunks/ -> hex/
+kubectl apply -f $D/ace-terrestrial-biodiversity-summary-repartition.yaml
+```
+
+## Deviations from the vanilla `cng-datasets workflow` output
+
+1. **`stage-raw` step (added).** The locked source URL contains `&` query params; the
+   generated `convert` command emitted it **unquoted**, so bash split it into background
+   jobs. Per AGENTS Step 1b we stage the raw zip to `s3://public-cdfw/raw/ds2739.zip`
+   first, then `convert` localizes it from internal S3, unzips, and passes the `.shp`.
+   The orchestrator `configmap.yaml` convert step was patched to do the same — but the
+   orchestrator DAG does **not** include `stage-raw`, so run `stage-raw` before using the
+   orchestrator.
+
+2. **`clean-columns` step (added).** `cng-convert-to-parquet` keeps the source `OBJECTID`
+   (excluded by issue scope) plus a GDAL `OGC_FID`. This DuckDB job rewrites the parquet
+   dropping both, leaving the 43 documented columns + `_cng_fid` + `geom`.
+
+3. **Hex `--chunk-size` 50 → 320.** The generated default (50) × 200 completions covers
+   only 10,000 of 63,890 features. ACE hexagons are tiny uniform polygons (~9 res-8 cells
+   each), so memory is not a concern; 320 × 200 = 64,000 ≥ 63,890 and every chunk has data.
+   8Gi hex memory was ample (no OOMs).
+
+4. **`hex-chunk29` recovery job (added).** One hex pod (index 29) wedged in
+   `ContainerCreating` then `Terminating` on an unhealthy node (`prp-gpu-2`). The other 199
+   chunks had already written to `chunks/`. We deleted the job and reran only chunk 29 with
+   a node anti-affinity excluding the bad node, then repartitioned.
+
+## Validation (via duckdb-geo MCP)
+
+- GeoParquet: 63,890 features, 63,890 distinct `Hex_ID`, `geom GEOMETRY('OGC:CRS84')`,
+  Polygon/MultiPolygon, DuckDB-native (no geopandas creator). Columns: 43 + `_cng_fid` + `geom`.
+- Hex: 519,971 rows, all 63,890 `Hex_ID` present, `h8` (uint64) + `h0` (int64, 2 cells),
+  no geometry column. Native res 8, parent res 0.
+
+## STAC / docs (on NRP S3, not in this repo)
+
+- `s3://public-cdfw/stac-collection.json` — bucket collection `cdfw-datasets`
+- `s3://public-cdfw/ace/terrestrial-biodiversity-summary/stac-collection.json` — `ace-terrestrial-biodiversity-summary`
+- `s3://public-cdfw/README.md`
+- Registered as a child of the root catalog (`public-data/stac/catalog.json`).
+- MinIO mirror: `catalog/sync/k8s/sync-public-cdfw.yaml`.

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-clean-columns.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-clean-columns.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-clean-columns
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-clean-columns
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-clean-columns
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: clean-columns-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          # Drop OBJECTID (source artifact, excluded by issue scope) and OGC_FID
+          # (redundant GDAL FID added during convert). Keep _cng_fid + geom + the
+          # 43 documented source columns. DuckDB-native GeoParquet in -> out.
+          python3 - <<'PY'
+          import duckdb, os
+          con = duckdb.connect()
+          con.execute("INSTALL spatial; LOAD spatial;")
+          con.execute("INSTALL httpfs; LOAD httpfs;")
+          con.execute("SET s3_endpoint='rook-ceph-rgw-nautiluss3.rook';")
+          con.execute("SET s3_use_ssl=false;")
+          con.execute("SET s3_url_style='path';")
+          con.execute(f"SET s3_access_key_id='{os.environ['AWS_ACCESS_KEY_ID']}';")
+          con.execute(f"SET s3_secret_access_key='{os.environ['AWS_SECRET_ACCESS_KEY']}';")
+          src = 's3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet'
+          dst = 's3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet'
+          # Fully materialize input before writing back to the same key.
+          con.execute(f"""
+            CREATE TABLE t AS
+            SELECT * EXCLUDE (OBJECTID, OGC_FID) FROM read_parquet('{src}');
+          """)
+          n = con.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+          print("input rows (post-exclude):", n)
+          con.execute(f"COPY t TO '{dst}' (FORMAT PARQUET, ROW_GROUP_SIZE 100000);")
+          cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{dst}')").fetchall()]
+          print("output ncols:", len(cols))
+          print("output cols:", cols)
+          assert 'OBJECTID' not in cols and 'OGC_FID' not in cols, "artifact columns still present"
+          PY
+          echo "Column cleanup complete."
+        resources:
+          requests:
+            cpu: '2'
+            memory: 8Gi
+          limits:
+            cpu: '2'
+            memory: 8Gi

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-convert.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-convert.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-convert
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-convert
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          # Read the raw shapefile zip staged to internal S3 (avoids the slow/rate-limited
+          # external hub.arcgis.com download and the unquoted-& URL breaking bash).
+          echo "Localizing raw zip from nrp:public-cdfw/raw/ds2739.zip ..."
+          rclone copyto nrp:public-cdfw/raw/ds2739.zip /tmp/ds2739.zip -v
+          mkdir -p /tmp/ds2739
+          unzip -q -o /tmp/ds2739.zip -d /tmp/ds2739
+          SHP=$(find /tmp/ds2739 -name '*.shp' | head -1)
+          echo "Converting shapefile: $SHP"
+          cng-convert-to-parquet \
+            "$SHP" \
+            s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-hex-chunk29.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-hex-chunk29.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-hex-chunk29
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-hex-chunk29
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-hex-chunk29
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - prp-gpu-2.t2.ucsd.edu
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: ace-terrestrial-biodiversity-summary
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet --output s3://public-cdfw/ace/terrestrial-biodiversity-summary/chunks --chunk-id 29 --chunk-size 320 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-hex.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-hex.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-hex
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-hex
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: ace-terrestrial-biodiversity-summary
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet --output s3://public-cdfw/ace/terrestrial-biodiversity-summary/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 320 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-pmtiles.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-pmtiles.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-pmtiles
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-pmtiles
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: terrestrial-biodiversity-summary
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/ace/terrestrial-biodiversity-summary.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/ace/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-repartition.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-repartition.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-repartition
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-repartition
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-cdfw/ace/terrestrial-biodiversity-summary/chunks --output-dir s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex --source-parquet s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet --cleanup
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-setup-bucket.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-setup-bucket
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-setup-bucket
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-stage-raw.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/ace-terrestrial-biodiversity-summary-stage-raw.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-stage-raw
+  labels:
+    k8s-app: ace-terrestrial-biodiversity-summary-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-stage-raw
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: stage-raw-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          URL="https://hub.arcgis.com/api/v3/datasets/f3430956fbe847c4b0e315b83bcd8844_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+          echo "Downloading ACE ds2739 shapefile zip..."
+          curl -L --retry 5 -o /tmp/ds2739.zip "$URL"
+          ls -la /tmp/ds2739.zip
+          echo "Verifying zip integrity..."
+          unzip -t /tmp/ds2739.zip > /dev/null && echo "zip OK"
+          echo "Staging to nrp:public-cdfw/raw/..."
+          rclone copyto /tmp/ds2739.zip nrp:public-cdfw/raw/ds2739.zip -v
+          echo "Done staging raw."
+        resources:
+          requests:
+            cpu: '2'
+            memory: 4Gi
+          limits:
+            cpu: '2'
+            memory: 4Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/configmap.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/configmap.yaml
@@ -1,0 +1,423 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: ace-terrestrial-biodiversity-summary-setup-bucket.yaml, ace-terrestrial-biodiversity-summary-convert.yaml, ace-terrestrial-biodiversity-summary-pmtiles.yaml, ace-terrestrial-biodiversity-summary-hex.yaml, ace-terrestrial-biodiversity-summary-repartition.yaml
+# Generation command: cng-datasets workflow --dataset ace/terrestrial-biodiversity-summary --source-url https://hub.arcgis.com/api/v3/datasets/f3430956fbe847c4b0e315b83bcd8844_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 --bucket public-cdfw --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap ace-terrestrial-biodiversity-summary-yamls \
+#     --from-file=ace-terrestrial-biodiversity-summary-setup-bucket.yaml \
+#     --from-file=ace-terrestrial-biodiversity-summary-convert.yaml \
+#     --from-file=ace-terrestrial-biodiversity-summary-pmtiles.yaml \
+#     --from-file=ace-terrestrial-biodiversity-summary-hex.yaml \
+#     --from-file=ace-terrestrial-biodiversity-summary-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  ace-terrestrial-biodiversity-summary-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ace-terrestrial-biodiversity-summary-convert
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ace-terrestrial-biodiversity-summary-convert
+        spec:
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
+              # Read the raw shapefile zip staged to internal S3 (see stage-raw job).
+              # Avoids the slow/rate-limited external hub.arcgis.com download AND the
+              # unquoted-& source URL breaking bash. After convert, the clean-columns
+              # job drops OBJECTID/OGC_FID per issue #228 scope.
+              rclone copyto nrp:public-cdfw/raw/ds2739.zip /tmp/ds2739.zip -v
+              mkdir -p /tmp/ds2739
+              unzip -q -o /tmp/ds2739.zip -d /tmp/ds2739
+              SHP=$(find /tmp/ds2739 -name '*.shp' | head -1)
+              cng-convert-to-parquet \
+                "$SHP" \
+                s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+  ace-terrestrial-biodiversity-summary-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ace-terrestrial-biodiversity-summary-hex
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ace-terrestrial-biodiversity-summary-hex
+        spec:
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: ace-terrestrial-biodiversity-summary
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet --output s3://public-cdfw/ace/terrestrial-biodiversity-summary/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 320 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+  ace-terrestrial-biodiversity-summary-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ace-terrestrial-biodiversity-summary-pmtiles
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ace-terrestrial-biodiversity-summary-pmtiles
+        spec:
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: terrestrial-biodiversity-summary
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/ace/terrestrial-biodiversity-summary.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/ace/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+  ace-terrestrial-biodiversity-summary-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ace-terrestrial-biodiversity-summary-repartition
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ace-terrestrial-biodiversity-summary-repartition
+        spec:
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-cdfw/ace/terrestrial-biodiversity-summary/chunks --output-dir s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex --source-parquet s3://public-cdfw/ace/terrestrial-biodiversity-summary.parquet --cleanup
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+  ace-terrestrial-biodiversity-summary-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ace-terrestrial-biodiversity-summary-setup-bucket
+      labels:
+        k8s-app: ace-terrestrial-biodiversity-summary-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ace-terrestrial-biodiversity-summary-setup-bucket
+        spec:
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+kind: ConfigMap
+metadata:
+  name: ace-terrestrial-biodiversity-summary-yamls
+  namespace: biodiversity

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/workflow-rbac.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/workflow.yaml
+++ b/catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/workflow.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ace-terrestrial-biodiversity-summary-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting ace-terrestrial-biodiversity-summary workflow...\"\
+          \n\n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/ace-terrestrial-biodiversity-summary-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/ace-terrestrial-biodiversity-summary-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/ace-terrestrial-biodiversity-summary-convert.yaml\
+          \ -n biodiversity\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/ace-terrestrial-biodiversity-summary-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/ace-terrestrial-biodiversity-summary-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/ace-terrestrial-biodiversity-summary-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/ace-terrestrial-biodiversity-summary-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/ace-terrestrial-biodiversity-summary-repartition.yaml -n biodiversity\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/ace-terrestrial-biodiversity-summary-repartition -n\
+          \ biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs ace-terrestrial-biodiversity-summary-setup-bucket\
+          \ ace-terrestrial-biodiversity-summary-convert ace-terrestrial-biodiversity-summary-pmtiles\
+          \ ace-terrestrial-biodiversity-summary-hex ace-terrestrial-biodiversity-summary-repartition\
+          \ ace-terrestrial-biodiversity-summary-workflow -n biodiversity\"\necho\
+          \ \"  kubectl delete configmap ace-terrestrial-biodiversity-summary-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: ace-terrestrial-biodiversity-summary-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/sync/k8s/sync-public-cdfw.yaml
+++ b/catalog/sync/k8s/sync-public-cdfw.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-cdfw
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-cdfw"
+              echo "Syncing: nrp:public-cdfw -> minio:public-cdfw"
+              rclone sync $RCLONE_FLAGS "nrp:public-cdfw" "minio:public-cdfw"
+              echo "Done: public-cdfw"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config


### PR DESCRIPTION
Closes #228.

Imports the **CDFW Areas of Conservation Emphasis (ACE) v3.0 — Terrestrial Biodiversity Summary** (BIOS layer `ds2739`) as a cloud-native dataset in a new **`public-cdfw`** bucket.

## Deliverables (all live on NRP S3)
- **GeoParquet** — `public-cdfw/ace/terrestrial-biodiversity-summary.parquet` — 63,890 features, `OGC:CRS84`, DuckDB-native.
- **PMTiles** — `…/terrestrial-biodiversity-summary.pmtiles`, `source-layer: terrestrial-biodiversity-summary`.
- **H3 hex** — `…/terrestrial-biodiversity-summary/hex/h0=*/data_0.parquet`, native res **8**, parent res **0**.
- **STAC** — bucket collection `cdfw-datasets` + dataset collection `ace-terrestrial-biodiversity-summary` (`version: 3.0`, `license: CC-BY-4.0`, four nav links, asset-level `table:columns` for all 43 columns, hex `h3:native_resolution`/`h3:parent_resolutions` + per-feature dedup warnings). Registered in the root catalog.
- **README** at `public-cdfw/README.md` (MapLibre + DuckDB examples).
- **MinIO mirror** via `catalog/sync/k8s/sync-public-cdfw.yaml` (run and verified).

## License
Confirmed **CC-BY-4.0** from the ArcGIS Hub dataset record (the FeatureServer `licenseInfo` was empty; the Hub record carries it). Attribution: *ACE 3 Working Group / ACE 3 Development Team, CDFW*. Details in issue #228 comment.

## What's in this PR
Only the `catalog/` k8s YAMLs (STAC JSON/README intentionally live on S3, never in the repo). See `BUILD-NOTES.md` for the exact run order and the deviations from the vanilla `cng-datasets workflow` output:
- **`stage-raw`** — the locked source URL contains `&`; the generated `convert` emitted it unquoted (breaks bash). We stage the zip to `raw/` and convert from internal S3 (AGENTS Step 1b).
- **`clean-columns`** — drops `OBJECTID` (excluded by scope) + GDAL `OGC_FID`, leaving 43 documented columns + `_cng_fid` + `geom`.
- **hex `--chunk-size` 50 → 320** — the default would cover only 10k of 63,890 features.
- **`hex-chunk29`** — recovers one chunk wedged on an unhealthy node.

## Validation (duckdb-geo MCP)
- Parquet: 63,890 features / distinct `Hex_ID`, `geom GEOMETRY('OGC:CRS84')`, Polygon/MultiPolygon, no geopandas creator.
- Hex: 519,971 rows, all 63,890 `Hex_ID` present, `h8`+`h0` (2 h0 cells), no geometry column.

## Not included
The ca-30x30 app surfacing checklist from the issue is intentionally **not** done in this PR (per request).