### PR TITLE
public-hazard: Mid-Century Habitat Climate Exposure (Thorne 2016) — raster

### DIFF
--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/configmap.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mid-century-habitat-climate-exposure/cnrm --source-url "s3://public-hazard/raw/thorne/exp_cnrm_4069_90m_ext.tif" --bucket public-hazard --h3-resolution 9 --parent-resolutions "8,0"
+apiVersion: v1
+data:
+  mid-century-habitat-climate-exposure-cnrm-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mid-century-habitat-climate-exposure-cnrm-hex
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-cnrm-hex
+    spec:
+      completions: 122
+      parallelism: 61
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mid-century-habitat-climate-exposure-cnrm-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-hazard/raw/thorne/exp_cnrm_4069_90m_ext.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure-cnrm/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mid-century-habitat-climate-exposure-cnrm-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mid-century-habitat-climate-exposure-cnrm-setup-bucket
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-cnrm-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mid-century-habitat-climate-exposure-cnrm-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mid-century-habitat-climate-exposure-cnrm-yamls
+  namespace: biodiversity

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/configmap.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/configmap.yaml
@@ -65,7 +65,7 @@ data:
             - |-
               set -e
 
-              cng-datasets raster --input "s3://public-hazard/raw/thorne/exp_cnrm_4069_90m_ext.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure-cnrm/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
+              cng-datasets raster --input "s3://public-hazard/mid-century-habitat-climate-exposure/cnrm-cog.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure/cnrm/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
             resources:
               requests:
                 cpu: '4'

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/mid-century-habitat-climate-exposure-cnrm-hex.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/mid-century-habitat-climate-exposure-cnrm-hex.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mid-century-habitat-climate-exposure-cnrm-hex
+  labels:
+    k8s-app: mid-century-habitat-climate-exposure-cnrm-hex
+spec:
+  completions: 122
+  parallelism: 8
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-cnrm-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-hazard/mid-century-habitat-climate-exposure/cnrm-cog.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure/cnrm/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
+        resources:
+          requests:
+            cpu: '4'
+            memory: 96Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 96Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/mid-century-habitat-climate-exposure-cnrm-setup-bucket.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/mid-century-habitat-climate-exposure-cnrm-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mid-century-habitat-climate-exposure-cnrm-setup-bucket
+  labels:
+    k8s-app: mid-century-habitat-climate-exposure-cnrm-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-cnrm-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/workflow-rbac.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/workflow.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/cnrm/workflow.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mid-century-habitat-climate-exposure-cnrm-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mid-century-habitat-climate-exposure-cnrm raster\
+          \ workflow...\"\n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/mid-century-habitat-climate-exposure-cnrm-setup-bucket.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=600s\
+          \ job/mid-century-habitat-climate-exposure-cnrm-setup-bucket -n biodiversity\n\
+          \n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal tiling...\"\
+          \nkubectl apply -f /yamls/mid-century-habitat-climate-exposure-cnrm-hex.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=7200s\
+          \ job/mid-century-habitat-climate-exposure-cnrm-hex -n biodiversity\n\n\
+          echo \"\u2713 Workflow complete!\"\necho \"Clean up with:\"\necho \"  kubectl\
+          \ delete jobs mid-century-habitat-climate-exposure-cnrm-setup-bucket mid-century-habitat-climate-exposure-cnrm-hex\
+          \ mid-century-habitat-climate-exposure-cnrm-workflow -n biodiversity\"\n\
+          echo \"  kubectl delete configmap mid-century-habitat-climate-exposure-cnrm-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mid-century-habitat-climate-exposure-cnrm-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/mche-stage.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/mche-stage.yaml
@@ -1,0 +1,112 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mche-stage
+  labels:
+    k8s-app: mche-stage
+spec:
+  backoffLimit: 2
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 21600
+  template:
+    metadata:
+      labels:
+        k8s-app: mche-stage
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: '4'
+            ephemeral-storage: 40Gi
+          limits:
+            memory: 8Gi
+            cpu: '4'
+            ephemeral-storage: 40Gi
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          mkdir -p /tmp/mche
+          cd /tmp/mche
+
+          echo "=== copy source zip from MinIO to public-hazard/raw/ ==="
+          rclone copy minio:public-ca30x30/CBN/Climate_risks/Mid-century_habitat_climate_exposure/Midcentury_habitat_climate_exposure.zip /tmp/mche/
+          rclone copy /tmp/mche/Midcentury_habitat_climate_exposure.zip nrp:public-hazard/raw/
+
+          echo "=== unzip ==="
+          unzip -q -o Midcentury_habitat_climate_exposure.zip
+          D="Mid-century habitat climate exposure"
+          ls -la "$D"/
+
+          echo "=== upload the two GCM exposure GeoTIFFs (Albers, raw source) to raw/thorne/ ==="
+          rclone copyto "$D/exp_cnrm_4069_90m_ext.tif"  nrp:public-hazard/raw/thorne/exp_cnrm_4069_90m_ext.tif
+          rclone copyto "$D/exp_miroc_4069_90m_ext.tif" nrp:public-hazard/raw/thorne/exp_miroc_4069_90m_ext.tif
+
+          # Source is Albers Equal-Area (NAD83); H3 hexing needs WGS84. Build a WGS84 COG per GCM
+          # (nearest resampling preserves the continuous exposure values; nodata -3.4028235e+38 kept).
+          ND="-3.4028234663852886e+38"
+          for gcm in cnrm miroc; do
+            src="$D/exp_${gcm}_4069_90m_ext.tif"
+            echo "=== ${gcm}: reproject Albers -> WGS84 ==="
+            gdalwarp -overwrite -t_srs EPSG:4326 -r near \
+              -srcnodata "$ND" -dstnodata "$ND" \
+              -co COMPRESS=DEFLATE -co BIGTIFF=YES \
+              "$src" /tmp/mche/${gcm}_4326.tif
+            echo "=== ${gcm}: write Cloud-Optimized GeoTIFF ==="
+            gdal_translate -of COG -co COMPRESS=DEFLATE -co OVERVIEWS=AUTO -co BLOCKSIZE=512 \
+              -a_nodata "$ND" \
+              /tmp/mche/${gcm}_4326.tif /tmp/mche/${gcm}-cog.tif
+            echo "=== ${gcm}: upload COG ==="
+            rclone copyto /tmp/mche/${gcm}-cog.tif \
+              nrp:public-hazard/mid-century-habitat-climate-exposure/${gcm}-cog.tif
+            rm -f /tmp/mche/${gcm}_4326.tif
+            gdalinfo -stats /tmp/mche/${gcm}-cog.tif 2>/dev/null | grep -iE 'Size is|EPSG|NoData|Minimum=|STATISTICS_M' | head
+          done
+
+          echo "Done."
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/configmap.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/configmap.yaml
@@ -65,7 +65,7 @@ data:
             - |-
               set -e
 
-              cng-datasets raster --input "s3://public-hazard/raw/thorne/exp_miroc_4069_90m_ext.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure-miroc/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
+              cng-datasets raster --input "s3://public-hazard/mid-century-habitat-climate-exposure/miroc-cog.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure/miroc/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
             resources:
               requests:
                 cpu: '4'

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/configmap.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mid-century-habitat-climate-exposure/miroc --source-url "s3://public-hazard/raw/thorne/exp_miroc_4069_90m_ext.tif" --bucket public-hazard --h3-resolution 9 --parent-resolutions "8,0"
+apiVersion: v1
+data:
+  mid-century-habitat-climate-exposure-miroc-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mid-century-habitat-climate-exposure-miroc-hex
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-miroc-hex
+    spec:
+      completions: 122
+      parallelism: 61
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mid-century-habitat-climate-exposure-miroc-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-hazard/raw/thorne/exp_miroc_4069_90m_ext.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure-miroc/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mid-century-habitat-climate-exposure-miroc-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mid-century-habitat-climate-exposure-miroc-setup-bucket
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-miroc-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mid-century-habitat-climate-exposure-miroc-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mid-century-habitat-climate-exposure-miroc-yamls
+  namespace: biodiversity

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/mid-century-habitat-climate-exposure-miroc-hex.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/mid-century-habitat-climate-exposure-miroc-hex.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mid-century-habitat-climate-exposure-miroc-hex
+  labels:
+    k8s-app: mid-century-habitat-climate-exposure-miroc-hex
+spec:
+  completions: 122
+  parallelism: 8
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-miroc-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-hazard/mid-century-habitat-climate-exposure/miroc-cog.tif" --output-parquet s3://public-hazard/mid-century-habitat-climate-exposure/miroc/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column exposure --hex-resampling mean
+        resources:
+          requests:
+            cpu: '4'
+            memory: 96Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 96Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/mid-century-habitat-climate-exposure-miroc-setup-bucket.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/mid-century-habitat-climate-exposure-miroc-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mid-century-habitat-climate-exposure-miroc-setup-bucket
+  labels:
+    k8s-app: mid-century-habitat-climate-exposure-miroc-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mid-century-habitat-climate-exposure-miroc-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/workflow-rbac.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/workflow.yaml
+++ b/catalog/hazard/k8s/mid-century-habitat-climate-exposure/miroc/workflow.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mid-century-habitat-climate-exposure-miroc-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mid-century-habitat-climate-exposure-miroc raster\
+          \ workflow...\"\n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/mid-century-habitat-climate-exposure-miroc-setup-bucket.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=600s\
+          \ job/mid-century-habitat-climate-exposure-miroc-setup-bucket -n biodiversity\n\
+          \n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal tiling...\"\
+          \nkubectl apply -f /yamls/mid-century-habitat-climate-exposure-miroc-hex.yaml\
+          \ -n biodiversity\nkubectl wait --for=condition=complete --timeout=7200s\
+          \ job/mid-century-habitat-climate-exposure-miroc-hex -n biodiversity\n\n\
+          echo \"\u2713 Workflow complete!\"\necho \"Clean up with:\"\necho \"  kubectl\
+          \ delete jobs mid-century-habitat-climate-exposure-miroc-setup-bucket mid-century-habitat-climate-exposure-miroc-hex\
+          \ mid-century-habitat-climate-exposure-miroc-workflow -n biodiversity\"\n\
+          echo \"  kubectl delete configmap mid-century-habitat-climate-exposure-miroc-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mid-century-habitat-climate-exposure-miroc-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/sync/k8s/sync-public-hazard.yaml
+++ b/catalog/sync/k8s/sync-public-hazard.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-hazard
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-hazard"
+              echo "Syncing: nrp:public-hazard -> minio:public-hazard"
+              rclone sync $RCLONE_FLAGS "nrp:public-hazard" "minio:public-hazard"
+              echo "Done: public-hazard"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config


### PR DESCRIPTION
Builds the **Mid-Century Habitat Climate Exposure** raster dataset (Thorne et al. 2016) into the new `public-hazard` bucket. Part of #236; closes #252.

## What
Two downscaled GCMs — **CNRM-CM5** and **MIROC5** — of the mid-century (2040–2069) climate-exposure index for California natural vegetation.

| Step | File |
|---|---|
| Stage source zip (MinIO) + Albers→WGS84 **COG** per GCM | `mche-stage.yaml` |
| Raster hex (exact-extract, **reducer=mean**, **H3 res 9**, parent 8,0) | `cnrm/`, `miroc/` |
| New-bucket MinIO sync (shared) | `catalog/sync/k8s/sync-public-hazard.yaml` |

## Deliverables (live on NRP `public-hazard`)
- `mid-century-habitat-climate-exposure/{cnrm,miroc}-cog.tif` (WGS84 COG, Float32, nodata −3.4e38)
- `mid-century-habitat-climate-exposure/{cnrm,miroc}/hex/h0=*/data_0.parquet` (res 9; 3.61M h9 cells each)
- STAC collection + README; registered under `public-hazard` bucket collection + root catalog.

## Validation (duckdb-geo MCP)
- CNRM: 3,614,320 h9 cells, exposure ∈ [−1, 1], mean 0.760 (matches COG mean 0.759).
- MIROC: 3,614,320 h9 cells, exposure ∈ [0.05, 1], mean 0.739 (within source range).
- Reducer `mean` is correct (continuous index, not a count/amount).

## Notes
- **Reducer choice:** the pixel value is a normalized exposure *index*, so `mean` (area-weighted), never `sum`.
- **Memory:** res-9 exact-extract enumerates ~40M h9 cells per h0 → tuned to 96Gi / parallelism 8 (32Gi OOMs).
- **License = `other` pending verification** — no explicit license is published with the Thorne 2016 / CA DFW source; redistribution terms should be confirmed before mirroring to source.coop.
- **Extent:** source is CA-extent (90 m `_ext` Albers extracts).
- Bucket/STAC/root setup and sync job are shared with the SLR dataset (#251); they ride in this PR as the first to land.