### PR TITLE
Add CAL FIRE FVEG CWHR habitat datasets (cwhr13 + cwhr) → public-ca30x30

### DIFF
--- a/catalog/cwhr/k8s/cwhr/cwhr-hex.yaml
+++ b/catalog/cwhr/k8s/cwhr/cwhr-hex.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cwhr-hex
+  namespace: biodiversity
+  labels: {k8s-app: cwhr-hex}
+spec:
+  completions: 2
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: cwhr-hex}}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,  valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,    value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,          value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,          value: /usr/share/gdal}
+        - {name: PYTHONPATH,         value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS,    value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(50 71)   # res-0 ordinals covering California
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== CWHR (60+ class) res-10 mode hex, h0-index $H0 ==="
+          cng-datasets raster \
+            --input "s3://public-ca30x30/cwhr-cog.tif" \
+            --output-parquet s3://public-ca30x30/cwhr/hex/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,7,6,5,0 \
+            --value-column whrnum --hex-resampling mode --resampling near --nodata "0"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/cwhr/k8s/cwhr13/cwhr13-hex.yaml
+++ b/catalog/cwhr/k8s/cwhr13/cwhr13-hex.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cwhr13-hex
+  namespace: biodiversity
+  labels: {k8s-app: cwhr13-hex}
+spec:
+  completions: 2
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: cwhr13-hex}}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,  valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,    value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,          value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,          value: /usr/share/gdal}
+        - {name: PYTHONPATH,         value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS,    value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(50 71)   # res-0 ordinals covering California
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== CWHR13 (13-class) res-10 mode hex, h0-index $H0 ==="
+          cng-datasets raster \
+            --input "s3://public-ca30x30/cwhr13-cog.tif" \
+            --output-parquet s3://public-ca30x30/cwhr13/hex/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,7,6,5,0 \
+            --value-column whr13num --hex-resampling mode --resampling near --nodata "0"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/cwhr/k8s/reclassify-fveg.yaml
+++ b/catalog/cwhr/k8s/reclassify-fveg.yaml
@@ -1,0 +1,104 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cwhr-reclassify-fveg
+  namespace: biodiversity
+  labels: {k8s-app: cwhr-reclassify-fveg}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: cwhr-reclassify-fveg}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: reclassify
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        command:
+        - bash
+        - -c
+        - |-
+          set -euo pipefail
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          [ -n "$PROJ_DB" ] && export PROJ_DATA="$(dirname $PROJ_DB)" PROJ_LIB="$(dirname $PROJ_DB)"
+
+          echo "=== 1. fetch + unzip raw FVEG GDB ==="
+          rclone copyto nrp:public-ca30x30/raw/fveg221gdb.zip /tmp/fveg221gdb.zip -P
+          cd /tmp && unzip -q -o fveg221gdb.zip
+          GDB=/tmp/fveg22_1.gdb
+          ls -d "$GDB"
+
+          echo "=== 2. reclassify Value -> WHR13NUM and Value -> WHRNUM (block-wise, nearest, uint8) ==="
+          python3 - <<'PY'
+          import numpy as np
+          from osgeo import gdal
+          gdal.UseExceptions()
+          src = gdal.OpenEx("/tmp/fveg22_1.gdb", gdal.OF_RASTER)
+          band = src.GetRasterBand(1)
+          rat = band.GetDefaultRAT()
+          cols = [rat.GetNameOfCol(i) for i in range(rat.GetColumnCount())]
+          ci = {c: cols.index(c) for c in cols}
+          n = rat.GetRowCount()
+          # LUTs sized to full uint16 range; unmapped values -> 0 (nodata/background)
+          lut13 = np.zeros(65536, dtype=np.uint8)
+          lutN  = np.zeros(65536, dtype=np.uint8)
+          for r in range(n):
+              v = rat.GetValueAsInt(r, ci['Value'])
+              lut13[v] = rat.GetValueAsInt(r, ci['WHR13NUM'])
+              lutN[v]  = rat.GetValueAsInt(r, ci['WHRNUM'])
+          print("RAT rows:", n, "max WHR13NUM:", int(lut13.max()), "max WHRNUM:", int(lutN.max()))
+
+          xs, ys = src.RasterXSize, src.RasterYSize
+          gt, proj = src.GetGeoTransform(), src.GetProjection()
+          drv = gdal.GetDriverByName("GTiff")
+          opts = ["COMPRESS=DEFLATE", "ZLEVEL=9", "TILED=YES", "BIGTIFF=YES",
+                  "BLOCKXSIZE=512", "BLOCKYSIZE=512", "NUM_THREADS=ALL_CPUS"]
+          outs = {"/tmp/cwhr13-3310.tif": lut13, "/tmp/cwhr-3310.tif": lutN}
+          handles = {}
+          for path, _ in outs.items():
+              ds = drv.Create(path, xs, ys, 1, gdal.GDT_Byte, options=opts)
+              ds.SetGeoTransform(gt); ds.SetProjection(proj)
+              ob = ds.GetRasterBand(1); ob.SetNoDataValue(0)
+              handles[path] = (ds, ob)
+          # block read; native block size
+          bxs, bys = band.GetBlockSize()
+          bxs = bxs or 512; bys = bys or 512
+          # use generous row strips to limit overhead
+          step_y = max(bys, 1024)
+          for y0 in range(0, ys, step_y):
+              ny = min(step_y, ys - y0)
+              arr = band.ReadAsArray(0, y0, xs, ny).astype(np.uint16, copy=False)
+              for path, lut in outs.items():
+                  handles[path][1].WriteArray(np.take(lut, arr), 0, y0)
+          for path, (ds, ob) in handles.items():
+              ob.FlushCache(); ds.FlushCache(); ds = None
+              print("wrote", path)
+          PY
+
+          echo "=== 3. reproject 3310 -> WGS84 (-r near) + COG (nearest overviews) ==="
+          for ds in cwhr13 cwhr; do
+            gdalwarp -t_srs EPSG:4326 -r near -of COG \
+              -srcnodata 0 -dstnodata 0 \
+              -co COMPRESS=DEFLATE -co BLOCKSIZE=512 -co OVERVIEW_RESAMPLING=NEAREST -co NUM_THREADS=ALL_CPUS \
+              /tmp/${ds}-3310.tif /tmp/${ds}-cog.tif
+            echo "--- ${ds}-cog.tif ---"; gdalinfo /tmp/${ds}-cog.tif | grep -iE "Size is|Pixel Size|NoData|Type=|COMPRESS|Min=|Max=" | head
+          done
+
+          echo "=== 4. publish WGS84 COGs ==="
+          rclone copyto /tmp/cwhr13-cog.tif nrp:public-ca30x30/cwhr13-cog.tif -P
+          rclone copyto /tmp/cwhr-cog.tif   nrp:public-ca30x30/cwhr-cog.tif   -P
+          echo "DONE"
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        resources:
+          requests: {cpu: '8', memory: 32Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 32Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}


### PR DESCRIPTION
Closes #230.

## Key finding: FVEG is a raster, not vector
The issue assumed FVEG was vector polygons ("millions of features"). Inspecting the actual GDB (`fveg22_1.gdb`) showed it is a **single-band UInt16 categorical raster** (39623×38094 @ 30 m, EPSG:3310) with a **Raster Attribute Table** (42,032 rows) mapping each pixel `Value` → classification columns. Scope was corrected and re-locked in #230 to the issue's stated **Alternative: two categorical COGs + `mode` hex**.

## What this delivers (both requested CBN layers)
| Dataset | Classification | Classes |
|---|---|---|
| `cwhr13` | `WHR13NUM` major habitat | 13 |
| `cwhr` | `WHRNUM` habitat type | 62 |

Each: WGS84 categorical **COG** + H3 **`mode`** hex (native res 10, parents 9,8,7,6,5,0).

## Pipeline (this PR = the k8s YAMLs)
- **`reclassify-fveg.yaml`** — reads GDB + RAT, remaps `Value→WHR13NUM` and `Value→WHRNUM` block-wise (uint8, nodata 0), reprojects **EPSG:3310→OGC:CRS84 with nearest-neighbour** (categorical-safe), writes `cwhr13-cog.tif` / `cwhr-cog.tif`.
- **`cwhr13/cwhr13-hex.yaml`, `cwhr/cwhr-hex.yaml`** — `cng-datasets raster --hex-resampling mode`, 256 Gi, h0 ordinals 50 & 71 (the two res-0 cells covering California).

The reducer is `mode` (correct for categorical); reproject/overviews are nearest (no class-code interpolation), following the NLCD-2024 categorical pattern.

## Validation (duckdb-geo MCP)
- Both hexes: one row per cell (`COUNT(*) == COUNT(DISTINCT h10)` = 25.94 M).
- Only valid class codes — cwhr13: all 13; cwhr: all 62, **0 invalid**.
- Distribution matches source pixel shares within ~1% (e.g. cwhr13 Desert Shrub 19.9% vs 21.0%; cwhr Desert Scrub 17.0% vs 17.6%).
- Exactly the 2 California h0 partitions; **0 dateline-seam rows**.

## Published to NRP (not in repo, per AGENTS.md)
- COGs: `s3://public-ca30x30/{cwhr13,cwhr}-cog.tif`
- Hex: `s3://public-ca30x30/{cwhr13,cwhr}/hex/h0=*/data_0.parquet`
- STAC collections with `classification:classes` (all codes/names/colors) + READMEs, registered as children of the `ca30x30` parent collection.
- **License:** `other` (CAL FIRE FRAP — free use with attribution + liability disclaimer; verified from the GDB's embedded ESRI metadata, no SPDX/CC license invoked).

## Follow-up (separate repo, gated on this)
Surfacing in the `boettiger-lab/ca-30x30` app (`layers-input.json` entries for `cwhr13`/`cwhr`) — per #230's downstream section; out of scope here (different repo).