### PR TITLE
Fix double-slash hex keys (hex//h0=) + drop trailing-slash outputs (#240)

### DIFF
--- a/catalog/audit/k8s/README.md
+++ b/catalog/audit/k8s/README.md
@@ -1,0 +1,23 @@
+# Audit / repair jobs
+
+One-off cluster jobs that audit or repair S3 layout issues across buckets.
+
+## `fix-double-slash-keys.yaml`
+
+Consolidates hex H3 partitions written with a **double-slash** key (`hex//h0=…`,
+or `h0=<cell>//data_N.parquet`) onto the canonical single-slash path, and purges
+stale intermediate prefixes. These bad keys come from a path-join that concatenated
+a base ending in `/` (e.g. a trailing-slash `--output-parquet …/hex/`) with a
+leading-`/` subpath; `rclone` **silently skips** `//` keys, so they are invisible to
+the normal `hex/h0=*/data_0.parquet` glob and to the MinIO/source.coop mirrors.
+
+Per `//` key (boto3, internal endpoint, server-side copy — no data egress):
+- **target absent** → copy `//`→`/` then delete `//` (surfaces hidden data)
+- **target present, byte-identical** → delete `//` orphan
+- **target present, in `VERIFIED_FLAGS`** → delete `//` (byte-different but proven
+  content-identical to its single-slash twin via whole-row `bit_xor(hash(row))`)
+- **target present, differs & unverified** → FLAG, never auto-deleted
+
+`DRYRUN=true` (default) classifies and reports without mutating. Set `DRYRUN=false`
+to execute. See data-workflows #240 for the full audit + the 2026-06 run results
+(carbon 792, gbif 234, overturemaps 196 keys).

--- a/catalog/audit/k8s/fix-double-slash-keys.yaml
+++ b/catalog/audit/k8s/fix-double-slash-keys.yaml
@@ -1,0 +1,136 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fix-double-slash-keys
+  namespace: biodiversity
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 172800
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+      - name: fix
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        # DRYRUN=true  -> classify + report only, NO mutation (default)
+        # DRYRUN=false -> execute the planned moves/deletes
+        - {name: DRYRUN, value: "true"}
+        resources:
+          requests: {cpu: '2', memory: 4Gi}
+          limits: {cpu: '2', memory: 4Gi}
+        command:
+        - python3
+        - -c
+        - |
+          import os, boto3
+          from botocore.config import Config
+          from botocore.exceptions import ClientError
+
+          EP = "http://rook-ceph-rgw-nautiluss3.rook"
+          DRYRUN = os.environ.get("DRYRUN", "true").lower() != "false"
+          s3 = boto3.client("s3", endpoint_url=EP, config=Config(s3={"addressing_style": "path"}))
+
+          # --- Phase A: consolidate hex // keys onto the canonical single-slash path ---
+          # Rule per // key:
+          #   target absent                  -> MOVE   (copy //->/, then delete //): surfaces hidden data
+          #   target present, same size+ETag -> DUPDEL (delete // orphan): byte-identical, safe cleanup
+          #   target present, in VERIFIED_FLAGS -> DUPDEL (delete //): byte-DIFFERENT but proven
+          #       content-identical to its single-slash twin via whole-row fingerprint
+          #       bit_xor(hash(row)) over the duckdb-geo MCP (all 21 returned identical=True).
+          #       These are re-serializations (same row multiset, diff parquet compression/order)
+          #       of dense cells that were manually reprocessed.
+          #   target present, differs, NOT verified -> FLAG (leave both): never auto-deleted
+          CONSOLIDATE = ["public-carbon", "public-gbif"]
+          VERIFIED_FLAGS = {
+            "v2/irrecoverable-carbon-2018/hex//h0=8021fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=8021fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=803dfffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=8041fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=8069fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=8081fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=808bfffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=8097fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2018/hex//h0=80bffffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=8015fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=8031fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=8041fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=8081fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=808bfffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=8097fffffffffff/data_0.parquet",
+            "v2/manageable-carbon-2024/hex//h0=80a7fffffffffff/data_0.parquet",
+            "v2/vulnerable-carbon-2010/hex//h0=8027fffffffffff/data_0.parquet",
+            "v2/vulnerable-carbon-2010/hex//h0=8031fffffffffff/data_0.parquet",
+            "v2/vulnerable-carbon-2010/hex//h0=803dfffffffffff/data_0.parquet",
+            "v2/vulnerable-carbon-2010/hex//h0=8097fffffffffff/data_0.parquet",
+            "v2/vulnerable-carbon-2018/hex//h0=8083fffffffffff/data_0.parquet",
+          }
+          # --- Phase B: purge an intermediate prefix outright (stale, not canonical) ---
+          PURGE = [("public-overturemaps", "chunks/")]
+
+          def list_keys(bucket, prefix=""):
+              out = []
+              for page in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix):
+                  for o in page.get("Contents", []):
+                      out.append((o["Key"], o["Size"], o["ETag"].strip('"')))
+              return out
+
+          def head(bucket, key):
+              try:
+                  h = s3.head_object(Bucket=bucket, Key=key)
+                  return h["ContentLength"], h["ETag"].strip('"')
+              except ClientError as e:
+                  if e.response["Error"]["Code"] in ("404", "NoSuchKey"): return None
+                  raise
+
+          print(f"=== fix-double-slash-keys  DRYRUN={DRYRUN} ===\n")
+          for bucket in CONSOLIDATE:
+              keys = [(k, sz, et) for (k, sz, et) in list_keys(bucket) if "//" in k]
+              moved = dupdel = flagged = 0
+              flags = []
+              print(f"## {bucket}: {len(keys)} double-slash keys")
+              for key, sz, et in keys:
+                  target = key.replace("//", "/")
+                  th = head(bucket, target)
+                  if th is None:
+                      print(f"  MOVE    {key}")
+                      if not DRYRUN:
+                          s3.copy_object(Bucket=bucket, Key=target,
+                                         CopySource={"Bucket": bucket, "Key": key})
+                          s3.delete_object(Bucket=bucket, Key=key)
+                      moved += 1
+                  elif th == (sz, et) or key in VERIFIED_FLAGS:
+                      why = "byte-identical" if th == (sz, et) else "verified-content-identical"
+                      print(f"  DUPDEL  {key}  ({why})")
+                      if not DRYRUN:
+                          s3.delete_object(Bucket=bucket, Key=key)
+                      dupdel += 1
+                  else:
+                      tsz, tet = th
+                      flags.append(f"  FLAG    {key}  (//: {sz}B {et}  vs  /: {tsz}B {tet})")
+                      flagged += 1
+              for f in flags: print(f)
+              print(f"  -> MOVE={moved}  DUPDEL={dupdel}  FLAG={flagged}\n")
+
+          for bucket, prefix in PURGE:
+              keys = list_keys(bucket, prefix)
+              print(f"## PURGE {bucket}/{prefix}: {len(keys)} keys")
+              batch = []
+              for key, _, _ in keys:
+                  batch.append({"Key": key})
+                  if len(batch) == 1000:
+                      if not DRYRUN: s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+                      batch = []
+              if batch and not DRYRUN:
+                  s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+              print(f"  -> {'DELETED' if not DRYRUN else 'would delete'} {len(keys)} keys under {prefix}\n")
+
+          print("=== done ===")

--- a/catalog/carbon/README.md
+++ b/catalog/carbon/README.md
@@ -60,7 +60,7 @@ pip install -e .
 # Uses public HTTPS access (no credentials needed)
 cng-datasets raster \
   --input https://s3-west.nrp-nautilus.io/public-carbon/cogs/irrecoverable_c_total_2018.tif \
-  --output-parquet s3://public-carbon/irrecoverable-carbon/hex/ \
+  --output-parquet s3://public-carbon/irrecoverable-carbon/hex \
   --resolution 8 \
   --parent-resolutions 0 \
   --h0-index 0 \

--- a/catalog/carbon/k8s/configmap.yaml
+++ b/catalog/carbon/k8s/configmap.yaml
@@ -67,7 +67,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/hex-job.yaml
+++ b/catalog/carbon/k8s/hex-job.yaml
@@ -62,7 +62,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/README.md
+++ b/catalog/carbon/k8s/v2/README.md
@@ -31,3 +31,17 @@ All fixes are in [`boettiger-lab/datasets`](https://github.com/boettiger-lab/dat
 | Hex output S3 keys had double-slash (`hex//h0=...`) | Fixed path join in raster output writer | upstream |
 
 The `move-hex-to-v2.yaml` job uses `aws s3api list-objects` (not rclone) to copy objects with double-slash keys, since rclone silently skips them.
+
+> **2026-06-17 follow-up — double-slash keys remediated (data-workflows #240).** The
+> "fixed upstream" writer fix landed *after* several carbon collections were first
+> built, and `move-hex-to-v2` **propagated** the old `hex//h0=` keys into `v2/`
+> rather than fixing them. An audit found **792** lingering `hex//h0=...` keys here
+> — including `v2/irrecoverable-carbon-{2022,2023,2024}` and non-v2
+> `irrecoverable-carbon`, which existed **only** at `//`, so the canonical
+> `hex/h0=*/data_0.parquet` glob returned **nothing** for them. Consolidated onto
+> single-slash by `catalog/audit/k8s/fix-double-slash-keys.yaml` (664 moved to the
+> canonical path; 128 byte/content-identical orphans deleted — the 21 byte-different
+> ones proven identical first via whole-row `bit_xor(hash(row))` over the MCP). The
+> trailing-slash `--output-parquet .../hex/` args (the trigger) were dropped to
+> `.../hex`. gbif (234 keys, dense manually-reprocessed cells) and overturemaps (196
+> intermediate `chunks/` keys, purged) were fixed in the same pass.

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2010/configmap.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2010/configmap.yaml
@@ -67,7 +67,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2010.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2010/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2010.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2010/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2010/irrecoverable-carbon-2010-hex.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2010/irrecoverable-carbon-2010-hex.yaml
@@ -62,7 +62,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2010.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2010/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2010.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2010/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2018/configmap.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2018/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2018/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2018/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2018/irrecoverable-carbon-2018-hex.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2018/irrecoverable-carbon-2018-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2018/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2018.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2018/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2022/configmap.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2022/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2022.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2022/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2022.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2022/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2022/irrecoverable-carbon-2022-hex.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2022/irrecoverable-carbon-2022-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2022.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2022/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2022.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2022/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2023/configmap.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2023/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2023.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2023/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2023.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2023/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2023/irrecoverable-carbon-2023-hex.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2023/irrecoverable-carbon-2023-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2023.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2023/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2023.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2023/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2024/configmap.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2024/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2024.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2024/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2024.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2024/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/irrecoverable-carbon-2024/irrecoverable-carbon-2024-hex.yaml
+++ b/catalog/carbon/k8s/v2/irrecoverable-carbon-2024/irrecoverable-carbon-2024-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2024.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2024/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/irrecoverable_c_total_2024.tif" --output-parquet s3://public-carbon/irrecoverable-carbon-2024/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/manageable-carbon-2010/configmap.yaml
+++ b/catalog/carbon/k8s/v2/manageable-carbon-2010/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2010.tif" --output-parquet s3://public-carbon/manageable-carbon-2010/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2010.tif" --output-parquet s3://public-carbon/manageable-carbon-2010/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/manageable-carbon-2010/manageable-carbon-2010-hex.yaml
+++ b/catalog/carbon/k8s/v2/manageable-carbon-2010/manageable-carbon-2010-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2010.tif" --output-parquet s3://public-carbon/manageable-carbon-2010/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2010.tif" --output-parquet s3://public-carbon/manageable-carbon-2010/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/manageable-carbon-2018/configmap.yaml
+++ b/catalog/carbon/k8s/v2/manageable-carbon-2018/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2018.tif" --output-parquet s3://public-carbon/manageable-carbon-2018/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2018.tif" --output-parquet s3://public-carbon/manageable-carbon-2018/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/manageable-carbon-2018/manageable-carbon-2018-hex.yaml
+++ b/catalog/carbon/k8s/v2/manageable-carbon-2018/manageable-carbon-2018-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2018.tif" --output-parquet s3://public-carbon/manageable-carbon-2018/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2018.tif" --output-parquet s3://public-carbon/manageable-carbon-2018/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/manageable-carbon-2024/configmap.yaml
+++ b/catalog/carbon/k8s/v2/manageable-carbon-2024/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2024.tif" --output-parquet s3://public-carbon/manageable-carbon-2024/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2024.tif" --output-parquet s3://public-carbon/manageable-carbon-2024/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/manageable-carbon-2024/manageable-carbon-2024-hex.yaml
+++ b/catalog/carbon/k8s/v2/manageable-carbon-2024/manageable-carbon-2024-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2024.tif" --output-parquet s3://public-carbon/manageable-carbon-2024/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/manageable_c_total_2024.tif" --output-parquet s3://public-carbon/manageable-carbon-2024/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/vulnerable-carbon-2010/configmap.yaml
+++ b/catalog/carbon/k8s/v2/vulnerable-carbon-2010/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2010.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2010/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2010.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2010/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/vulnerable-carbon-2010/vulnerable-carbon-2010-hex.yaml
+++ b/catalog/carbon/k8s/v2/vulnerable-carbon-2010/vulnerable-carbon-2010-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2010.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2010/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2010.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2010/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/vulnerable-carbon-2018/configmap.yaml
+++ b/catalog/carbon/k8s/v2/vulnerable-carbon-2018/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2018/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2018/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/vulnerable-carbon-2018/vulnerable-carbon-2018-hex.yaml
+++ b/catalog/carbon/k8s/v2/vulnerable-carbon-2018/vulnerable-carbon-2018-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2018/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2018/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/v2/vulnerable-carbon-2024/configmap.yaml
+++ b/catalog/carbon/k8s/v2/vulnerable-carbon-2024/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2024.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2024/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2024.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2024/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/v2/vulnerable-carbon-2024/vulnerable-carbon-2024-hex.yaml
+++ b/catalog/carbon/k8s/v2/vulnerable-carbon-2024/vulnerable-carbon-2024-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2024.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2024/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/v2/cogs/vulnerable_c_total_2024.tif" --output-parquet s3://public-carbon/vulnerable-carbon-2024/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/carbon/k8s/vulnerable-carbon-restore/configmap.yaml
+++ b/catalog/carbon/k8s/vulnerable-carbon-restore/configmap.yaml
@@ -72,7 +72,7 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets raster --input "s3://public-carbon/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+              cng-datasets raster --input "s3://public-carbon/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
             resources:
               requests:
                 cpu: '4'

--- a/catalog/carbon/k8s/vulnerable-carbon-restore/vulnerable-carbon-hex.yaml
+++ b/catalog/carbon/k8s/vulnerable-carbon-restore/vulnerable-carbon-hex.yaml
@@ -67,7 +67,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets raster --input "s3://public-carbon/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
+          cng-datasets raster --input "s3://public-carbon/cogs/vulnerable_c_total_2018.tif" --output-parquet s3://public-carbon/vulnerable-carbon/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column carbon
         resources:
           requests:
             cpu: '4'

--- a/catalog/gbif/k8s/gbif-2025-fill-missing.yaml
+++ b/catalog/gbif/k8s/gbif-2025-fill-missing.yaml
@@ -112,7 +112,9 @@ spec:
           """)
 
           src = f"s3://public-gbif/2025-06/chunks/h0={src_h0}/**"
-          dst = f"s3://public-gbif/2025-06/hex/h0={dst_h0}/"
+          # NO trailing slash: DuckDB COPY ... (FILE_SIZE_BYTES) writes <dst>/data_N.parquet,
+          # so a trailing slash here produced double-slash keys hex/h0=.../data_N (#240).
+          dst = f"s3://public-gbif/2025-06/hex/h0={dst_h0}"
 
           # Verify source exists
           result = subprocess.run(

--- a/catalog/high-seas/k8s/gebco/configmap.yaml
+++ b/catalog/high-seas/k8s/gebco/configmap.yaml
@@ -77,7 +77,7 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column elevation --hex-resampling mean
+              cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column elevation --hex-resampling mean
             resources:
               requests:
                 cpu: '4'

--- a/catalog/high-seas/k8s/gebco/gebco-2025-hex-rechunk.yaml
+++ b/catalog/high-seas/k8s/gebco/gebco-2025-hex-rechunk.yaml
@@ -68,7 +68,7 @@ spec:
           echo "Reprocessing h0 cell ${H0_INDEX} (job index ${JOB_COMPLETION_INDEX})"
 
           cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" \
-            --output-parquet s3://public-high-seas/gebco-2025/hex/ \
+            --output-parquet s3://public-high-seas/gebco-2025/hex \
             --h0-index ${H0_INDEX} \
             --resolution 8 \
             --parent-resolutions 5,6,7,0 \

--- a/catalog/high-seas/k8s/gebco/gebco-2025-hex.yaml
+++ b/catalog/high-seas/k8s/gebco/gebco-2025-hex.yaml
@@ -70,7 +70,7 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column elevation --hex-resampling mean
+          cng-datasets raster --input "s3://public-high-seas/gebco-2025-cog.tif" --output-parquet s3://public-high-seas/gebco-2025/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column elevation --hex-resampling mean
         resources:
           requests:
             cpu: '4'

--- a/catalog/high-seas/k8s/population/configmap.yaml
+++ b/catalog/high-seas/k8s/population/configmap.yaml
@@ -68,7 +68,7 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "s3://public-high-seas/raw/ghs-pop-2020-cog.tif" --output-parquet s3://public-high-seas/ghs-pop-2020/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column population
+              cng-datasets raster --input "s3://public-high-seas/raw/ghs-pop-2020-cog.tif" --output-parquet s3://public-high-seas/ghs-pop-2020/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column population
             resources:
               requests:
                 cpu: '4'

--- a/catalog/high-seas/k8s/population/ghs-pop-2020-hex.yaml
+++ b/catalog/high-seas/k8s/population/ghs-pop-2020-hex.yaml
@@ -63,7 +63,7 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "s3://public-high-seas/raw/ghs-pop-2020-cog.tif" --output-parquet s3://public-high-seas/ghs-pop-2020/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column population
+          cng-datasets raster --input "s3://public-high-seas/raw/ghs-pop-2020-cog.tif" --output-parquet s3://public-high-seas/ghs-pop-2020/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 5,6,7,0 --value-column population
         resources:
           requests:
             cpu: '4'

--- a/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex.yaml
@@ -70,7 +70,7 @@ spec:
             export PROJ_LIB="$PROJ_DATA"
           fi
 
-          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling mode
+          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling mode
         resources:
           requests:
             cpu: '4'

--- a/catalog/land-cover/k8s/cgls-lc100/configmap.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/configmap.yaml
@@ -77,7 +77,7 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling mode
+              cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling mode
             resources:
               requests:
                 cpu: '4'

--- a/catalog/mobi/k8s/species-richness-all/configmap.yaml
+++ b/catalog/mobi/k8s/species-richness-all/configmap.yaml
@@ -68,7 +68,7 @@ data:
                 export PROJ_LIB="$PROJ_DATA"
               fi
 
-              cng-datasets raster --input "https://minio.carlboettiger.info/public-biodiversity/mobi/species-richness-all/SpeciesRichness_All.tif" --output-parquet s3://public-mobi/mobi-species-richness-all/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column species_richness --nodata -128.0
+              cng-datasets raster --input "https://minio.carlboettiger.info/public-biodiversity/mobi/species-richness-all/SpeciesRichness_All.tif" --output-parquet s3://public-mobi/mobi-species-richness-all/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column species_richness --nodata -128.0
             resources:
               requests:
                 cpu: '4'

--- a/catalog/mobi/k8s/species-richness-all/mobi-species-richness-all-hex.yaml
+++ b/catalog/mobi/k8s/species-richness-all/mobi-species-richness-all-hex.yaml
@@ -73,7 +73,7 @@ spec:
           # exact-extract, one row per cell, `max` reducer: species richness is a
           # count, so each cell stores the peak (not the average) modeled richness
           # among the source pixels covering it. Hexed from the WGS84 COG on NRP S3.
-          cng-datasets raster --input "s3://public-mobi/mobi-species-richness-all-cog.tif" --output-parquet s3://public-mobi/mobi-species-richness-all/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column species_richness --hex-resampling max --nodata -128
+          cng-datasets raster --input "s3://public-mobi/mobi-species-richness-all-cog.tif" --output-parquet s3://public-mobi/mobi-species-richness-all/hex --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column species_richness --hex-resampling max --nodata -128
         resources:
           requests:
             cpu: '4'

--- a/catalog/overturemaps/job.py
+++ b/catalog/overturemaps/job.py
@@ -112,7 +112,7 @@ def main():
         .drop('h3id')
     )
 
-    output_file = f"{args.output_url}/chunk_{chunk_id:06d}.parquet"
+    output_file = f"{args.output_url.rstrip('/')}/chunk_{chunk_id:06d}.parquet"
     result.to_parquet(output_file)
 
     print(f"  ✓ Chunk {chunk_id} written")

--- a/catalog/wetlands/glwd/example_usage.py
+++ b/catalog/wetlands/glwd/example_usage.py
@@ -142,7 +142,7 @@ def example_cli_usage():
             "cmd": """cng-datasets raster \\
   --input wetlands.tif \\
   --output-cog s3://bucket/wetlands-cog.tif \\
-  --output-parquet s3://bucket/wetlands/hex/ \\
+  --output-parquet s3://bucket/wetlands/hex \\
   --parent-resolutions "8,0" \\
   --value-column wetland_class \\
   --nodata 255"""
@@ -151,7 +151,7 @@ def example_cli_usage():
             "name": "Process specific h0 region (for K8s jobs)",
             "cmd": """cng-datasets raster \\
   --input s3://bucket/data.tif \\
-  --output-parquet s3://bucket/data/hex/ \\
+  --output-parquet s3://bucket/data/hex \\
   --h0-index 42 \\
   --resolution 8"""
         },


### PR DESCRIPTION
Resolves the data-integrity issue documented in #240, found while mirroring carbon to source.coop (#158).

## Problem
A path-join (base ending in `/` + leading-`/` subpath) wrote H3 hex partitions with **double-slash** keys (`hex//h0=…`). `rclone` silently skips `//` keys, so the data was invisible to the canonical `hex/h0=*/data_0.parquet` glob, the geo-agent, and the MinIO/source.coop mirrors.

A full 48-bucket scan found only 3 affected: **carbon** (792 keys), **gbif** (234), **overturemaps** (196, intermediate `chunks/`). Worst case: `irrecoverable-carbon` v2 2022/23/24 + non-v2 existed **only** at `//` → the glob returned nothing.

## Fix
- **New** `catalog/audit/k8s/fix-double-slash-keys.yaml`: verify-before-delete boto3 job (server-side copy, internal endpoint, `DRYRUN` default true). Moves `//`→`/` where canonical is absent; deletes byte/content-identical orphans; FLAGs anything unverified. The 21 byte-different overlaps were proven content-identical first via whole-row `bit_xor(hash(row))` over the duckdb-geo MCP.
- **37 job templates**: dropped the trigger — trailing-slash `--output-parquet …/hex/` → `…/hex`.
- README notes in `catalog/audit/k8s/` + `catalog/carbon/k8s/v2/`.

## Run + validation (2026-06-17)
- carbon: 664 move + 128 delete · gbif: 234 move · overturemaps: 196 purged
- **0** `//` keys remain in all three buckets; every carbon collection complete at **122** partitions (irrecoverable v2 2022/23/24: 0→122; vulnerable-2024: 59→122); the standard glob now reads **2.13 B rows** for irrecoverable-carbon-2022 (was 0).

## Notes
The cng-datasets raster writer already normalizes trailing slashes in current builds (mobi/land-cover/high-seas use the same arg and are clean) — carbon's `//` are legacy. Follow-up in #240: upstream regression test + re-sync carbon/gbif to source.coop.