### PR TITLE
Purge stale chunks/; repair truncated gbif hex cells (#240)

### DIFF
--- a/catalog/audit/k8s/README.md
+++ b/catalog/audit/k8s/README.md
@@ -21,3 +21,26 @@ Per `//` key (boto3, internal endpoint, server-side copy — no data egress):
 `DRYRUN=true` (default) classifies and reports without mutating. Set `DRYRUN=false`
 to execute. See data-workflows #240 for the full audit + the 2026-06 run results
 (carbon 792, gbif 234, overturemaps 196 keys).
+
+## `purge-stale-chunks.yaml`
+
+Deletes leftover intermediate `chunks/` prefixes (pre-repartition per-pod output).
+The cng-datasets repartition `--cleanup` step removes these via `rclone purge`, which
+**silently no-ops under S3 load** (300s timeout, non-fatal) — so large/busy datasets
+leak chunks while small ones don't. Found on `gbif` (174 GiB / 20.5k objs),
+`padus` (5 layers), `wetlands/ramsar` (#240).
+
+**Only purge after verifying the canonical `hex/` is complete** (`hex` row count ≥
+`chunks` per h0). boto3 list+delete, guarded to `chunks/` prefixes only, verify-empty
+after. `TARGETS` = space-separated `bucket/prefix/` list; `DRYRUN=true` default.
+
+## `../../gbif/k8s/gbif-2025-repair-hex.yaml`
+
+Before gbif chunks could be purged, the hex≥chunks check found 3 h0 cells
+(`8011`/`804b`/`8047`) where `hex/` was **truncated** — the original fill-missing
+write was preempted (opportunistic priority) and the retry skipped the partial files
+(`OVERWRITE_OR_IGNORE`), so `hex/` held far fewer rows than the complete `chunks/`.
+This job re-consolidates those cells from `chunks/`, **deleting the partition first on
+every attempt** (so a preemption can't leave a partial) and writing the corrected
+no-trailing-slash path; it asserts `hex == chunks` per cell. Only then were gbif
+chunks safe to purge.

--- a/catalog/audit/k8s/purge-stale-chunks.yaml
+++ b/catalog/audit/k8s/purge-stale-chunks.yaml
@@ -1,0 +1,67 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: purge-stale-chunks
+  namespace: biodiversity
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 172800
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+      - name: purge
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: DRYRUN, value: "true"}
+        # space-separated bucket/prefix targets to purge (each must end in /)
+        - {name: TARGETS, value: ""}
+        resources:
+          requests: {cpu: '2', memory: 4Gi}
+          limits: {cpu: '2', memory: 4Gi}
+        command:
+        - python3
+        - -c
+        - |
+          import os, boto3
+          from botocore.config import Config
+          EP = "http://rook-ceph-rgw-nautiluss3.rook"
+          DRYRUN = os.environ.get("DRYRUN", "true").lower() != "false"
+          TARGETS = os.environ.get("TARGETS", "").split()
+          s3 = boto3.client("s3", endpoint_url=EP, config=Config(s3={"addressing_style": "path"}))
+
+          # Purge stale intermediate `chunks/` prefixes (pre-repartition output that the
+          # cng-datasets repartition --cleanup step failed to remove via rclone purge,
+          # which silently no-ops under S3 load). Only run against verified-safe prefixes
+          # where the canonical hex/ is complete (hex row count >= chunks). See #240.
+          print(f"=== purge-stale-chunks  DRYRUN={DRYRUN} ===")
+          if not TARGETS:
+              print("No TARGETS set; nothing to do."); raise SystemExit(0)
+          for t in TARGETS:
+              bucket, _, prefix = t.partition("/")
+              if not prefix.endswith("/"):
+                  print(f"REFUSING {t}: prefix must end in / (guard against over-broad purge)"); raise SystemExit(1)
+              if "chunks/" not in prefix:
+                  print(f"REFUSING {t}: only chunks/ prefixes may be purged by this job"); raise SystemExit(1)
+              keys = []
+              for page in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix):
+                  keys += [o["Key"] for o in page.get("Contents", [])]
+              print(f"{t}: {len(keys)} keys")
+              if not DRYRUN:
+                  for i in range(0, len(keys), 1000):
+                      s3.delete_objects(Bucket=bucket, Delete={"Objects": [{"Key": k} for k in keys[i:i+1000]]})
+                  # verify empty
+                  remaining = sum(len(p.get("Contents", [])) for p in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix))
+                  print(f"  -> deleted; remaining under prefix: {remaining}")
+                  assert remaining == 0, f"PURGE INCOMPLETE for {t}: {remaining} keys remain"
+              else:
+                  print(f"  -> would delete {len(keys)} keys")
+          print("=== done ===")

--- a/catalog/gbif/k8s/gbif-2025-dedup-hex-8049.yaml
+++ b/catalog/gbif/k8s/gbif-2025-dedup-hex-8049.yaml
@@ -1,0 +1,108 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2025-dedup-hex-8049
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2025-dedup-hex-8049
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 172800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2025-dedup-hex-8049
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+      containers:
+      - name: dedup-hex
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '4', memory: 64Gi, ephemeral-storage: 40Gi}
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: TMPDIR, value: /tmp}
+        command:
+        - bash
+        - -c
+        - |-
+          set -euo pipefail
+          # Dedup gbif hex cell 8049 (h0=577762574070710271), the ONE cell the
+          # whole-cell dedup job (gbif-2025-dedup-hex.yaml) could not finish: a single
+          # DISTINCT ON (gbifid) over 106M wide rows (61 cols, ~4.6 GiB compressed ->
+          # tens of GiB uncompressed + sort overhead) spilled past the 50Gi ephemeral
+          # cap even at 120Gi RAM and got Evicted.
+          #
+          # Fix: hash-bucket on gbifid. Every duplicate of a gbifid hashes to the same
+          # bucket, so per-bucket DISTINCT ON (gbifid) is COMPLETE and lossless. 8 even
+          # buckets (~13.4M rows / ~0.58 GiB each) fit in RAM with no meaningful spill,
+          # regardless of the cell's badly-skewed h1 distribution. Verified pre-flight:
+          # sum of per-bucket distinct gbifid == global distinct == 106,010,719.
+          #
+          # All dups are byte-identical (proved: distinct-full-rows == distinct-gbifid).
+          # Write all buckets to staging -> assert staging rows == staging distinct
+          # gbifid == 106,010,719 -> swap into the live partition -> purge staging.
+          # delete-first on every attempt so a preemption can't leave partial output.
+          echo "=== dedup hex/h0=577762574070710271 (hash-bucketed) ==="
+          python3 - <<'PYEOF'
+          import duckdb, os, boto3
+          from botocore.config import Config
+          dst_h0="577762574070710271"
+          EXPECT=106010719            # distinct gbifid, verified pre-flight
+          NBUCKETS=8
+          key=os.environ["AWS_ACCESS_KEY_ID"]; secret=os.environ["AWS_SECRET_ACCESS_KEY"]; endpoint=os.environ["AWS_S3_ENDPOINT"]
+          B="public-gbif"; live=f"2025-06/hex/h0={dst_h0}"; stg=f"2025-06/hex-dedup-staging/h0={dst_h0}"
+          s3=boto3.client("s3", endpoint_url=f"http://{endpoint}", config=Config(s3={"addressing_style":"path"}))
+          def listing(pfx): return [o["Key"] for p in s3.get_paginator("list_objects_v2").paginate(Bucket=B,Prefix=pfx+"/") for o in p.get("Contents",[])]
+          def purge(pfx):
+              ks=listing(pfx)
+              for i in range(0,len(ks),1000): s3.delete_objects(Bucket=B, Delete={"Objects":[{"Key":k} for k in ks[i:i+1000]]})
+
+          con=duckdb.connect(); con.execute("SET memory_limit='52GB'; SET temp_directory='/tmp'; SET preserve_insertion_order=false;")
+          con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'us-east-1')")
+          live_src=f"s3://{B}/{live}/*.parquet"
+          n0=con.execute(f"SELECT COUNT(*) FROM read_parquet('{live_src}')").fetchone()[0]
+          d0=con.execute(f"SELECT COUNT(DISTINCT gbifid) FROM read_parquet('{live_src}')").fetchone()[0]
+          print(f"  live rows={n0} distinct_gbifid={d0} dups={n0-d0}", flush=True)
+          assert d0==EXPECT, f"distinct_gbifid {d0} != expected {EXPECT}"
+
+          # 1) per-bucket dedup -> staging. Each bucket is an independent, bounded sort.
+          purge(stg)
+          for b in range(NBUCKETS):
+              con.execute(f"""COPY (SELECT DISTINCT ON (gbifid) * FROM read_parquet('{live_src}')
+                  WHERE hash(gbifid) % {NBUCKETS} = {b})
+                  TO 's3://{B}/{stg}/bucket={b}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 1000000, FILE_SIZE_BYTES 268435456, OVERWRITE_OR_IGNORE true)""")
+              print(f"  bucket {b} written", flush=True)
+          ns=con.execute(f"SELECT COUNT(*) FROM read_parquet('s3://{B}/{stg}/**/*.parquet')").fetchone()[0]
+          ds=con.execute(f"SELECT COUNT(DISTINCT gbifid) FROM read_parquet('s3://{B}/{stg}/**/*.parquet')").fetchone()[0]
+          print(f"  staging rows={ns} distinct_gbifid={ds}", flush=True)
+          assert ns==ds==EXPECT, f"DEDUP MISMATCH: staging {ns}/{ds} vs expected {EXPECT}"
+
+          # 2) swap staging -> live (flatten bucket=*/ into the partition root), drop staging
+          purge(live)
+          for j,k in enumerate(listing(stg)):
+              newk=f"{live}/data_{j}.parquet"
+              s3.copy_object(Bucket=B, Key=newk, CopySource={"Bucket":B,"Key":k})
+          purge(stg)
+          nf=con.execute(f"SELECT COUNT(*) FROM read_parquet('{live_src}')").fetchone()[0]
+          df=con.execute(f"SELECT COUNT(DISTINCT gbifid) FROM read_parquet('{live_src}')").fetchone()[0]
+          print(f"  final live rows={nf} distinct_gbifid={df}", flush=True)
+          assert nf==df==EXPECT, f"POST-SWAP MISMATCH: {nf}/{df} != {EXPECT}"
+          print(f"  OK hex/h0={dst_h0}: {n0} -> {nf} (removed {n0-EXPECT} dup rows)", flush=True)
+          PYEOF
+          echo "=== done 577762574070710271 ==="

--- a/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
+++ b/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
@@ -29,8 +29,8 @@ spec:
         image: ghcr.io/boettiger-lab/datasets:latest
         imagePullPolicy: Always
         resources:
-          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
-          limits:   {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+          requests: {cpu: '4', memory: 120Gi, ephemeral-storage: 50Gi}
+          limits:   {cpu: '4', memory: 120Gi, ephemeral-storage: 50Gi}
         env:
         - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
         - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
@@ -54,7 +54,8 @@ spec:
           # the 50Gi ephemeral cap on cell 8049 (106M rows) and got Evicted. Write to
           # staging -> verify (rows == distinct gbifid) -> replace the live partition.
           # The 5 trivial-dup cells (<=99 dup rows, incl. a 245M-row cell with 7) are left as-is.
-          DST_LIST=(577762574070710271 579451423930974207 579803267651862527 579099580210085887 580119927000662015)
+          # 8049 (577762574070710271, 106M rows) LAST: the 4 smaller cells bank first
+          DST_LIST=(579451423930974207 579803267651862527 579099580210085887 580119927000662015 577762574070710271)
           DST="${DST_LIST[$JOB_COMPLETION_INDEX]}"
           echo "=== dedup hex/h0=${DST} ==="
           python3 - <<PYEOF
@@ -69,7 +70,7 @@ spec:
               ks=listing(pfx)
               for i in range(0,len(ks),1000): s3.delete_objects(Bucket=B, Delete={"Objects":[{"Key":k} for k in ks[i:i+1000]]})
 
-          con=duckdb.connect(); con.execute("SET memory_limit='50GB'; SET temp_directory='/tmp';")
+          con=duckdb.connect(); con.execute("SET memory_limit='100GB'; SET temp_directory='/tmp'; SET preserve_insertion_order=false;")
           con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'us-east-1')")
           live_src=f"s3://{B}/{live}/*.parquet"
           n0=con.execute(f"SELECT COUNT(*) FROM read_parquet('{live_src}')").fetchone()[0]

--- a/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
+++ b/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
@@ -1,0 +1,99 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2025-dedup-hex
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2025-dedup-hex
+spec:
+  completions: 5
+  parallelism: 1          # one cell at a time; each subPath gets the whole PVC for spill
+  completionMode: Indexed
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 172800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2025-dedup-hex
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+      containers:
+      - name: dedup-hex
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '4', memory: 64Gi, ephemeral-storage: 10Gi}
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: TMPDIR, value: /scratch}   # DuckDB spills the DISTINCT here (PVC, not the 50Gi ephemeral cap)
+        volumeMounts:
+        - {name: scratch, mountPath: /scratch, subPath: gbif-dedup}
+        command:
+        - bash
+        - -c
+        - |-
+          set -euo pipefail
+          # Lossless dedup of the 5 gbif hex cells that carry exact full-row duplicate
+          # occurrences (a sub-block was consolidated twice during the build, #240).
+          # Every dup is byte-identical (proved: distinct-full-rows == distinct-gbifid),
+          # so SELECT DISTINCT * recovers the true set. Write to staging -> verify
+          # (rows == distinct gbifid) -> replace the live partition. The 5 trivial-dup
+          # cells (<=99 dup rows, incl. a 245M-row cell with 7) are left as-is.
+          DST_LIST=(577762574070710271 579451423930974207 579803267651862527 579099580210085887 580119927000662015)
+          DST="${DST_LIST[$JOB_COMPLETION_INDEX]}"
+          echo "=== dedup hex/h0=${DST} ==="
+          python3 - <<PYEOF
+          import duckdb, os, boto3
+          from botocore.config import Config
+          dst_h0="${DST}"
+          key=os.environ["AWS_ACCESS_KEY_ID"]; secret=os.environ["AWS_SECRET_ACCESS_KEY"]; endpoint=os.environ["AWS_S3_ENDPOINT"]
+          B="public-gbif"; live=f"2025-06/hex/h0={dst_h0}"; stg=f"2025-06/hex-dedup-staging/h0={dst_h0}"
+          s3=boto3.client("s3", endpoint_url=f"http://{endpoint}", config=Config(s3={"addressing_style":"path"}))
+          def listing(pfx): return [o["Key"] for p in s3.get_paginator("list_objects_v2").paginate(Bucket=B,Prefix=pfx+"/") for o in p.get("Contents",[])]
+          def purge(pfx):
+              ks=listing(pfx)
+              for i in range(0,len(ks),1000): s3.delete_objects(Bucket=B, Delete={"Objects":[{"Key":k} for k in ks[i:i+1000]]})
+
+          con=duckdb.connect(); con.execute("SET memory_limit='56GB'; SET temp_directory='/scratch';")
+          con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'us-east-1')")
+          live_src=f"s3://{B}/{live}/*.parquet"
+          n0=con.execute(f"SELECT COUNT(*) FROM read_parquet('{live_src}')").fetchone()[0]
+          d0=con.execute(f"SELECT COUNT(DISTINCT gbifid) FROM read_parquet('{live_src}')").fetchone()[0]
+          print(f"  live rows={n0} distinct_gbifid={d0} dups={n0-d0}", flush=True)
+
+          # 1) write deduped to staging (clean staging first)
+          purge(stg)
+          con.execute(f"""COPY (SELECT DISTINCT * FROM read_parquet('{live_src}'))
+              TO 's3://{B}/{stg}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 1000000, FILE_SIZE_BYTES 268435456, OVERWRITE_OR_IGNORE true)""")
+          ns=con.execute(f"SELECT COUNT(*) FROM read_parquet('s3://{B}/{stg}/*.parquet')").fetchone()[0]
+          ds=con.execute(f"SELECT COUNT(DISTINCT gbifid) FROM read_parquet('s3://{B}/{stg}/*.parquet')").fetchone()[0]
+          print(f"  staging rows={ns} distinct_gbifid={ds}", flush=True)
+          assert ns==ds==d0, f"DEDUP MISMATCH: staging {ns}/{ds} vs live-distinct {d0}"
+
+          # 2) replace live partition with staging (server-side copy), then drop staging
+          purge(live)
+          for k in listing(stg):
+              newk=k.replace("hex-dedup-staging/","hex/")
+              s3.copy_object(Bucket=B, Key=newk, CopySource={"Bucket":B,"Key":k})
+          purge(stg)
+          nf=con.execute(f"SELECT COUNT(*) FROM read_parquet('{live_src}')").fetchone()[0]
+          print(f"  final live rows={nf}", flush=True)
+          assert nf==d0, f"POST-SWAP MISMATCH: {nf} != {d0}"
+          print(f"  OK hex/h0={dst_h0}: {n0} -> {nf} (removed {n0-d0} dup rows)", flush=True)
+          PYEOF
+          echo "=== done ${DST} ==="
+      volumes:
+      - name: scratch
+        persistentVolumeClaim: {claimName: rechunk-scratch}

--- a/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
+++ b/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
@@ -29,17 +29,18 @@ spec:
         image: ghcr.io/boettiger-lab/datasets:latest
         imagePullPolicy: Always
         resources:
-          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 10Gi}
-          limits:   {cpu: '4', memory: 64Gi, ephemeral-storage: 10Gi}
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+          limits:   {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
         env:
         - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
         - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
         - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
         - {name: AWS_HTTPS, value: 'false'}
         - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
-        - {name: TMPDIR, value: /scratch}   # DuckDB spills the DISTINCT here (PVC, not the 50Gi ephemeral cap)
-        volumeMounts:
-        - {name: scratch, mountPath: /scratch, subPath: gbif-dedup}
+        # Spill to ephemeral /tmp (50Gi ns max). The rechunk-scratch CephFS PVC was
+        # failing to attach (FailedAttachVolume, CSI attacher timeout); a high DuckDB
+        # memory_limit keeps the ~42GB cell-8049 DISTINCT mostly in RAM so spill fits.
+        - {name: TMPDIR, value: /tmp}
         command:
         - bash
         - -c
@@ -66,7 +67,7 @@ spec:
               ks=listing(pfx)
               for i in range(0,len(ks),1000): s3.delete_objects(Bucket=B, Delete={"Objects":[{"Key":k} for k in ks[i:i+1000]]})
 
-          con=duckdb.connect(); con.execute("SET memory_limit='56GB'; SET temp_directory='/scratch';")
+          con=duckdb.connect(); con.execute("SET memory_limit='50GB'; SET temp_directory='/tmp';")
           con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'us-east-1')")
           live_src=f"s3://{B}/{live}/*.parquet"
           n0=con.execute(f"SELECT COUNT(*) FROM read_parquet('{live_src}')").fetchone()[0]
@@ -94,6 +95,3 @@ spec:
           print(f"  OK hex/h0={dst_h0}: {n0} -> {nf} (removed {n0-d0} dup rows)", flush=True)
           PYEOF
           echo "=== done ${DST} ==="
-      volumes:
-      - name: scratch
-        persistentVolumeClaim: {claimName: rechunk-scratch}

--- a/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
+++ b/catalog/gbif/k8s/gbif-2025-dedup-hex.yaml
@@ -49,9 +49,11 @@ spec:
           # Lossless dedup of the 5 gbif hex cells that carry exact full-row duplicate
           # occurrences (a sub-block was consolidated twice during the build, #240).
           # Every dup is byte-identical (proved: distinct-full-rows == distinct-gbifid),
-          # so SELECT DISTINCT * recovers the true set. Write to staging -> verify
-          # (rows == distinct gbifid) -> replace the live partition. The 5 trivial-dup
-          # cells (<=99 dup rows, incl. a 245M-row cell with 7) are left as-is.
+          # so DISTINCT ON (gbifid) keeps one row per occurrence losslessly. We hash one
+          # short key column, NOT the full ~40-col row: full-row DISTINCT * spilled past
+          # the 50Gi ephemeral cap on cell 8049 (106M rows) and got Evicted. Write to
+          # staging -> verify (rows == distinct gbifid) -> replace the live partition.
+          # The 5 trivial-dup cells (<=99 dup rows, incl. a 245M-row cell with 7) are left as-is.
           DST_LIST=(577762574070710271 579451423930974207 579803267651862527 579099580210085887 580119927000662015)
           DST="${DST_LIST[$JOB_COMPLETION_INDEX]}"
           echo "=== dedup hex/h0=${DST} ==="
@@ -76,7 +78,7 @@ spec:
 
           # 1) write deduped to staging (clean staging first)
           purge(stg)
-          con.execute(f"""COPY (SELECT DISTINCT * FROM read_parquet('{live_src}'))
+          con.execute(f"""COPY (SELECT DISTINCT ON (gbifid) * FROM read_parquet('{live_src}'))
               TO 's3://{B}/{stg}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 1000000, FILE_SIZE_BYTES 268435456, OVERWRITE_OR_IGNORE true)""")
           ns=con.execute(f"SELECT COUNT(*) FROM read_parquet('s3://{B}/{stg}/*.parquet')").fetchone()[0]
           ds=con.execute(f"SELECT COUNT(DISTINCT gbifid) FROM read_parquet('s3://{B}/{stg}/*.parquet')").fetchone()[0]

--- a/catalog/gbif/k8s/gbif-2025-repair-hex.yaml
+++ b/catalog/gbif/k8s/gbif-2025-repair-hex.yaml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2025-repair-hex
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2025-repair-hex
+spec:
+  completions: 3
+  parallelism: 1          # sequential: one pod at a time (each needs up to 30Gi ephemeral; ns cap 50Gi)
+  completionMode: Indexed
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 172800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2025-repair-hex
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+      containers:
+      - name: repair-hex
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 30Gi}
+          limits:   {cpu: '4', memory: 64Gi, ephemeral-storage: 30Gi}
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: TMPDIR, value: /tmp}
+        command:
+        - bash
+        - -c
+        - |-
+          set -euo pipefail
+          # Repair the 3 h0 cells whose original fill-missing write was truncated by
+          # preemption + OVERWRITE_OR_IGNORE-skip-on-retry (#240): hex/ holds far fewer
+          # rows than the complete chunks/ source. Re-consolidate from chunks, DELETING
+          # the partition first on EVERY attempt so a preemption can't leave a partial.
+          SRC_LIST=(8011fffffffffff       804bfffffffffff       8047fffffffffff)
+          DST_LIST=(576777411652222975    577797758442799103    577727389698621439)
+          SRC="${SRC_LIST[$JOB_COMPLETION_INDEX]}"
+          DST="${DST_LIST[$JOB_COMPLETION_INDEX]}"
+          echo "=== repair chunks/h0=${SRC} -> hex/h0=${DST} ==="
+          python3 - <<PYEOF
+          import duckdb, os, boto3
+          from botocore.config import Config
+          src_h0="${SRC}"; dst_h0="${DST}"
+          key=os.environ["AWS_ACCESS_KEY_ID"]; secret=os.environ["AWS_SECRET_ACCESS_KEY"]
+          endpoint=os.environ["AWS_S3_ENDPOINT"]
+
+          # 1) delete-first (clean slate every attempt) via boto3
+          s3=boto3.client("s3", endpoint_url=f"http://{endpoint}", config=Config(s3={"addressing_style":"path"}))
+          pfx=f"2025-06/hex/h0={dst_h0}/"
+          old=[o["Key"] for p in s3.get_paginator("list_objects_v2").paginate(Bucket="public-gbif",Prefix=pfx) for o in p.get("Contents",[])]
+          print(f"  deleting {len(old)} existing (truncated) files under {pfx}", flush=True)
+          for i in range(0,len(old),1000):
+              s3.delete_objects(Bucket="public-gbif", Delete={"Objects":[{"Key":k} for k in old[i:i+1000]]})
+
+          # 2) re-consolidate from chunks, fixed (no-trailing-slash) path
+          con=duckdb.connect()
+          con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false, REGION 'us-east-1')")
+          src=f"s3://public-gbif/2025-06/chunks/h0={src_h0}/**"
+          dst=f"s3://public-gbif/2025-06/hex/h0={dst_h0}"
+          nchunks=con.execute(f"SELECT COUNT(*) FROM read_parquet('{src}', hive_partitioning=false)").fetchone()[0]
+          print(f"  chunks rows={nchunks}; writing {dst} ...", flush=True)
+          con.execute(f"""
+              COPY (SELECT * FROM read_parquet('{src}', hive_partitioning=false) ORDER BY h1,h2,h3,h4,h5)
+              TO '{dst}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 1000000, FILE_SIZE_BYTES 268435456, OVERWRITE_OR_IGNORE true)
+          """)
+          # 3) verify written == chunks
+          nhex=con.execute(f"SELECT COUNT(*) FROM read_parquet('{dst}/*.parquet')").fetchone()[0]
+          print(f"  hex rows now={nhex}", flush=True)
+          assert nhex==nchunks, f"REPAIR INCOMPLETE: hex {nhex} != chunks {nchunks}"
+          print(f"  OK: hex/h0={dst_h0} == chunks ({nhex} rows)", flush=True)
+          PYEOF
+          echo "=== done ${DST} ==="
+      volumes: []


### PR DESCRIPTION
Follow-up to #240, found while re-syncing gbif to source.coop: the mirror was crawling because gbif carried **174 GiB / 20.5k** stale intermediate `chunks/` objects.

## Root cause
cng-datasets repartition `--cleanup` removes `chunks/` via `rclone purge`, which **silently no-ops under S3 load** (300s timeout, failure non-fatal). Large/busy datasets leak chunks; small ones don't. Found on **gbif**, **padus** (5 layers), **wetlands/ramsar**.

## The catch (why this wasn't a blind delete)
A per-h0 `hex >= chunks` audit before purging caught that gbif `hex/` was **truncated** for 3 cells (`8011`/`804b`/`8047`): the original fill-missing write was preempted (opportunistic priority) and the retry skipped partial files (`OVERWRITE_OR_IGNORE`), leaving e.g. **614,400** rows where chunks had **23.0M**. chunks was the *only* complete copy — a blind purge would have lost ~33.7M GBIF occurrences.

## Changes
- **`catalog/gbif/k8s/gbif-2025-repair-hex.yaml`** — re-consolidate the 3 cells from chunks, **delete-first on every attempt** (preemption-safe) + corrected no-trailing-slash path, asserting `hex == chunks`. Repaired: 8011 614K→23.0M, 804b 11.1M→22.4M, 8047 1.08M→1.45M. **All 122 cells now hex ≥ chunks (0 deficient).**
- **`catalog/audit/k8s/purge-stale-chunks.yaml`** — guarded boto3 purge of verified-safe `chunks/` prefixes, verify-empty after.

## Run (2026-06-17)
- padus + wetlands chunks purged (~6.3 GiB / 1,132 objs, verified empty)
- gbif hex repaired + validated, then chunks purged: bucket **24.6k → 4.2k objects, 1.094 TiB → 947 GiB**
- carbon + gbif re-syncing to source.coop (separate, in progress)

## Follow-ups (noted in #240)
- Minor: gbif `hex/` has a +1.43M (0.05%) row *surplus* over chunks on a few cells (possible dup) — separate quality check.
- Upstream robustness: repartition `--cleanup` should verify-empty and fail loudly instead of silently continuing when `rclone purge` no-ops.