### PR TITLE
Add CBN plant-richness family (Kling et al. 2018) → COG + H3 hex (#229)

### DIFF
--- a/catalog/plant-richness/README.md
+++ b/catalog/plant-richness/README.md
@@ -1,0 +1,73 @@
+# CBN plant-richness family (Kling et al. 2018) — build notes
+
+Issue: [#229](https://github.com/boettiger-lab/data-workflows/issues/229). Two California
+Biodiversity Network rasters from Kling et al. (2018), *Phil. Trans. R. Soc. B*
+(https://royalsocietypublishing.org/doi/full/10.1098/rstb.2017.0397), processed to
+cloud-native COG + H3 hex on `public-ca30x30` (flat layout, per the 2026-06-17 scope lock):
+
+| `--dataset` | S3 prefix | value col | source raster |
+|---|---|---|---|
+| `plant-richness` | `public-ca30x30/plant-richness/` | `richness` | `species_D.tif` |
+| `rarity-weighted-endemic-plant-richness` | `public-ca30x30/rarity-weighted-endemic-plant-richness/` | `rwe` | `endemicspecies_E.tif` |
+
+Each dataset is built **3 ways** from one WGS84 reprojection of the EPSG:3310 source:
+
+1. full continuous COG + `hex-max/` (reducer `max` — peak richness per cell)
+2. (same COG) + `hex-mean/` (reducer `mean` — area-weighted mean per cell)
+3. 80th-percentile hotspot COG (pixels ≥ P80) + `p80-hex/` (reducer `max`)
+
+`max` is the correct reducer for richness/peak quantities (SUM double-counts species,
+MEAN averages away hotspots); `hex-mean` is kept to retain all data.
+
+## Generating the job YAMLs
+
+```bash
+bash gen-jobs.sh      # writes k8s/<dataset>/*.yaml for both datasets
+```
+
+`gen-jobs.sh` emits, per dataset: `<ds>-cog.yaml`, `<ds>-hex-max.yaml`,
+`<ds>-hex-mean.yaml`, `<ds>-p80-cog.yaml`, `<ds>-p80-hex.yaml`.
+Hex jobs read the **WGS84 COG** (so `MAX(hex)` validates exactly against the COG) and use
+`cng-datasets raster` with `--method exact-extract` (area-weighted, one row per cell).
+
+### Two source quirks handled in the build
+
+1. **CRS authority missing.** The source GeoTIFFs carry a valid CA-Albers WKT but no EPSG
+   authority code ("unnamed" PROJCS), which makes the tool's `AutoIdentifyEPSG()` crash
+   (`Unsupported SRS`). We re-tag them to EPSG:3310 (lossless metadata edit; the WKT
+   `IsSame(3310)`) and stage `raw/<src>_epsg3310.tif` as the build input.
+2. **Dual fill value after reproject.** The 3310→4326 warp emits a *second* near-nodata
+   value (~`-3.3999997e38`) next to the declared `-3.4e38`, which a single `--nodata`
+   cannot exclude (it leaked ~850k fill pixels into the first hex/percentile pass). The
+   `-cog` job therefore **normalizes** all fill (`< -1e30`) to one exact float32 sentinel
+   and re-flags nodata, so downstream hex (`--nodata -3.4e38`) and the P80 pass exclude
+   all fill cleanly.
+
+## Running (k8s, namespace `biodiversity`)
+
+One k8s hex workflow at a time (122 completions / 61 parallel ≈ 61 pods each; the
+namespace pod quota is 200). Single-pod COG / P80 jobs can overlap a hex job.
+
+```bash
+kubectl apply -n biodiversity -f k8s/plant-richness/workflow-rbac.yaml   # once
+for ds in plant-richness rarity-weighted-endemic-plant-richness; do
+  D=k8s/$ds
+  kubectl apply -n biodiversity -f $D/$ds-cog.yaml        # build + clean WGS84 COG
+  kubectl apply -n biodiversity -f $D/$ds-p80-cog.yaml    # compute P80, mask, write hotspot COG
+  kubectl apply -n biodiversity -f $D/$ds-hex-max.yaml    # wait for completion before the next hex job
+  kubectl apply -n biodiversity -f $D/$ds-hex-mean.yaml
+  kubectl apply -n biodiversity -f $D/$ds-p80-hex.yaml
+done
+```
+
+## Results (validated via duckdb-geo MCP)
+
+| dataset | full range | P80 | hex cells (max/mean) | p80-hex cells |
+|---|---|---|---|---|
+| plant-richness | 1.481–553.87 | **317.72** | 528,686 | 145,903 |
+| rarity-weighted-endemic-plant-richness | 0.0–0.10399 | **0.003853** | _see PR_ | _see PR_ |
+
+All hex layers: no fill cells, `MAX(hex)` == COG max, every cell ∈ [COG min, COG max]
+(p80-hex ∈ [P80, COG max]); res-0 rollup via `GROUP BY h0 + MAX`.
+
+STAC + README live on NRP (not in this repo): `s3://public-ca30x30/<dataset>/stac-collection.json`.

--- a/catalog/plant-richness/gen-jobs.sh
+++ b/catalog/plant-richness/gen-jobs.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Generate the cluster job YAMLs for the CBN plant-richness family (issue #229).
+#
+# Two Kling et al. (2018) CBN rasters, each processed 3 ways from ONE WGS84
+# reprojection of the EPSG:3310 source:
+#   1. full continuous COG  + hex-max  (reducer=max  — peak richness per cell)
+#   2. (same COG)           + hex-mean (reducer=mean — area-weighted mean per cell)
+#   3. 80th-percentile hotspot COG (pixels >= P80) + p80-hex (reducer=max)
+#
+# Per dataset the build order is: cog -> hex-max -> hex-mean -> p80-cog -> p80-hex.
+# Hex jobs read the WGS84 COG (so hex MAX validates exactly against the COG).
+# exact-extract (tool default) does area-weighted per-cell aggregation, one row per cell.
+set -euo pipefail
+cd "$(dirname "$0")/k8s"
+
+BUCKET=public-ca30x30
+IMAGE=ghcr.io/boettiger-lab/datasets:latest
+
+# dataset-segment | source-raster-filename | value-column
+# Source rasters carry a valid CA-Albers WKT but no EPSG authority code ("unnamed"
+# PROJCS), which makes the tool's AutoIdentifyEPSG() crash ("Unsupported SRS").
+# We re-tag them to EPSG:3310 (lossless metadata edit; the WKT IsSame(3310)) and
+# stage the normalized *_epsg3310.tif into raw/ — that is the build input below.
+DATASETS=(
+  "plant-richness|species_D_epsg3310.tif|richness"
+  "rarity-weighted-endemic-plant-richness|endemicspecies_E_epsg3310.tif|rwe"
+)
+
+# ---- shared pod fragments -------------------------------------------------
+ENV_BLOCK=$(cat <<'EOF'
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+EOF
+)
+
+VOL_AFFINITY=$(cat <<'EOF'
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+EOF
+)
+
+# ---- single-pod job (COG build / P80 build) -------------------------------
+# args: $1 job-name  $2 mem  $3 ephemeral  $4 command-string  -> stdout
+single_job() {
+  local name=$1 mem=$2 eph=$3 cmd=$4
+  cat <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${name}
+  labels: {k8s-app: ${name}}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: ${name}}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: task
+        image: ${IMAGE}
+        imagePullPolicy: Always
+${ENV_BLOCK}
+        command:
+        - bash
+        - -c
+        - |
+$(printf '%s\n' "$cmd" | sed 's/^/            /')
+        resources:
+          requests: {cpu: '4', memory: ${mem}, ephemeral-storage: ${eph}}
+          limits:   {cpu: '4', memory: ${mem}, ephemeral-storage: ${eph}}
+${VOL_AFFINITY}
+EOF
+}
+
+# ---- indexed hex job (122 h0 regions) -------------------------------------
+# args: $1 job-name  $2 command-string -> stdout
+hex_job() {
+  local name=$1 cmd=$2
+  cat <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${name}
+  labels: {k8s-app: ${name}}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: ${name}}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ${IMAGE}
+        imagePullPolicy: Always
+${ENV_BLOCK}
+        command:
+        - bash
+        - -c
+        - |
+$(printf '%s\n' "$cmd" | sed 's/^/            /')
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+${VOL_AFFINITY}
+EOF
+}
+
+for entry in "${DATASETS[@]}"; do
+  IFS='|' read -r DS SRC VAL <<<"$entry"
+  DIR="$DS"; mkdir -p "$DIR"
+  PFX="s3://${BUCKET}/${DS}"
+  RAW="${PFX}/raw/${SRC}"
+  COG="${PFX}/${DS}-cog.tif"
+  P80COG="${PFX}/${DS}-p80-cog.tif"
+
+  # 1. full continuous WGS84 COG (reproject) + fill normalization.
+  #    The 3310->4326 warp emits a SECOND near-nodata value (~-3.3999997e38)
+  #    alongside the declared -3.4e38, which a single --nodata cannot exclude
+  #    (leaks ~850k fill pixels into hex/percentile). Collapse every fill pixel
+  #    (< -1e30 or non-finite) to one exact float32 sentinel and re-flag nodata,
+  #    so downstream hex (--nodata -3.4e38) and the P80 pass exclude all fill.
+  single_job "${DS}-cog" 32Gi 20Gi \
+"set -e
+cng-datasets raster --input \"${RAW}\" --output-cog \"${COG}\" \\
+  --target-crs EPSG:4326 --value-column ${VAL} --nodata -3.4e38 --resampling near --compression deflate
+python3 - <<'PY'
+import subprocess, numpy as np
+from osgeo import gdal
+gdal.UseExceptions()
+ND = np.float32(-3.4e38)
+subprocess.run(['rclone','copyto','nrp:${BUCKET}/${DS}/${DS}-cog.tif','/tmp/full.tif'], check=True)
+ds = gdal.Open('/tmp/full.tif'); b = ds.GetRasterBand(1); arr = b.ReadAsArray()
+fill = ~np.isfinite(arr) | (arr < -1e30)
+arr = np.where(fill, ND, arr).astype('float32')
+drv = gdal.GetDriverByName('GTiff')
+t = drv.Create('/tmp/clean.tif', ds.RasterXSize, ds.RasterYSize, 1, gdal.GDT_Float32)
+t.SetGeoTransform(ds.GetGeoTransform()); t.SetProjection(ds.GetProjection())
+ob = t.GetRasterBand(1); ob.WriteArray(arr); ob.SetNoDataValue(float(ND)); t.FlushCache(); t = None
+gdal.Translate('/tmp/clean-cog.tif', '/tmp/clean.tif', format='COG',
+               creationOptions=['COMPRESS=DEFLATE','BLOCKSIZE=512'])
+v = arr[~fill]
+print('CLEANED valid=%d fill=%d min=%.5f max=%.5f' % (int((~fill).sum()), int(fill.sum()), float(v.min()), float(v.max())))
+PY
+rclone copyto /tmp/clean-cog.tif nrp:${BUCKET}/${DS}/${DS}-cog.tif
+echo 'clean COG uploaded'" \
+    > "${DIR}/${DS}-cog.yaml"
+
+  # 2. hex-max (peak richness per cell)
+  hex_job "${DS}-hex-max" \
+"set -e
+cng-datasets raster --input \"${COG}\" --output-parquet ${PFX}/hex-max/ \\
+  --h0-index \${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \\
+  --value-column ${VAL} --hex-resampling max --nodata -3.4e38" \
+    > "${DIR}/${DS}-hex-max.yaml"
+
+  # 3. hex-mean (area-weighted mean richness per cell)
+  hex_job "${DS}-hex-mean" \
+"set -e
+cng-datasets raster --input \"${COG}\" --output-parquet ${PFX}/hex-mean/ \\
+  --h0-index \${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \\
+  --value-column ${VAL} --hex-resampling mean --nodata -3.4e38" \
+    > "${DIR}/${DS}-hex-mean.yaml"
+
+  # 4. P80 hotspot COG: compute P80 over valid pixels of the full COG, keep >= P80
+  single_job "${DS}-p80-cog" 32Gi 20Gi \
+"set -e
+python3 - <<'PY'
+import subprocess, numpy as np
+from osgeo import gdal
+gdal.UseExceptions()
+subprocess.run(['rclone','copyto','nrp:${BUCKET}/${DS}/${DS}-cog.tif','/tmp/full-cog.tif'], check=True)
+ds = gdal.Open('/tmp/full-cog.tif'); b = ds.GetRasterBand(1)
+nd = b.GetNoDataValue(); arr = b.ReadAsArray()
+# robust fill mask (threshold, not exact-equality) — see cog clean step
+valid_mask = np.isfinite(arr) & (arr > -1e30)
+p80 = float(np.percentile(arr[valid_mask], 80))
+print('COMPUTED_P80=%r' % p80)
+keep = valid_mask & (arr >= p80)
+out = np.where(keep, arr, nd).astype('float32')
+drv = gdal.GetDriverByName('GTiff')
+tmp = drv.Create('/tmp/p80.tif', ds.RasterXSize, ds.RasterYSize, 1, gdal.GDT_Float32)
+tmp.SetGeoTransform(ds.GetGeoTransform()); tmp.SetProjection(ds.GetProjection())
+ob = tmp.GetRasterBand(1); ob.WriteArray(out); ob.SetNoDataValue(nd); tmp.FlushCache(); tmp = None
+gdal.Translate('/tmp/p80-cog.tif', '/tmp/p80.tif', format='COG',
+               creationOptions=['COMPRESS=DEFLATE','BLOCKSIZE=512'])
+open('/tmp/p80-value.txt','w').write('%s\n' % p80)
+print('RETAINED_PIXELS=%d  MIN_RETAINED=%.6f  MAX_RETAINED=%.6f' % (int(keep.sum()), float(arr[keep].min()), float(arr[keep].max())))
+PY
+rclone copyto /tmp/p80-cog.tif   nrp:${BUCKET}/${DS}/${DS}-p80-cog.tif
+rclone copyto /tmp/p80-value.txt nrp:${BUCKET}/${DS}/p80-value.txt
+echo 'P80 build done'" \
+    > "${DIR}/${DS}-p80-cog.yaml"
+
+  # 5. p80-hex (peak richness per cell, hotspot footprint only)
+  hex_job "${DS}-p80-hex" \
+"set -e
+cng-datasets raster --input \"${P80COG}\" --output-parquet ${PFX}/p80-hex/ \\
+  --h0-index \${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \\
+  --value-column ${VAL} --hex-resampling max --nodata -3.4e38" \
+    > "${DIR}/${DS}-p80-hex.yaml"
+
+  echo "generated ${DIR}/ ($(ls "${DIR}"/*.yaml | wc -l) job yamls)"
+done

--- a/catalog/plant-richness/k8s/plant-richness/plant-richness-cog.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/plant-richness-cog.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plant-richness-cog
+  labels: {k8s-app: plant-richness-cog}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: plant-richness-cog}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/plant-richness/raw/species_D_epsg3310.tif" --output-cog "s3://public-ca30x30/plant-richness/plant-richness-cog.tif" \
+              --target-crs EPSG:4326 --value-column richness --nodata -3.4e38 --resampling near --compression deflate
+            python3 - <<'PY'
+            import subprocess, numpy as np
+            from osgeo import gdal
+            gdal.UseExceptions()
+            ND = np.float32(-3.4e38)
+            subprocess.run(['rclone','copyto','nrp:public-ca30x30/plant-richness/plant-richness-cog.tif','/tmp/full.tif'], check=True)
+            ds = gdal.Open('/tmp/full.tif'); b = ds.GetRasterBand(1); arr = b.ReadAsArray()
+            fill = ~np.isfinite(arr) | (arr < -1e30)
+            arr = np.where(fill, ND, arr).astype('float32')
+            drv = gdal.GetDriverByName('GTiff')
+            t = drv.Create('/tmp/clean.tif', ds.RasterXSize, ds.RasterYSize, 1, gdal.GDT_Float32)
+            t.SetGeoTransform(ds.GetGeoTransform()); t.SetProjection(ds.GetProjection())
+            ob = t.GetRasterBand(1); ob.WriteArray(arr); ob.SetNoDataValue(float(ND)); t.FlushCache(); t = None
+            gdal.Translate('/tmp/clean-cog.tif', '/tmp/clean.tif', format='COG',
+                           creationOptions=['COMPRESS=DEFLATE','BLOCKSIZE=512'])
+            v = arr[~fill]
+            print('CLEANED valid=%d fill=%d min=%.5f max=%.5f' % (int((~fill).sum()), int(fill.sum()), float(v.min()), float(v.max())))
+            PY
+            rclone copyto /tmp/clean-cog.tif nrp:public-ca30x30/plant-richness/plant-richness-cog.tif
+            echo 'clean COG uploaded'
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/plant-richness/plant-richness-hex-max.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/plant-richness-hex-max.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plant-richness-hex-max
+  labels: {k8s-app: plant-richness-hex-max}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: plant-richness-hex-max}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/plant-richness/plant-richness-cog.tif" --output-parquet s3://public-ca30x30/plant-richness/hex-max/ \
+              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
+              --value-column richness --hex-resampling max --nodata -3.4e38
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/plant-richness/plant-richness-hex-mean.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/plant-richness-hex-mean.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plant-richness-hex-mean
+  labels: {k8s-app: plant-richness-hex-mean}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: plant-richness-hex-mean}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/plant-richness/plant-richness-cog.tif" --output-parquet s3://public-ca30x30/plant-richness/hex-mean/ \
+              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
+              --value-column richness --hex-resampling mean --nodata -3.4e38
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/plant-richness/plant-richness-p80-cog.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/plant-richness-p80-cog.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plant-richness-p80-cog
+  labels: {k8s-app: plant-richness-p80-cog}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: plant-richness-p80-cog}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            python3 - <<'PY'
+            import subprocess, numpy as np
+            from osgeo import gdal
+            gdal.UseExceptions()
+            subprocess.run(['rclone','copyto','nrp:public-ca30x30/plant-richness/plant-richness-cog.tif','/tmp/full-cog.tif'], check=True)
+            ds = gdal.Open('/tmp/full-cog.tif'); b = ds.GetRasterBand(1)
+            nd = b.GetNoDataValue(); arr = b.ReadAsArray()
+            # robust fill mask (threshold, not exact-equality) — see cog clean step
+            valid_mask = np.isfinite(arr) & (arr > -1e30)
+            p80 = float(np.percentile(arr[valid_mask], 80))
+            print('COMPUTED_P80=%r' % p80)
+            keep = valid_mask & (arr >= p80)
+            out = np.where(keep, arr, nd).astype('float32')
+            drv = gdal.GetDriverByName('GTiff')
+            tmp = drv.Create('/tmp/p80.tif', ds.RasterXSize, ds.RasterYSize, 1, gdal.GDT_Float32)
+            tmp.SetGeoTransform(ds.GetGeoTransform()); tmp.SetProjection(ds.GetProjection())
+            ob = tmp.GetRasterBand(1); ob.WriteArray(out); ob.SetNoDataValue(nd); tmp.FlushCache(); tmp = None
+            gdal.Translate('/tmp/p80-cog.tif', '/tmp/p80.tif', format='COG',
+                           creationOptions=['COMPRESS=DEFLATE','BLOCKSIZE=512'])
+            open('/tmp/p80-value.txt','w').write('%s\n' % p80)
+            print('RETAINED_PIXELS=%d  MIN_RETAINED=%.6f  MAX_RETAINED=%.6f' % (int(keep.sum()), float(arr[keep].min()), float(arr[keep].max())))
+            PY
+            rclone copyto /tmp/p80-cog.tif   nrp:public-ca30x30/plant-richness/plant-richness-p80-cog.tif
+            rclone copyto /tmp/p80-value.txt nrp:public-ca30x30/plant-richness/p80-value.txt
+            echo 'P80 build done'
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/plant-richness/plant-richness-p80-hex.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/plant-richness-p80-hex.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: plant-richness-p80-hex
+  labels: {k8s-app: plant-richness-p80-hex}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: plant-richness-p80-hex}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/plant-richness/plant-richness-p80-cog.tif" --output-parquet s3://public-ca30x30/plant-richness/p80-hex/ \
+              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
+              --value-column richness --hex-resampling max --nodata -3.4e38
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/plant-richness/workflow-rbac.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.yaml
+++ b/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rarity-weighted-endemic-plant-richness-cog
+  labels: {k8s-app: rarity-weighted-endemic-plant-richness-cog}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: rarity-weighted-endemic-plant-richness-cog}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/rarity-weighted-endemic-plant-richness/raw/endemicspecies_E_epsg3310.tif" --output-cog "s3://public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.tif" \
+              --target-crs EPSG:4326 --value-column rwe --nodata -3.4e38 --resampling near --compression deflate
+            python3 - <<'PY'
+            import subprocess, numpy as np
+            from osgeo import gdal
+            gdal.UseExceptions()
+            ND = np.float32(-3.4e38)
+            subprocess.run(['rclone','copyto','nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.tif','/tmp/full.tif'], check=True)
+            ds = gdal.Open('/tmp/full.tif'); b = ds.GetRasterBand(1); arr = b.ReadAsArray()
+            fill = ~np.isfinite(arr) | (arr < -1e30)
+            arr = np.where(fill, ND, arr).astype('float32')
+            drv = gdal.GetDriverByName('GTiff')
+            t = drv.Create('/tmp/clean.tif', ds.RasterXSize, ds.RasterYSize, 1, gdal.GDT_Float32)
+            t.SetGeoTransform(ds.GetGeoTransform()); t.SetProjection(ds.GetProjection())
+            ob = t.GetRasterBand(1); ob.WriteArray(arr); ob.SetNoDataValue(float(ND)); t.FlushCache(); t = None
+            gdal.Translate('/tmp/clean-cog.tif', '/tmp/clean.tif', format='COG',
+                           creationOptions=['COMPRESS=DEFLATE','BLOCKSIZE=512'])
+            v = arr[~fill]
+            print('CLEANED valid=%d fill=%d min=%.5f max=%.5f' % (int((~fill).sum()), int(fill.sum()), float(v.min()), float(v.max())))
+            PY
+            rclone copyto /tmp/clean-cog.tif nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.tif
+            echo 'clean COG uploaded'
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-hex-max.yaml
+++ b/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-hex-max.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rarity-weighted-endemic-plant-richness-hex-max
+  labels: {k8s-app: rarity-weighted-endemic-plant-richness-hex-max}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: rarity-weighted-endemic-plant-richness-hex-max}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.tif" --output-parquet s3://public-ca30x30/rarity-weighted-endemic-plant-richness/hex-max/ \
+              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
+              --value-column rwe --hex-resampling max --nodata -3.4e38
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-hex-mean.yaml
+++ b/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-hex-mean.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rarity-weighted-endemic-plant-richness-hex-mean
+  labels: {k8s-app: rarity-weighted-endemic-plant-richness-hex-mean}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: rarity-weighted-endemic-plant-richness-hex-mean}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.tif" --output-parquet s3://public-ca30x30/rarity-weighted-endemic-plant-richness/hex-mean/ \
+              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
+              --value-column rwe --hex-resampling mean --nodata -3.4e38
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-cog.yaml
+++ b/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-cog.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rarity-weighted-endemic-plant-richness-p80-cog
+  labels: {k8s-app: rarity-weighted-endemic-plant-richness-p80-cog}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: rarity-weighted-endemic-plant-richness-p80-cog}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            python3 - <<'PY'
+            import subprocess, numpy as np
+            from osgeo import gdal
+            gdal.UseExceptions()
+            subprocess.run(['rclone','copyto','nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-cog.tif','/tmp/full-cog.tif'], check=True)
+            ds = gdal.Open('/tmp/full-cog.tif'); b = ds.GetRasterBand(1)
+            nd = b.GetNoDataValue(); arr = b.ReadAsArray()
+            # robust fill mask (threshold, not exact-equality) — see cog clean step
+            valid_mask = np.isfinite(arr) & (arr > -1e30)
+            p80 = float(np.percentile(arr[valid_mask], 80))
+            print('COMPUTED_P80=%r' % p80)
+            keep = valid_mask & (arr >= p80)
+            out = np.where(keep, arr, nd).astype('float32')
+            drv = gdal.GetDriverByName('GTiff')
+            tmp = drv.Create('/tmp/p80.tif', ds.RasterXSize, ds.RasterYSize, 1, gdal.GDT_Float32)
+            tmp.SetGeoTransform(ds.GetGeoTransform()); tmp.SetProjection(ds.GetProjection())
+            ob = tmp.GetRasterBand(1); ob.WriteArray(out); ob.SetNoDataValue(nd); tmp.FlushCache(); tmp = None
+            gdal.Translate('/tmp/p80-cog.tif', '/tmp/p80.tif', format='COG',
+                           creationOptions=['COMPRESS=DEFLATE','BLOCKSIZE=512'])
+            open('/tmp/p80-value.txt','w').write('%s\n' % p80)
+            print('RETAINED_PIXELS=%d  MIN_RETAINED=%.6f  MAX_RETAINED=%.6f' % (int(keep.sum()), float(arr[keep].min()), float(arr[keep].max())))
+            PY
+            rclone copyto /tmp/p80-cog.tif   nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-cog.tif
+            rclone copyto /tmp/p80-value.txt nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/p80-value.txt
+            echo 'P80 build done'
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-hex.yaml
+++ b/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-hex.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rarity-weighted-endemic-plant-richness-p80-hex
+  labels: {k8s-app: rarity-weighted-endemic-plant-richness-p80-hex}
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - {type: DisruptionTarget}
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: rarity-weighted-endemic-plant-richness-p80-hex}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA, value: /usr/share/gdal}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        command:
+        - bash
+        - -c
+        - |
+            set -e
+            cng-datasets raster --input "s3://public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-cog.tif" --output-parquet s3://public-ca30x30/rarity-weighted-endemic-plant-richness/p80-hex/ \
+              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
+              --value-column rwe --hex-resampling max --nodata -3.4e38
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/sync/source-coop/license-inventory.md
+++ b/catalog/sync/source-coop/license-inventory.md
@@ -10,6 +10,11 @@ Full recursive STAC walk (130 nodes). Verdict per collection:
 ## public-ca-wolves
 - **OK (license) / HELD (data semantics)** · `CC0-1.0` — public-ca-wolves  · license is fully clear (CC0); NOT mirrored to source.coop because it is a real-time updated product (`wolf_*_latest.geojson` + `snapshots/`) — a static mirror would be a stale copy presented as current. Revisit publishing only the dated `snapshots/`.
 
+## public-ca30x30
+- **OK** · `other (free use w/ attribution)` — public-ca30x30/plant-richness  · Kling et al. (2018) Phil. Trans. R. Soc. B, [DOI 10.1098/rstb.2017.0397](https://doi.org/10.1098/rstb.2017.0397). Upstream terms: *"These data can be used freely, provided attribution is given to: Kling et al. (2018)…"* — **redistribution is permitted with attribution** (not a formal CC license, so STAC `license: other` + a `cite-as`/`sci:doi` citation, not an SPDX id). Mirror-eligible.
+- **OK** · `other (free use w/ attribution)` — public-ca30x30/rarity-weighted-endemic-plant-richness  · same Kling et al. (2018) source/terms as above. Mirror-eligible.
+- **N/A (partial)** — the rest of `public-ca30x30` is not yet catalogued (see `gen-source-sync.sh`); only the two plant-richness collections above are license-cleared. Do **not** add `ca30x30` to `REPOS` until the whole bucket is catalogued + cleared.
+
 ## public-calenviroscreen
 - **OK** · `CA OEHHA (other)` — public-calenviroscreen  · CA public data; NOTE it is a DRAFT release
 


### PR DESCRIPTION
Closes #229.

Imports the two California Biodiversity Network (CBN) rasters from **Kling et al. (2018)**, *Phil. Trans. R. Soc. B* — **plant species richness** and **rarity-weighted endemic plant richness** — as cloud-native COG + H3 hex on `public-ca30x30` (flat layout per the 2026-06-17 scope lock).

## What was built

Per dataset, **3 ways** from one WGS84 reprojection of the EPSG:3310 source:

| `--dataset` | value col | full range | **P80** |
|---|---|---|---|
| `plant-richness` (`species_D.tif`) | `richness` | 1.481–553.87 | **317.72** |
| `rarity-weighted-endemic-plant-richness` (`endemicspecies_E.tif`) | `rwe` | 0.0–0.10399 | **0.003853** |

Each → full continuous **COG** + **hex-max** (peak per cell), **hex-mean** (area-weighted mean), and an **80th-percentile hotspot COG** + **p80-hex** (max). `max` is correct for richness/peak quantities (SUM double-counts species, MEAN averages away hotspots); `hex-mean` retains all data. H3 native resolution **8**, parent `[0]`, `exact-extract` reducer (one row per cell).

## Acceptance criteria — all verified via the duckdb-geo MCP

- **COGs:** WGS84/CRS84, statewide CA (lon −124.5..−113.5, lat 32.4..42.1), non-empty, value range = source, single clean nodata.
- **hex-max / hex-mean:** 528,686 cells each, **no fill cells**, every cell ∈ [COG min, COG max]; `MAX(hex)` == COG max; res-0 rollup via `GROUP BY h0 + MAX`.
- **p80 COGs:** only pixels ≥ P80 retained (min retained ≈ P80); P80 recorded in STAC/README and `p80-value.txt`.
- **p80-hex:** plant-richness 145,903 cells (min 317.72); rwe 135,900 cells (min 0.003853); both within [P80, COG max].

## Two source quirks handled (documented in `gen-jobs.sh` + `catalog/plant-richness/README.md`)

1. **No EPSG authority on source.** The GeoTIFFs carry a valid CA-Albers WKT but an "unnamed" PROJCS (no EPSG code), which crashes the tool's `AutoIdentifyEPSG()`. Re-tagged to EPSG:3310 (lossless; WKT `IsSame(3310)`) and staged as `raw/<src>_epsg3310.tif`.
2. **Dual fill value after reproject.** The 3310→4326 warp emits a *second* near-nodata value (~`-3.3999997e38`) that a single `--nodata` can't exclude (it leaked ~850k fill pixels into the first hex/percentile pass). The `-cog` job now normalizes all fill to one exact sentinel + re-flags nodata, so hex (`--nodata -3.4e38`) and the P80 pass exclude all fill.

## Off-repo artifacts (per AGENTS.md, not committed)

- COGs + hex parquet + `stac-collection.json` + `README.md` published to `s3://public-ca30x30/<dataset>/`.
- Bucket-level `public-ca30x30/stac-collection.json` created; **`public-ca30x30` registered as a top-level child of the root catalog** (`public-data/stac/catalog.json`).
- Stale, unreferenced `CBN/Biodiversity_unique/{Plant_richness,Rarityweighted_endemic_plant_richness}/` artifacts **purged from NRP** (the MinIO source zips are retained as the archived source).

## Notes / not done here

- **MinIO sync (`sync-public-ca30x30.yaml`) already exists; intentionally not triggered** — the source zips still live on MinIO at the old prefix, and the mirror/delete sync would remove them. Safe to run on the next scheduled pass now that the build is on NRP.
- `ca-30x30` web-app wiring (separate repo) is deferred to a follow-up per the locked scope.
