### PR TITLE
docs: surface weekly source-sync CronJob + Phase 2 + new-bucket flow in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ Key commands:
 
 ## Sync, Backup & Public Mirror
 
-NRP S3 is canonical. Two off-NRP destinations, both driven by per-bucket k8s Jobs under `catalog/sync/`:
+NRP S3 is canonical. Two off-NRP destinations, driven by k8s Jobs under `catalog/sync/`:
 
-| Destination | Purpose | Scope | Jobs |
+| Destination | Purpose | Scope | Mechanism |
 |---|---|---|---|
-| **MinIO** (`minio.carlboettiger.info`) | **private backup** of every public bucket (and the only off-NRP copy for license-restricted data) | all `public-*` | `catalog/sync/k8s/sync-public-*.yaml` |
-| **Source Cooperative** (`source.coop`) | **public mirror** for discoverability | catalogued **and** license-clear datasets only | `catalog/sync/k8s/source-sync-*.yaml` |
+| **MinIO** (`minio.carlboettiger.info`) | **private backup** of every public bucket (and the only off-NRP copy for license-restricted data) | all `public-*` | per-bucket Jobs `catalog/sync/k8s/sync-public-*.yaml` |
+| **Source Cooperative** (`source.coop`) | **public mirror** for discoverability | catalogued **and** license-clear datasets only | weekly **`source-sync` CronJob** (+ per-bucket `source-sync-*.yaml` for backfill) |
 
 ```bash
 # MinIO backup (private)
@@ -100,14 +100,17 @@ kubectl apply -f catalog/sync/k8s/                             # all
 
 # source.coop public mirror — see the campaign docs first (scope is license-gated)
 catalog/sync/source-coop/dry-run-local.sh census               # preview (no writes)
-catalog/sync/source-coop/run-source-sync.sh census             # one repo (sequential runner)
+catalog/sync/source-coop/run-source-sync.sh census             # one repo (manual/backfill)
+kubectl -n biodiversity create job --from=cronjob/source-sync source-sync-manual  # run the weekly job now
 
 kubectl get jobs | grep -E 'sync-public|source-sync'           # monitor
 ```
 
 Each job runs `rclone sync` with bandwidth throttling. When adding a new NRP bucket, add a MinIO sync job (see [AGENTS.md](AGENTS.md) Step 7).
 
-**source.coop mirror — read before touching it:** [`catalog/sync/source-coop/README.md`](catalog/sync/source-coop/README.md) is the campaign plan (scope policy, the add-a-repo loop, account-wide-credentials safety, phase-2 STAC). Scope is the `REPOS`/`EXCLUDES` arrays in `gen-source-sync.sh`; per-collection license verdicts are in `license-inventory.md`; repos still to create are in `new-repos.md`. Some datasets **cannot** be mirrored (license forbids redistribution — WDPA/IUCN/ICCA/HydroBASINS) and stay MinIO-only. Tracking + status: **issue #158**.
+**source.coop is a standing automated mirror, not a one-shot.** A weekly **`source-sync` CronJob** (Sundays 08:00 UTC, `catalog/sync/k8s/source-sync-cron.yaml`) re-syncs every in-scope repo and then re-applies the **Phase 2 STAC href-rewrite** (`rewrite-stac-hrefs.py`, which repoints mirrored STAC hrefs to `data.source.coop/…`; a plain sync would clobber it). It does **not** auto-discover new NRP buckets — scope is the generated `source-sync-scope` ConfigMap. **Adding a bucket** means following the *add-a-repo loop* in the campaign README, including **manually creating the `cboettig/<repo>` product in the source.coop web UI first** (the create API is disabled); a repo added to scope before its product exists fails its own sync *visibly* (continue-on-error) rather than auto-creating anything.
+
+**source.coop mirror — read before touching it:** [`catalog/sync/source-coop/README.md`](catalog/sync/source-coop/README.md) is the campaign plan (scope policy, the **add-a-repo loop**, the weekly CronJob, account-wide-credentials safety, the Phase 2 STAC rewrite). Scope is the `REPOS`/`MODE`/`EXCLUDES` arrays in `gen-source-sync.sh`; per-collection license verdicts are in `license-inventory.md`. Some datasets **cannot** be mirrored (license forbids redistribution — WDPA/IUCN/ICCA/HydroBASINS) and stay MinIO-only. Tracking + status: **issue #158**.
 
 ## Infrastructure
 


### PR DESCRIPTION
The top-level README's *Sync, Backup & Public Mirror* section predated the weekly CronJob (#258) and Phase 2 (#263) — it still framed source.coop as manual per-bucket jobs, so a reader skimming the top wouldn't learn the standing automated backup exists or how new buckets are handled.

This updates that section to note:
- the weekly **`source-sync` CronJob** (Sundays 08:00 UTC) that re-syncs + re-applies the Phase 2 STAC rewrite;
- that scope is the generated ConfigMap (**not** auto-discovered);
- that **adding a bucket requires manually creating the `cboettig/<repo>` product in the web UI first**, and a repo added to scope before its product exists fails its sync *visibly* (continue-on-error) — pointing at the campaign README's add-a-repo loop for the full procedure.

Docs-only; the detailed procedure already lives in `catalog/sync/source-coop/README.md` (one hop away). Closes the discoverability gap behind the question 'will this pick up new buckets / how is manual creation handled?'.