### PR TITLE
public-hazard: NOAA Sea Level Rise (national, 5 ft) — vector

### DIFF
--- a/catalog/hazard/k8s/sea-level-rise/configmap.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: sea-level-rise-setup-bucket.yaml, sea-level-rise-convert.yaml, sea-level-rise-pmtiles.yaml, sea-level-rise-hex.yaml, sea-level-rise-repartition.yaml
+# Generation command: cng-datasets workflow --dataset sea-level-rise --source-url s3://public-hazard/sea-level-rise.parquet --bucket public-hazard --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap sea-level-rise-yamls \
+#     --from-file=sea-level-rise-setup-bucket.yaml \
+#     --from-file=sea-level-rise-convert.yaml \
+#     --from-file=sea-level-rise-pmtiles.yaml \
+#     --from-file=sea-level-rise-hex.yaml \
+#     --from-file=sea-level-rise-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  sea-level-rise-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sea-level-rise-convert
+      labels:
+        k8s-app: sea-level-rise-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sea-level-rise-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-hazard/sea-level-rise.parquet \
+                s3://public-hazard/sea-level-rise.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sea-level-rise-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sea-level-rise-hex
+      labels:
+        k8s-app: sea-level-rise-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sea-level-rise-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-hazard
+            - name: DATASET
+              value: sea-level-rise
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-hazard/sea-level-rise.parquet --output s3://public-hazard/sea-level-rise/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sea-level-rise-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sea-level-rise-pmtiles
+      labels:
+        k8s-app: sea-level-rise-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sea-level-rise-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-hazard
+            - name: DATASET
+              value: sea-level-rise
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-hazard/sea-level-rise.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-hazard/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sea-level-rise-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sea-level-rise-repartition
+      labels:
+        k8s-app: sea-level-rise-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sea-level-rise-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-hazard/sea-level-rise/chunks --output-dir s3://public-hazard/sea-level-rise/hex --source-parquet s3://public-hazard/sea-level-rise.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sea-level-rise-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sea-level-rise-setup-bucket
+      labels:
+        k8s-app: sea-level-rise-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sea-level-rise-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-hazard
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: sea-level-rise-yamls
+  namespace: biodiversity

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-convert.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-convert
+  labels:
+    k8s-app: sea-level-rise-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sea-level-rise-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-hazard/sea-level-rise.parquet \
+            s3://public-hazard/sea-level-rise.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-hex.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-hex.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-hex
+  labels:
+    k8s-app: sea-level-rise-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 30
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sea-level-rise-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-hazard
+        - name: DATASET
+          value: sea-level-rise
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-hazard/sea-level-rise.parquet --output s3://public-hazard/sea-level-rise/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 3000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 30Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 30Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-hex.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-hex.yaml
@@ -56,7 +56,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets vector --input s3://public-hazard/sea-level-rise.parquet --output s3://public-hazard/sea-level-rise/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 3000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+          cng-datasets vector --input s3://public-hazard/sea-level-rise.parquet --output s3://public-hazard/sea-level-rise/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 3100 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
         resources:
           requests:
             cpu: '4'

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-pmtiles.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-pmtiles
+  labels:
+    k8s-app: sea-level-rise-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sea-level-rise-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-hazard
+        - name: DATASET
+          value: sea-level-rise
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-hazard/sea-level-rise.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-hazard/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-pmtiles.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-pmtiles.yaml
@@ -66,7 +66,11 @@ spec:
           # environment, not the shell. A plain assignment is invisible to it, so it
           # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
           export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
-          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+          # maxzoom capped at 12: dense national 5 ft inundation polygons need no more web
+          # detail, and an uncapped --extend-zooms-if-still-dropping ran away (>2.5 h, climbing
+          # zoom levels) — same failure mode documented for high-seas/ebsa (capped there at z10).
+          # Cap + drop the extend flag to bound the work.
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET -z12 --drop-densest-as-needed --force /tmp/$DATASET.geojsonl
 
           # Upload to S3 using rclone
           rclone copy /tmp/$DATASET.pmtiles nrp:public-hazard/

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-preprocess.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-preprocess.yaml
@@ -143,10 +143,19 @@ spec:
               echo "  NO OGR SOURCE FOUND"; FAILED="$FAILED $fname"; rm -rf "$WORK/ex" "$WORK/${fname}"; continue
             fi
 
-            # discover the 5 ft ocean-connected layer: newer gpkg = *_slr_5_0ft, older gdb = *_slr_5ft
-            layers=$(ogrinfo -ro -q "$src" 2>/dev/null)
-            layer=$(echo "$layers" | grep -oE '[A-Za-z0-9_]+_slr_5_0ft' | head -1)
-            [ -z "$layer" ] && layer=$(echo "$layers" | grep -oE '[A-Za-z0-9_]+_slr_5ft' | head -1)
+            # discover the 5 ft ocean-connected layer via OGR API (returns the FULL layer name).
+            # Naming varies: newer gpkg = *_slr_5_0ft, older gdb = *_slr_5ft, and some regions
+            # ship only a levee-modeled variant *_slr_5ft_Levee (e.g. TX_Central). Prefer the
+            # plain *_slr_5_0ft, else any *_slr_5ft* (incl. _Levee); always exclude *_low_*.
+            # A bare grep -oE truncates the _Levee suffix → references a non-existent layer.
+            layer=$(python3 -c "
+            import re
+            from osgeo import gdal
+            ds=gdal.OpenEx('$src')
+            ls=[ds.GetLayer(i).GetName() for i in range(ds.GetLayerCount())]
+            c=[l for l in ls if re.search(r'_slr_5_0ft\$', l) and '_low_' not in l] \
+              or [l for l in ls if re.search(r'_slr_5ft', l) and '_low_' not in l]
+            print(c[0] if c else '')" 2>/dev/null)
             if [ -z "$layer" ]; then
               echo "  NO 5ft slr LAYER (skipping)"; rm -rf "$WORK/ex" "$WORK/${fname}"; continue
             fi

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-preprocess.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-preprocess.yaml
@@ -1,0 +1,195 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-preprocess
+  labels:
+    k8s-app: sea-level-rise-preprocess
+spec:
+  backoffLimit: 2
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 21600
+  template:
+    metadata:
+      labels:
+        k8s-app: sea-level-rise-preprocess
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      # cluster CoreDNS fails to resolve external hosts (coast.noaa.gov) on some nodes;
+      # append public resolvers as fallback. ClusterFirst still resolves the internal .rook S3 endpoint.
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+        options:
+        - name: timeout
+          value: '2'
+        - name: attempts
+          value: '3'
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      containers:
+      - name: preprocess
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: 64Gi
+            cpu: '8'
+            ephemeral-storage: 10Gi
+          limits:
+            memory: 64Gi
+            cpu: '8'
+            ephemeral-storage: 10Gi
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-hazard
+        - name: TMPDIR
+          value: /scratch/tmp
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /scratch
+          subPath: sea-level-rise-preprocess
+        command:
+        - bash
+        - -c
+        - |
+          set -uo pipefail
+
+          # coast.noaa.gov/slrdata (nginx) reliably serves both URL lists and zips;
+          # chs.coast.noaa.gov (the host inside the lists) has DNS flakiness on cluster nodes.
+          BASE="https://coast.noaa.gov/slrdata/Sea_Level_Rise_Vectors"
+          CODES="AL AS CA CT DC DE FL GA GU HI LA MA MD ME MS MP NC NH NJ NY OR PR RI SC TX VA VI WA"
+          WORK=/scratch/work
+          MERGED=/scratch/sea_level_rise_5ft.gpkg
+          mkdir -p "$WORK" /scratch/tmp
+          rm -f "$MERGED"
+
+          echo "=== building national URL list ==="
+          : > /scratch/all_urls.txt
+          for c in $CODES; do
+            curl -sSL --retry 8 --retry-delay 5 --retry-all-errors "${BASE}/${c}/URLlist_${c}.txt" | tr -d '\r' >> /scratch/all_urls.txt
+            echo "" >> /scratch/all_urls.txt
+          done
+          # keep only standard vector bundles (zip) + bare gpkgs; drop HalfFoot supplements & blanks;
+          # rewrite the flaky chs.coast.noaa.gov download host -> reliable coast.noaa.gov/slrdata
+          grep -E '_slr_data_dist\.zip$|_slr_final_dist\.gpkg$' /scratch/all_urls.txt \
+            | grep -v 'HalfFoot' \
+            | sed 's#https://chs.coast.noaa.gov/htdata/Inundation/SLR/BulkDownload/#https://coast.noaa.gov/slrdata/#' \
+            | sort -u > /scratch/urls.txt
+          n=$(wc -l < /scratch/urls.txt)
+          echo "selected $n source files"
+
+          FAILED=""
+          i=0
+          while read -r url; do
+            [ -z "$url" ] && continue
+            i=$((i+1))
+            fname=$(basename "$url")
+            echo "=== [$i/$n] $fname ==="
+
+            # fetch: reuse s3 raw copy if present (fast internal), else download from NOAA + stage raw
+            # NB: `rclone lsf` exits 0 with empty output for a missing file, so test for non-empty output.
+            if [ -n "$(rclone lsf "nrp:public-hazard/raw/${fname}" 2>/dev/null)" ]; then
+              echo "  reusing staged raw from s3"
+              rclone copy "nrp:public-hazard/raw/${fname}" "$WORK/" || { FAILED="$FAILED $fname"; continue; }
+            else
+              if ! curl -sSL --retry 8 --retry-delay 5 --retry-all-errors -o "$WORK/${fname}" "$url"; then
+                echo "  DOWNLOAD FAILED"; FAILED="$FAILED $fname"; rm -f "$WORK/${fname}"; continue
+              fi
+              rclone copy "$WORK/${fname}" nrp:public-hazard/raw/ || true
+            fi
+
+            # locate the OGR source (unzip if needed). Format varies by region vintage:
+            #   newer = GeoPackage (.gpkg); older = Esri File Geodatabase (.gdb dir); fallback = shapefile.
+            if [[ "$fname" == *.zip ]]; then
+              unzip -q -o "$WORK/${fname}" -d "$WORK/ex" || { FAILED="$FAILED $fname"; rm -rf "$WORK/ex" "$WORK/${fname}"; continue; }
+              src=$(find "$WORK/ex" -name '*.gpkg' | head -1)
+              [ -z "$src" ] && src=$(find "$WORK/ex" -name '*.gdb' -type d | head -1)
+              [ -z "$src" ] && src=$(find "$WORK/ex" \( -iname '*_slr_5_0ft.shp' -o -iname '*_slr_5ft.shp' \) | head -1)
+            else
+              src="$WORK/${fname}"
+            fi
+            if [ -z "${src:-}" ] || [ ! -e "$src" ]; then
+              echo "  NO OGR SOURCE FOUND"; FAILED="$FAILED $fname"; rm -rf "$WORK/ex" "$WORK/${fname}"; continue
+            fi
+
+            # discover the 5 ft ocean-connected layer: newer gpkg = *_slr_5_0ft, older gdb = *_slr_5ft
+            layers=$(ogrinfo -ro -q "$src" 2>/dev/null)
+            layer=$(echo "$layers" | grep -oE '[A-Za-z0-9_]+_slr_5_0ft' | head -1)
+            [ -z "$layer" ] && layer=$(echo "$layers" | grep -oE '[A-Za-z0-9_]+_slr_5ft' | head -1)
+            if [ -z "$layer" ]; then
+              echo "  NO 5ft slr LAYER (skipping)"; rm -rf "$WORK/ex" "$WORK/${fname}"; continue
+            fi
+
+            base="${fname%_slr_data_dist.zip}"; base="${base%_slr_final_dist.gpkg}"
+            state="${base%%_*}"
+            region="${base#*_}"; [ "$region" = "$base" ] && region="$base"
+
+            # Discover the geometry column name and select it EXPLICITLY. OGR SQL does NOT
+            # auto-carry a GeoPackage's named geom column with a restricted column list
+            # (it silently produced NULL geometry for all gpkg sources); naming it fixes that.
+            # Most NOAA gpkgs use "Shape" but some (e.g. FL_SW, FL_East_1) use "geom", so read
+            # the real column via OGR's API rather than parsing ogrinfo text.
+            geomcol=$(python3 -c "from osgeo import gdal; ds=gdal.OpenEx('$src'); print((ds.GetLayerByName('$layer').GetGeometryColumn()) or 'Shape')" 2>/dev/null)
+            [ -z "$geomcol" ] && geomcol="Shape"
+            echo "  layer=$layer geomcol=$geomcol state=$state region=$region"
+
+            ogr2ogr -f GPKG -append "$MERGED" "$src" -nln slr -t_srs OGC:CRS84 \
+              -sql "SELECT \"${geomcol}\", '${state}' AS state, '${region}' AS region, 5.0 AS slr_ft FROM \"${layer}\"" \
+              || { echo "  OGR2OGR FAILED"; FAILED="$FAILED $fname"; }
+
+            rm -rf "$WORK/ex" "$WORK/${fname}"
+          done < /scratch/urls.txt
+
+          echo "=== FAILED FILES:${FAILED:- none} ==="
+          echo "=== merged feature count ==="
+          ogrinfo -so "$MERGED" slr | grep -i 'Feature Count'
+
+          echo "=== converting merged gpkg -> DuckDB-native GeoParquet (OGC:CRS84) ==="
+          cng-convert-to-parquet \
+            "$MERGED" \
+            s3://public-hazard/sea-level-rise.parquet \
+            --layer slr \
+            --target-crs OGC:CRS84 \
+            --compression ZSTD \
+            --compression-level 15 \
+            --row-group-size 100000
+
+          echo "Done."
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-repartition.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-repartition
+  labels:
+    k8s-app: sea-level-rise-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sea-level-rise-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-hazard/sea-level-rise/chunks --output-dir s3://public-hazard/sea-level-rise/hex --source-parquet s3://public-hazard/sea-level-rise.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/sea-level-rise/sea-level-rise-setup-bucket.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/sea-level-rise-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-setup-bucket
+  labels:
+    k8s-app: sea-level-rise-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sea-level-rise-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-hazard
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/hazard/k8s/sea-level-rise/workflow-rbac.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/hazard/k8s/sea-level-rise/workflow.yaml
+++ b/catalog/hazard/k8s/sea-level-rise/workflow.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sea-level-rise-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting sea-level-rise workflow...\"\n\n# Step 0: Setup\
+          \ bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/sea-level-rise-setup-bucket.yaml -n biodiversity\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/sea-level-rise-setup-bucket -n biodiversity\n\n# Step\
+          \ 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/sea-level-rise-convert.yaml -n biodiversity\n\necho \"Waiting for\
+          \ GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/sea-level-rise-convert -n biodiversity\n\n# Step 2:\
+          \ Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/sea-level-rise-pmtiles.yaml -n biodiversity\n\
+          kubectl apply -f /yamls/sea-level-rise-hex.yaml -n biodiversity\n\necho\
+          \ \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/sea-level-rise-hex -n biodiversity\n\necho \"Step\
+          \ 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/sea-level-rise-repartition.yaml\
+          \ -n biodiversity\n\necho \"Waiting for repartition to complete...\"\nkubectl\
+          \ wait --for=condition=complete --timeout=3600s job/sea-level-rise-repartition\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs sea-level-rise-setup-bucket sea-level-rise-convert\
+          \ sea-level-rise-pmtiles sea-level-rise-hex sea-level-rise-repartition sea-level-rise-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap sea-level-rise-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: sea-level-rise-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Builds the **national NOAA Sea Level Rise** inundation dataset (5.0 ft ocean-connected scenario) into the `public-hazard` bucket. Closes #251.

## What
NOAA Office for Coastal Management SLR inundation, **5.0 ft scenario**, **all 28 coastal states/territories** (AL, AS, CA, CNMI, CT, DC, DE, FL, GA, Guam, HI, LA, MA, MD, ME, MS, NC, NH, NJ, NY, OR, PR, RI, SC, TX, USVI, VA, WA), merged to one dataset and reprojected to **OGC:CRS84**.

| Step | File |
|---|---|
| Per-state download (gpkg/gdb/shp) + extract `*_slr_5_0ft` + merge → GeoParquet | `sea-level-rise-preprocess.yaml` |
| PMTiles (source-layer `sea-level-rise`) | `sea-level-rise-pmtiles.yaml` |
| H3 hex (res 10, parent 9,8,0) | `sea-level-rise-hex.yaml` → `sea-level-rise-repartition.yaml` |
| setup-bucket / convert / workflow / rbac / configmap | (rest) |

## Deliverables (live on NRP `public-hazard`)
- `sea-level-rise.parquet` — **605,292 features, 28 states, 0 null geometry**, DuckDB-native, OGC:CRS84
- `sea-level-rise.pmtiles` — web tiles (generating; large national set)
- `sea-level-rise/hex/h0=*/data_0.parquet` — **~15.2M res-10 cells** across 10 h0 partitions
- STAC collection (license `public-domain`, asset-level `table:columns` + h3 resolutions) + README; registered under the `public-hazard` bucket collection + root catalog.

## Notes / lessons (worth a look)
- **Geometry-column gotcha:** `ogr2ogr -sql` with a restricted column list does **not** auto-carry a GeoPackage's named geometry column — it silently produced NULL geometry for GPKG-sourced states. Fixed by discovering the real geometry column via OGR's API and naming it explicitly. (Most NOAA gpkgs use `Shape`; some, e.g. FL_SW/FL_East_1, use `geom`.) Validated end-to-end: 0 null geometry, all 28 states present in the hex.
- **Cluster DNS:** external hosts fail to resolve on some nodes → `dnsConfig` public resolvers + `curl --retry-all-errors`.
- Per-feature columns on hex (`_cng_fid`, `state`, `region`, `slr_ft`) repeat per cell — estimate area via `COUNT(DISTINCT h10) × cell_area`, documented in the STAC.
