### PR TITLE
Add public-connectivity bucket: CBN connectivity datasets (#234)

### DIFF
--- a/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex-71.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex-71.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-hex-71
+  labels:
+    k8s-app: climate-migration-routes-hex
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: climate-migration-routes-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/climate-migration-routes-cog.tif" --output-parquet s3://public-connectivity/climate-migration-routes/hex/ --h0-index 71 --resolution 9 --parent-resolutions 0 --value-column connectivity_class --hex-resampling mode --nodata "65535"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-hex
+  labels:
+    k8s-app: climate-migration-routes-hex
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: climate-migration-routes-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/climate-migration-routes-cog.tif" --output-parquet s3://public-connectivity/climate-migration-routes/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column connectivity_class --hex-resampling mode --nodata "65535"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-preprocess-cog.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-preprocess-cog.yaml
@@ -1,0 +1,82 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-preprocess-cog
+  labels:
+    k8s-app: climate-migration-routes-preprocess-cog
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: climate-migration-routes-preprocess-cog
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      containers:
+      - name: preprocess-cog
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_CACHEMAX
+          value: '4096'
+        - name: GDAL_HTTP_TIMEOUT
+          value: '60'
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - "set -e\n\necho \"Mosaicking 1 tiles \u2192 s3://public-connectivity/climate-migration-routes-cog.tif\"\
+          \n\ncng-datasets raster \\\n  --input \"https://s3-west.nrp-nautilus.io/public-connectivity/raw/climateConnectivityOmniscapeCalifornia.tif\"\
+          \ \\\n  --output-cog \"s3://public-connectivity/climate-migration-routes-cog.tif\"\
+          \ \\\n  --target-crs EPSG:4326 \\\n  --resampling near \\\n  --nodata\
+          \ \"65535\" \\\n  --hex-resampling mode\n\necho \"\u2713 Preprocess COG\
+          \ complete: s3://public-connectivity/climate-migration-routes-cog.tif\"\n"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-setup-bucket.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-setup-bucket
+  labels:
+    k8s-app: climate-migration-routes-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: climate-migration-routes-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/climate-migration-routes/configmap.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/configmap.yaml
@@ -1,0 +1,258 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset climate-migration-routes --source-url "https://s3-west.nrp-nautilus.io/public-connectivity/raw/climateConnectivityOmniscapeCalifornia.tif" --bucket public-connectivity --h3-resolution 9 --parent-resolutions "0"
+apiVersion: v1
+data:
+  climate-migration-routes-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: climate-migration-routes-hex
+      labels:
+        k8s-app: climate-migration-routes-hex
+    spec:
+      completions: 122
+      parallelism: 61
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: climate-migration-routes-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-connectivity/climate-migration-routes-cog.tif" --output-parquet s3://public-connectivity/climate-migration-routes/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column connectivity_class --hex-resampling mode --nodata "65535"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  climate-migration-routes-preprocess-cog.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: climate-migration-routes-preprocess-cog
+      labels:
+        k8s-app: climate-migration-routes-preprocess-cog
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            k8s-app: climate-migration-routes-preprocess-cog
+        spec:
+          restartPolicy: Never
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          containers:
+          - name: preprocess-cog
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_CACHEMAX
+              value: '4096'
+            - name: GDAL_HTTP_TIMEOUT
+              value: '60'
+            - name: GDAL_HTTP_MAX_RETRY
+              value: '5'
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - "set -e\n\necho \"Mosaicking 1 tiles \u2192 s3://public-connectivity/climate-migration-routes-cog.tif\"\
+              \n\ncng-datasets raster \\\n  --input \"https://s3-west.nrp-nautilus.io/public-connectivity/raw/climateConnectivityOmniscapeCalifornia.tif\"\
+              \ \\\n  --output-cog \"s3://public-connectivity/climate-migration-routes-cog.tif\"\
+              \ \\\n  --target-crs EPSG:4326 \\\n  --resampling near \\\n  --nodata\
+              \ \"65535\" \\\n  --hex-resampling mode\n\necho \"\u2713 Preprocess COG\
+              \ complete: s3://public-connectivity/climate-migration-routes-cog.tif\"\n"
+            resources:
+              requests:
+                cpu: '8'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '8'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  climate-migration-routes-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: climate-migration-routes-setup-bucket
+      labels:
+        k8s-app: climate-migration-routes-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: climate-migration-routes-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: climate-migration-routes-yamls
+  namespace: biodiversity

--- a/catalog/connectivity/k8s/climate-migration-routes/workflow-rbac.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/connectivity/k8s/climate-migration-routes/workflow.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/workflow.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting climate-migration-routes raster workflow...\"\
+          \n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/climate-migration-routes-setup-bucket.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=600s job/climate-migration-routes-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Preprocess \u2014 mosaic tiles into a single\
+          \ COG on S3\necho \"Step 1: Preprocessing COG mosaic...\"\nkubectl apply\
+          \ -f /yamls/climate-migration-routes-preprocess-cog.yaml -n biodiversity\n\
+          \necho \"Waiting for preprocess-cog (may take 30-60 min for large tile sets)...\"\
+          \nkubectl wait --for=condition=complete --timeout=7200s job/climate-migration-routes-preprocess-cog\
+          \ -n biodiversity\n\n# Step 2: H3 hexagonal tiling\necho \"Step 2: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/climate-migration-routes-hex.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=7200s\
+          \ job/climate-migration-routes-hex -n biodiversity\n\necho \"\u2713 Workflow\
+          \ complete!\"\necho \"Clean up with:\"\necho \"  kubectl delete jobs climate-migration-routes-setup-bucket\
+          \ climate-migration-routes-preprocess-cog climate-migration-routes-hex climate-migration-routes-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap climate-migration-routes-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: climate-migration-routes-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/connectivity/k8s/present-day-connectivity/categories/configmap.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/categories/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset present-day-connectivity/categories --source-url "https://s3-west.nrp-nautilus.io/public-connectivity/raw/ConnectivityCategories.tif" --bucket public-connectivity --h3-resolution 9 --parent-resolutions "0"
+apiVersion: v1
+data:
+  present-day-connectivity-categories-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: present-day-connectivity-categories-hex
+      labels:
+        k8s-app: present-day-connectivity-categories-hex
+    spec:
+      completions: 122
+      parallelism: 61
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: present-day-connectivity-categories-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-connectivity/raw/ConnectivityCategories.tif" --output-parquet s3://public-connectivity/present-day-connectivity-categories/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column connectivity_category --hex-resampling mode --nodata "255"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  present-day-connectivity-categories-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: present-day-connectivity-categories-setup-bucket
+      labels:
+        k8s-app: present-day-connectivity-categories-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: present-day-connectivity-categories-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: present-day-connectivity-categories-yamls
+  namespace: biodiversity

--- a/catalog/connectivity/k8s/present-day-connectivity/categories/present-day-connectivity-categories-hex.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/categories/present-day-connectivity-categories-hex.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-categories-hex
+  labels:
+    k8s-app: present-day-connectivity-categories-hex
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-categories-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/present-day-connectivity-categories-cog.tif" --output-parquet s3://public-connectivity/present-day-connectivity-categories/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column connectivity_category --hex-resampling mode --nodata "255"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/categories/present-day-connectivity-categories-setup-bucket.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/categories/present-day-connectivity-categories-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-categories-setup-bucket
+  labels:
+    k8s-app: present-day-connectivity-categories-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-categories-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/categories/workflow-rbac.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/categories/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/connectivity/k8s/present-day-connectivity/categories/workflow.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/categories/workflow.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-categories-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting present-day-connectivity-categories raster workflow...\"\
+          \n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/present-day-connectivity-categories-setup-bucket.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=600s\
+          \ job/present-day-connectivity-categories-setup-bucket -n biodiversity\n\
+          \n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal tiling...\"\
+          \nkubectl apply -f /yamls/present-day-connectivity-categories-hex.yaml -n\
+          \ biodiversity\nkubectl wait --for=condition=complete --timeout=7200s job/present-day-connectivity-categories-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs present-day-connectivity-categories-setup-bucket\
+          \ present-day-connectivity-categories-hex present-day-connectivity-categories-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap present-day-connectivity-categories-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: present-day-connectivity-categories-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/configmap.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset present-day-connectivity/flow --source-url "https://s3-west.nrp-nautilus.io/public-connectivity/raw/Cflow1.tif" --bucket public-connectivity --h3-resolution 9 --parent-resolutions "0"
+apiVersion: v1
+data:
+  present-day-connectivity-flow-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: present-day-connectivity-flow-hex
+      labels:
+        k8s-app: present-day-connectivity-flow-hex
+    spec:
+      completions: 122
+      parallelism: 61
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: present-day-connectivity-flow-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-connectivity/raw/Cflow1.tif" --output-parquet s3://public-connectivity/present-day-connectivity-flow/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column current_flow --hex-resampling mean --nodata "128"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  present-day-connectivity-flow-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: present-day-connectivity-flow-setup-bucket
+      labels:
+        k8s-app: present-day-connectivity-flow-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: present-day-connectivity-flow-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: present-day-connectivity-flow-yamls
+  namespace: biodiversity

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-hex-50.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-hex-50.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-flow-hex-50
+  labels:
+    k8s-app: present-day-connectivity-flow-hex
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-flow-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/present-day-connectivity-flow-cog.tif" --output-parquet s3://public-connectivity/present-day-connectivity-flow/hex/ --h0-index 50 --resolution 9 --parent-resolutions 0 --value-column current_flow --hex-resampling mean --nodata "128"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-hex-71.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-hex-71.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-flow-hex-71
+  labels:
+    k8s-app: present-day-connectivity-flow-hex
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-flow-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/present-day-connectivity-flow-cog.tif" --output-parquet s3://public-connectivity/present-day-connectivity-flow/hex/ --h0-index 71 --resolution 9 --parent-resolutions 0 --value-column current_flow --hex-resampling mean --nodata "128"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-hex.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-hex.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-flow-hex
+  labels:
+    k8s-app: present-day-connectivity-flow-hex
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-flow-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/present-day-connectivity-flow-cog.tif" --output-parquet s3://public-connectivity/present-day-connectivity-flow/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column current_flow --hex-resampling mean --nodata "128"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-setup-bucket.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/present-day-connectivity-flow-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-flow-setup-bucket
+  labels:
+    k8s-app: present-day-connectivity-flow-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-flow-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/workflow-rbac.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/connectivity/k8s/present-day-connectivity/flow/workflow.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/flow/workflow.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-flow-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting present-day-connectivity-flow raster workflow...\"\
+          \n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/present-day-connectivity-flow-setup-bucket.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=600s job/present-day-connectivity-flow-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/present-day-connectivity-flow-hex.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=7200s\
+          \ job/present-day-connectivity-flow-hex -n biodiversity\n\necho \"\u2713\
+          \ Workflow complete!\"\necho \"Clean up with:\"\necho \"  kubectl delete\
+          \ jobs present-day-connectivity-flow-setup-bucket present-day-connectivity-flow-hex\
+          \ present-day-connectivity-flow-workflow -n biodiversity\"\necho \"  kubectl\
+          \ delete configmap present-day-connectivity-flow-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: present-day-connectivity-flow-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/configmap.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/configmap.yaml
@@ -1,0 +1,428 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: regional-connectivity-linkages-setup-bucket.yaml, regional-connectivity-linkages-convert.yaml, regional-connectivity-linkages-pmtiles.yaml, regional-connectivity-linkages-hex.yaml, regional-connectivity-linkages-repartition.yaml
+# Generation command: cng-datasets workflow --dataset regional-connectivity-linkages --source-url https://s3-west.nrp-nautilus.io/public-connectivity/raw/ds419.gdb --bucket public-connectivity --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap regional-connectivity-linkages-yamls \
+#     --from-file=regional-connectivity-linkages-setup-bucket.yaml \
+#     --from-file=regional-connectivity-linkages-convert.yaml \
+#     --from-file=regional-connectivity-linkages-pmtiles.yaml \
+#     --from-file=regional-connectivity-linkages-hex.yaml \
+#     --from-file=regional-connectivity-linkages-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  regional-connectivity-linkages-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: regional-connectivity-linkages-convert
+      labels:
+        k8s-app: regional-connectivity-linkages-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: regional-connectivity-linkages-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://s3-west.nrp-nautilus.io/public-connectivity/raw/ds419.gdb \
+                s3://public-connectivity/regional-connectivity-linkages.parquet \
+                --row-group-size 100000 \
+                --layer ds419
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  regional-connectivity-linkages-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: regional-connectivity-linkages-hex
+      labels:
+        k8s-app: regional-connectivity-linkages-hex
+    spec:
+      completions: 11
+      parallelism: 11
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: regional-connectivity-linkages-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-connectivity
+            - name: DATASET
+              value: regional-connectivity-linkages
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-connectivity/regional-connectivity-linkages.parquet --output s3://public-connectivity/regional-connectivity-linkages/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  regional-connectivity-linkages-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: regional-connectivity-linkages-pmtiles
+      labels:
+        k8s-app: regional-connectivity-linkages-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: regional-connectivity-linkages-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-connectivity
+            - name: DATASET
+              value: regional-connectivity-linkages
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-connectivity/regional-connectivity-linkages.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-connectivity/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  regional-connectivity-linkages-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: regional-connectivity-linkages-repartition
+      labels:
+        k8s-app: regional-connectivity-linkages-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: regional-connectivity-linkages-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-connectivity/regional-connectivity-linkages/chunks --output-dir s3://public-connectivity/regional-connectivity-linkages/hex --source-parquet s3://public-connectivity/regional-connectivity-linkages.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  regional-connectivity-linkages-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: regional-connectivity-linkages-setup-bucket
+      labels:
+        k8s-app: regional-connectivity-linkages-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: regional-connectivity-linkages-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: regional-connectivity-linkages-yamls
+  namespace: biodiversity

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-convert.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-convert.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regional-connectivity-linkages-convert
+  labels:
+    k8s-app: regional-connectivity-linkages-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: regional-connectivity-linkages-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://s3-west.nrp-nautilus.io/public-connectivity/raw/ds419.gdb \
+            s3://public-connectivity/regional-connectivity-linkages.parquet \
+            --row-group-size 100000 \
+            --layer ds419
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-hex.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regional-connectivity-linkages-hex
+  labels:
+    k8s-app: regional-connectivity-linkages-hex
+spec:
+  completions: 11
+  parallelism: 11
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: regional-connectivity-linkages-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-connectivity
+        - name: DATASET
+          value: regional-connectivity-linkages
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-connectivity/regional-connectivity-linkages.parquet --output s3://public-connectivity/regional-connectivity-linkages/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-pmtiles.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regional-connectivity-linkages-pmtiles
+  labels:
+    k8s-app: regional-connectivity-linkages-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: regional-connectivity-linkages-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-connectivity
+        - name: DATASET
+          value: regional-connectivity-linkages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-connectivity/regional-connectivity-linkages.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-connectivity/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-repartition.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regional-connectivity-linkages-repartition
+  labels:
+    k8s-app: regional-connectivity-linkages-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: regional-connectivity-linkages-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-connectivity/regional-connectivity-linkages/chunks --output-dir s3://public-connectivity/regional-connectivity-linkages/hex --source-parquet s3://public-connectivity/regional-connectivity-linkages.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-setup-bucket.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/regional-connectivity-linkages-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regional-connectivity-linkages-setup-bucket
+  labels:
+    k8s-app: regional-connectivity-linkages-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: regional-connectivity-linkages-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/workflow-rbac.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/connectivity/k8s/regional-connectivity-linkages/workflow.yaml
+++ b/catalog/connectivity/k8s/regional-connectivity-linkages/workflow.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regional-connectivity-linkages-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting regional-connectivity-linkages workflow...\"\
+          \n\n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/regional-connectivity-linkages-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/regional-connectivity-linkages-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/regional-connectivity-linkages-convert.yaml -n\
+          \ biodiversity\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/regional-connectivity-linkages-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/regional-connectivity-linkages-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/regional-connectivity-linkages-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/regional-connectivity-linkages-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/regional-connectivity-linkages-repartition.yaml -n biodiversity\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/regional-connectivity-linkages-repartition -n biodiversity\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs regional-connectivity-linkages-setup-bucket regional-connectivity-linkages-convert\
+          \ regional-connectivity-linkages-pmtiles regional-connectivity-linkages-hex\
+          \ regional-connectivity-linkages-repartition regional-connectivity-linkages-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap regional-connectivity-linkages-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: regional-connectivity-linkages-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/connectivity/k8s/reproject-cogs.yaml
+++ b/catalog/connectivity/k8s/reproject-cogs.yaml
@@ -1,0 +1,77 @@
+# Workaround for cng-datasets AutoIdentifyEPSG crash on sources whose CRS has no
+# EPSG code (ESRI:102003 USA Contiguous Albers; sphere Web-Mercator). See
+# boettiger-lab/datasets bug report. Reprojects each connectivity raster source to
+# a clean EPSG:4326 COG so the raster hex step (cng-datasets raster --input <cog>)
+# can read it. Resampling per data type: near for categorical, bilinear for the
+# continuous flow index.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: connectivity-reproject-cogs
+  namespace: biodiversity
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: reproject
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "4"
+              memory: "12Gi"
+              ephemeral-storage: "40Gi"
+            limits:
+              cpu: "4"
+              memory: "12Gi"
+              ephemeral-storage: "40Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              cd /tmp
+              WARP="gdalwarp -t_srs EPSG:4326 -of COG -multi -wo NUM_THREADS=ALL_CPUS \
+                    -co COMPRESS=DEFLATE -co BLOCKSIZE=512 -co BIGTIFF=IF_SAFER --config GDAL_CACHEMAX 2048"
+
+              echo '### 1/3 Schloss omniscape (categorical UInt16, nodata 65535) -> near'
+              rclone copy nrp:public-connectivity/raw/climateConnectivityOmniscapeCalifornia.tif /tmp/ -P
+              $WARP -r near -co OVERVIEW_RESAMPLING=NEAREST -srcnodata 65535 -dstnodata 65535 \
+                /tmp/climateConnectivityOmniscapeCalifornia.tif /tmp/climate-migration-routes-cog.tif
+              rclone copyto /tmp/climate-migration-routes-cog.tif nrp:public-connectivity/climate-migration-routes-cog.tif
+              gdalinfo -norat -nomd /tmp/climate-migration-routes-cog.tif | grep -E "Size is|EPSG|NoData|Type=" | head
+
+              echo '### 2/3 Cameron Cflow1 (continuous Int16 1-100, nodata 128) -> bilinear'
+              rclone copy nrp:public-connectivity/raw/Cflow1.tif /tmp/ -P
+              $WARP -r bilinear -co OVERVIEW_RESAMPLING=AVERAGE -srcnodata 128 -dstnodata 128 \
+                /tmp/Cflow1.tif /tmp/present-day-connectivity-flow-cog.tif
+              rclone copyto /tmp/present-day-connectivity-flow-cog.tif nrp:public-connectivity/present-day-connectivity-flow-cog.tif
+              gdalinfo -norat -nomd /tmp/present-day-connectivity-flow-cog.tif | grep -E "Size is|EPSG|NoData|Type=" | head
+
+              echo '### 3/3 Cameron ConnectivityCategories (categorical Float64 -> Byte) -> near'
+              rclone copy nrp:public-connectivity/raw/ConnectivityCategories.tif /tmp/ -P
+              $WARP -r near -ot Byte -co OVERVIEW_RESAMPLING=NEAREST -dstnodata 255 \
+                /tmp/ConnectivityCategories.tif /tmp/present-day-connectivity-categories-cog.tif
+              rclone copyto /tmp/present-day-connectivity-categories-cog.tif nrp:public-connectivity/present-day-connectivity-categories-cog.tif
+              gdalinfo -norat -nomd /tmp/present-day-connectivity-categories-cog.tif | grep -E "Size is|EPSG|NoData|Type=" | head
+
+              echo "ALL COGS DONE"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/sync/k8s/sync-public-connectivity.yaml
+++ b/catalog/sync/k8s/sync-public-connectivity.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-connectivity
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-connectivity"
+              echo "Syncing: nrp:public-connectivity -> minio:public-connectivity"
+              rclone sync $RCLONE_FLAGS "nrp:public-connectivity" "minio:public-connectivity"
+              echo "Done: public-connectivity"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config


### PR DESCRIPTION
Closes #234.

New **`public-connectivity`** bucket with three CBN connectivity/resilience datasets as cloud-native products. STAC collections + README live on NRP S3 (per AGENTS); this PR holds the k8s workflow YAMLs + MinIO sync job.

## Datasets — all built + validated ✅
| Dataset | Source | Type | Reducer | Validation |
|---|---|---|---|---|
| `regional-connectivity-linkages` | Beier 2006 / CDFW BIOS **ds419** | vector (11 polygons) | — | GeoParquet + PMTiles + hex res 8; geometries valid |
| `climate-migration-routes` | Schloss 2022 / Dryad **d7wm37q1m** | raster, categorical (13 classes) | `mode` | COG + hex res 9; classes {0,100–303}, no interpolation |
| `present-day-connectivity/flow` | Cameron 2022 / Dryad **7sqv9s4v3** | raster, continuous 0–100 | `mean` | COG + hex res 9; 3.65M cells, range 0–100 |
| `present-day-connectivity/categories` | Cameron 2022 | raster, categorical (12 classes) | `mode` | COG + hex res 9; classes {0,3,4,19,25,29,31,35,39,41,45,49} |

STAC: 4 flat leaf collections live + traversable via the geo-agent MCP; `public-connectivity` registered in the root catalog; per-bucket MinIO sync added (`sync-public-connectivity`, ran Complete).

## Notable decisions
- **Schloss reducer corrected `mean` → `mode`** — pre-flight showed it's categorical (13 class codes), not continuous current flow. [Issue comment](https://github.com/boettiger-lab/data-workflows/issues/234#issuecomment-4738260061).
- **CRS workaround (`reproject-cogs.yaml`)** — all rasters use ESRI:102003 / sphere Web-Mercator (no EPSG code), which crashes `cng-datasets` at `AutoIdentifyEPSG()` (filed **boettiger-lab/datasets#131** with MRE). Pre-reproject each source to a clean EPSG:4326 COG (`near` for categorical, `bilinear` for flow) before hexing.
- **Memory tuning** — res-9 hex over the two data-bearing California h0 cells is heavy; Schloss-71 and Cameron flow-50/71 OOM'd at 32Gi (flow's `mean` pegged the ceiling) and were re-run as single-index jobs at 120Gi (`*-hex-71.yaml`, `*-hex-50.yaml`). Cameron categories (`mode`) fit in 32Gi.
- **Source access** — Dryad `/downloads/` are behind an AWS WAF JS bot-challenge no headless tool can pass; the raster zips were downloaded via browser and staged to `raw/`. The Beier vector came from the CDFW BIOS HTTPS mirror (the issue's FTP URL was dead).

## Downstream (separate)
ca-30x30 `layers-input.json` integration — gated on STAC being live, now satisfied.
