### PR TITLE
Add public-usgs-nhd bucket: NHD streams nationwide (by order + perennial) (#235)

### DIFF
--- a/catalog/sync/k8s/sync-public-usgs-nhd.yaml
+++ b/catalog/sync/k8s/sync-public-usgs-nhd.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-public-usgs-nhd
+  namespace: biodiversity
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              rclone mkdir "minio:public-usgs-nhd"
+              echo "Syncing: nrp:public-usgs-nhd -> minio:public-usgs-nhd"
+              rclone sync $RCLONE_FLAGS "nrp:public-usgs-nhd" "minio:public-usgs-nhd"
+              echo "Done: public-usgs-nhd"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-config

--- a/catalog/usgs-nhd/k8s/BUILD.md
+++ b/catalog/usgs-nhd/k8s/BUILD.md
@@ -1,0 +1,47 @@
+# USGS NHD streams — build notes (issue #235)
+
+New bucket `public-usgs-nhd`. Two datasets from the **same** source file
+(`NHD_H_National_GDB.zip`, USGS National High-Resolution seamless GDB, ~30 GB zipped):
+
+- **`streams-by-order`** — all 30,221,659 `NHDFlowline` features, with Strahler stream order
+  (`STREAMORDER`) + `STREAMLEVEL` joined from the bundled non-spatial table `NHDFlowlineVAA`
+  on `PERMANENT_IDENTIFIER`. **Stream order is NOT a native NHDFlowline attribute** — it lives in
+  the VAA table, so a join step is required (this is why the build is custom, not a plain
+  `cng-datasets workflow`). NHD only populates order for the connected network (~4.6M of 30.2M
+  flowlines); the rest are NULL.
+- **`perennial-streams`** — the 6,799,617 flowlines with `FCODE = 46006`
+  (Stream/River: Hydrographic Category = Perennial), confirmed against the `NHDFCode` domain.
+
+Geometry reprojected NAD83 (EPSG:4269) → **OGC:CRS84**; hexed to **H3 resolution 8**
+(lines buffered by the H3 cell circumradius before polyfill).
+
+## Actual build sequence (run manually, in order)
+
+1. **`stage-raw.yaml`** — download the 30 GB zip to the `rechunk-scratch` PVC (exceeds the 50Gi
+   ephemeral cap), archive the zip to `s3://public-usgs-nhd/raw/`, unzip the GDB onto the PVC.
+2. **`convert.yaml`** — `cng-convert-to-parquet` `NHDFlowline` → `nhdflowline.parquet` (OGC:CRS84;
+   auto-flattens the 3D-measured geometry); `ogr2ogr` `NHDFlowlineVAA` → `vaa.parquet`. Both
+   archived to `raw/`.
+3. **`derive.yaml`** — DuckDB over the internal S3 endpoint:
+   - `streams-by-order.parquet` = `nhdflowline` LEFT JOIN `vaa` on `PERMANENT_IDENTIFIER`
+     (VAA keys are unique → no fan-out).
+   - `perennial-streams.parquet` = `nhdflowline` WHERE `FCODE = 46006`.
+4. Bucket made public + CORS (`cng-datasets storage setup-bucket`, equivalently a public-read
+   policy + CORS).
+5. Per dataset: **`<ds>-hex.yaml`** (200 completions; chunk-size = ceil(features/200):
+   151200 for streams-by-order, 34000 for perennial) → **`<ds>-repartition.yaml`**, and
+   **`<ds>-pmtiles.yaml`**.
+
+The generated `<ds>-convert.yaml`, `<ds>-setup-bucket.yaml`, and `workflow.yaml` (orchestrator)
+are the standard `cng-datasets workflow` scaffolding; they are **superseded** by the custom
+`convert.yaml` + `derive.yaml` above (kept for reference only — do not run the orchestrator, it
+would skip the VAA join).
+
+## Notes / gotchas hit during the build
+
+- **`<ds>-hex-rechunk.yaml`** — on both hex runs, 3 indexed pods got stuck `Terminating` on a
+  preempted/lost node (output never written). The rechunk jobs reprocess just those chunk-ids
+  (CHUNK_MAP) into `chunks/` before repartition. Force-delete the stuck job, run the rechunk.
+- **`streams-by-order-pmtiles.yaml` uses the `rechunk-scratch` PVC** for its working dir + TMPDIR:
+  the 30M-feature GeoJSONL intermediate + tippecanoe temp tiles exceed the 50Gi ephemeral cap
+  (first attempt was evicted). Perennial PMTiles fit in ephemeral but the streams one does not.

--- a/catalog/usgs-nhd/k8s/convert.yaml
+++ b/catalog/usgs-nhd/k8s/convert.yaml
@@ -1,0 +1,93 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nhd-convert
+  labels:
+    k8s-app: nhd-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nhd-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /scratch/tmp
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /scratch
+          subPath: nhd-stage
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          mkdir -p /scratch/tmp
+          GDB=/scratch/NHD_H_National_GDB.gdb
+          echo "=== GDB layers present ==="
+          ogrinfo -so "$GDB" NHDFlowline 2>&1 | grep -i "Feature Count" || true
+
+          echo "=== [1/2] Convert NHDFlowline -> GeoParquet (reproject NAD83 -> OGC:CRS84) ==="
+          cng-convert-to-parquet "$GDB" /scratch/nhdflowline.parquet \
+            --layer NHDFlowline --target-crs OGC:CRS84 \
+            --compression ZSTD --compression-level 6 --row-group-size 100000 --no-progress
+          ls -lh /scratch/nhdflowline.parquet
+
+          echo "=== nhdflowline.parquet schema (so we know the geometry column name) ==="
+          python3 -c "import duckdb; c=duckdb.connect(); print(c.execute(\"DESCRIBE SELECT * FROM read_parquet('/scratch/nhdflowline.parquet')\").fetchdf().to_string())"
+
+          echo "=== [2/2] Convert NHDFlowlineVAA -> parquet (non-spatial: stream order) ==="
+          ogr2ogr -f Parquet /scratch/vaa.parquet "$GDB" NHDFlowlineVAA \
+            -select "PERMANENT_IDENTIFIER,STREAMORDER,STREAMLEVEL"
+          ls -lh /scratch/vaa.parquet
+          echo "=== vaa.parquet schema ==="
+          python3 -c "import duckdb; c=duckdb.connect(); print(c.execute(\"DESCRIBE SELECT * FROM read_parquet('/scratch/vaa.parquet')\").fetchdf().to_string())"
+          python3 -c "import duckdb; c=duckdb.connect(); print(c.execute('SELECT COUNT(*) n, COUNT(DISTINCT \"PERMANENT_IDENTIFIER\") d FROM read_parquet(%r)' % '/scratch/vaa.parquet').fetchdf().to_string())"
+
+          echo "=== Archive intermediates to s3://public-usgs-nhd/raw/ ==="
+          rclone copy /scratch/nhdflowline.parquet nrp:public-usgs-nhd/raw/ -P --s3-chunk-size 256M
+          rclone copy /scratch/vaa.parquet nrp:public-usgs-nhd/raw/ -P --s3-chunk-size 256M
+          echo "CONVERT DONE"
+        resources:
+          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '8', memory: 64Gi, ephemeral-storage: 10Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      - name: scratch
+        persistentVolumeClaim: {claimName: rechunk-scratch}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/usgs-nhd/k8s/derive.yaml
+++ b/catalog/usgs-nhd/k8s/derive.yaml
@@ -1,0 +1,96 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nhd-derive
+  labels:
+    k8s-app: nhd-derive
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nhd-derive
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: derive
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: scratch
+          mountPath: /scratch
+          subPath: nhd-stage
+        command:
+        - python3
+        - -c
+        - |
+          import os, duckdb
+          con = duckdb.connect()
+          con.execute("INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;")
+          con.execute("SET s3_endpoint='rook-ceph-rgw-nautiluss3.rook';")
+          con.execute("SET s3_use_ssl=false; SET s3_url_style='path';")
+          con.execute("SET s3_access_key_id='%s';" % os.environ['AWS_ACCESS_KEY_ID'])
+          con.execute("SET s3_secret_access_key='%s';" % os.environ['AWS_SECRET_ACCESS_KEY'])
+          con.execute("SET memory_limit='100GB'; SET threads=8;")
+          con.execute("SET temp_directory='/scratch/tmp_derive'; SET preserve_insertion_order=false;")
+
+          FL = "/scratch/nhdflowline.parquet"
+          VAA = "/scratch/vaa.parquet"
+
+          n_fl = con.execute(f"SELECT COUNT(*) FROM read_parquet('{FL}')").fetchone()[0]
+          print(f"flowlines: {n_fl:,}", flush=True)
+
+          print("=== streams-by-order: LEFT JOIN VAA stream order ===", flush=True)
+          con.execute(f"""
+            COPY (
+              SELECT f.*, v.STREAMORDER, v.STREAMLEVEL
+              FROM read_parquet('{FL}') f
+              LEFT JOIN read_parquet('{VAA}') v
+                ON f.PERMANENT_IDENTIFIER = v.PERMANENT_IDENTIFIER
+            ) TO 's3://public-usgs-nhd/streams-by-order.parquet'
+            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000);
+          """)
+          print("wrote streams-by-order.parquet", flush=True)
+
+          print("=== perennial-streams: WHERE FCODE = 46006 ===", flush=True)
+          n_per = con.execute(f"SELECT COUNT(*) FROM read_parquet('{FL}') WHERE FCODE = 46006").fetchone()[0]
+          print(f"perennial (FCODE=46006): {n_per:,}", flush=True)
+          con.execute(f"""
+            COPY (
+              SELECT * FROM read_parquet('{FL}') WHERE FCODE = 46006
+            ) TO 's3://public-usgs-nhd/perennial-streams.parquet'
+            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000);
+          """)
+          print("wrote perennial-streams.parquet", flush=True)
+          print("DERIVE DONE", flush=True)
+        resources:
+          requests: {cpu: '8', memory: 100Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '8', memory: 100Gi, ephemeral-storage: 10Gi}
+      volumes:
+      - name: scratch
+        persistentVolumeClaim: {claimName: rechunk-scratch}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/usgs-nhd/k8s/perennial-streams/configmap.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: perennial-streams-setup-bucket.yaml, perennial-streams-convert.yaml, perennial-streams-pmtiles.yaml, perennial-streams-hex.yaml, perennial-streams-repartition.yaml
+# Generation command: cng-datasets workflow --dataset perennial-streams --source-url s3://public-usgs-nhd/perennial-streams.parquet --bucket public-usgs-nhd --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap perennial-streams-yamls \
+#     --from-file=perennial-streams-setup-bucket.yaml \
+#     --from-file=perennial-streams-convert.yaml \
+#     --from-file=perennial-streams-pmtiles.yaml \
+#     --from-file=perennial-streams-hex.yaml \
+#     --from-file=perennial-streams-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  perennial-streams-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: perennial-streams-convert
+      labels:
+        k8s-app: perennial-streams-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: perennial-streams-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-usgs-nhd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-usgs-nhd/perennial-streams.parquet \
+                s3://public-usgs-nhd/perennial-streams.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  perennial-streams-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: perennial-streams-hex
+      labels:
+        k8s-app: perennial-streams-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: perennial-streams-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usgs-nhd
+            - name: DATASET
+              value: perennial-streams
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-usgs-nhd/perennial-streams.parquet --output s3://public-usgs-nhd/perennial-streams/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  perennial-streams-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: perennial-streams-pmtiles
+      labels:
+        k8s-app: perennial-streams-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: perennial-streams-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usgs-nhd
+            - name: DATASET
+              value: perennial-streams
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usgs-nhd/perennial-streams.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-usgs-nhd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  perennial-streams-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: perennial-streams-repartition
+      labels:
+        k8s-app: perennial-streams-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: perennial-streams-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usgs-nhd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-usgs-nhd/perennial-streams/chunks --output-dir s3://public-usgs-nhd/perennial-streams/hex --source-parquet s3://public-usgs-nhd/perennial-streams.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  perennial-streams-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: perennial-streams-setup-bucket
+      labels:
+        k8s-app: perennial-streams-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: perennial-streams-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-usgs-nhd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: perennial-streams-yamls
+  namespace: biodiversity

--- a/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-convert.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-convert
+  labels:
+    k8s-app: perennial-streams-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: perennial-streams-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-usgs-nhd/perennial-streams.parquet \
+            s3://public-usgs-nhd/perennial-streams.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-hex-rechunk.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-hex-rechunk.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-hex-rechunk
+  labels:
+    k8s-app: perennial-streams-hex-rechunk
+spec:
+  completions: 3
+  parallelism: 3
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: perennial-streams-hex-rechunk
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        - name: DATASET
+          value: perennial-streams
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(3 30 36)
+          CID=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "Reprocessing chunk-id $CID"
+          cng-datasets vector --input s3://public-usgs-nhd/perennial-streams.parquet --output s3://public-usgs-nhd/perennial-streams/chunks --chunk-id $CID --chunk-size 34000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-hex.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-hex
+  labels:
+    k8s-app: perennial-streams-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: perennial-streams-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        - name: DATASET
+          value: perennial-streams
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-usgs-nhd/perennial-streams.parquet --output s3://public-usgs-nhd/perennial-streams/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 34000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-pmtiles.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-pmtiles
+  labels:
+    k8s-app: perennial-streams-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: perennial-streams-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        - name: DATASET
+          value: perennial-streams
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usgs-nhd/perennial-streams.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-usgs-nhd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-repartition.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-repartition
+  labels:
+    k8s-app: perennial-streams-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: perennial-streams-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-usgs-nhd/perennial-streams/chunks --output-dir s3://public-usgs-nhd/perennial-streams/hex --source-parquet s3://public-usgs-nhd/perennial-streams.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-setup-bucket.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/perennial-streams-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-setup-bucket
+  labels:
+    k8s-app: perennial-streams-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: perennial-streams-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/perennial-streams/workflow-rbac.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/usgs-nhd/k8s/perennial-streams/workflow.yaml
+++ b/catalog/usgs-nhd/k8s/perennial-streams/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: perennial-streams-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting perennial-streams workflow...\"\n\n# Step 0:\
+          \ Setup bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/perennial-streams-setup-bucket.yaml -n biodiversity\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/perennial-streams-setup-bucket -n biodiversity\n\n\
+          # Step 1: Convert to optimized GeoParquet (needed by both pmtiles and hex\
+          \ jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\nkubectl\
+          \ apply -f /yamls/perennial-streams-convert.yaml -n biodiversity\n\necho\
+          \ \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/perennial-streams-convert -n biodiversity\n\n# Step\
+          \ 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/perennial-streams-pmtiles.yaml -n biodiversity\n\
+          kubectl apply -f /yamls/perennial-streams-hex.yaml -n biodiversity\n\necho\
+          \ \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/perennial-streams-hex -n biodiversity\n\necho \"\
+          Step 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/perennial-streams-repartition.yaml\
+          \ -n biodiversity\n\necho \"Waiting for repartition to complete...\"\nkubectl\
+          \ wait --for=condition=complete --timeout=3600s job/perennial-streams-repartition\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs perennial-streams-setup-bucket\
+          \ perennial-streams-convert perennial-streams-pmtiles perennial-streams-hex\
+          \ perennial-streams-repartition perennial-streams-workflow -n biodiversity\"\
+          \necho \"  kubectl delete configmap perennial-streams-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: perennial-streams-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/usgs-nhd/k8s/stage-raw.yaml
+++ b/catalog/usgs-nhd/k8s/stage-raw.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nhd-stage-raw
+  labels:
+    k8s-app: nhd-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nhd-stage-raw
+    spec:
+      restartPolicy: Never
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+        - 9.9.9.9
+      dnsPolicy: None
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: SOURCE_URL
+          value: https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHD/National/GDB/NHD_H_National_GDB.zip
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /scratch
+          subPath: nhd-stage
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          cd /scratch
+          echo "=== Downloading national GDB zip (~30 GB) to PVC ==="
+          curl -L --retry 8 --retry-delay 15 --retry-all-errors -C - \
+            -o NHD_H_National_GDB.zip "$SOURCE_URL"
+          ls -lh NHD_H_National_GDB.zip
+          echo "=== Archiving raw zip to s3://public-usgs-nhd/raw/ ==="
+          rclone copy NHD_H_National_GDB.zip nrp:public-usgs-nhd/raw/ -P --transfers 8 --s3-chunk-size 256M
+          echo "=== Unzipping GDB onto PVC ==="
+          rm -rf gdb_unzip && mkdir -p gdb_unzip
+          unzip -q -o NHD_H_National_GDB.zip -d gdb_unzip
+          GDB=$(find gdb_unzip -maxdepth 2 -name '*.gdb' -type d | head -1)
+          echo "Found GDB: $GDB"
+          du -sh "$GDB"
+          # Persist the unzipped GDB at a stable path for downstream convert jobs
+          rm -rf /scratch/NHD_H_National_GDB.gdb
+          mv "$GDB" /scratch/NHD_H_National_GDB.gdb
+          echo "=== GDB ready at PVC subPath nhd-stage/NHD_H_National_GDB.gdb ==="
+          ogrinfo -so /scratch/NHD_H_National_GDB.gdb NHDFlowline 2>&1 | grep -i "Feature Count" || true
+          rm -f NHD_H_National_GDB.zip
+          echo "DONE"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/configmap.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: streams-by-order-setup-bucket.yaml, streams-by-order-convert.yaml, streams-by-order-pmtiles.yaml, streams-by-order-hex.yaml, streams-by-order-repartition.yaml
+# Generation command: cng-datasets workflow --dataset streams-by-order --source-url s3://public-usgs-nhd/streams-by-order.parquet --bucket public-usgs-nhd --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap streams-by-order-yamls \
+#     --from-file=streams-by-order-setup-bucket.yaml \
+#     --from-file=streams-by-order-convert.yaml \
+#     --from-file=streams-by-order-pmtiles.yaml \
+#     --from-file=streams-by-order-hex.yaml \
+#     --from-file=streams-by-order-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  streams-by-order-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: streams-by-order-convert
+      labels:
+        k8s-app: streams-by-order-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: streams-by-order-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-usgs-nhd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-usgs-nhd/streams-by-order.parquet \
+                s3://public-usgs-nhd/streams-by-order.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  streams-by-order-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: streams-by-order-hex
+      labels:
+        k8s-app: streams-by-order-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: streams-by-order-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usgs-nhd
+            - name: DATASET
+              value: streams-by-order
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-usgs-nhd/streams-by-order.parquet --output s3://public-usgs-nhd/streams-by-order/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  streams-by-order-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: streams-by-order-pmtiles
+      labels:
+        k8s-app: streams-by-order-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: streams-by-order-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usgs-nhd
+            - name: DATASET
+              value: streams-by-order
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usgs-nhd/streams-by-order.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-usgs-nhd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  streams-by-order-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: streams-by-order-repartition
+      labels:
+        k8s-app: streams-by-order-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: streams-by-order-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usgs-nhd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-usgs-nhd/streams-by-order/chunks --output-dir s3://public-usgs-nhd/streams-by-order/hex --source-parquet s3://public-usgs-nhd/streams-by-order.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  streams-by-order-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: streams-by-order-setup-bucket
+      labels:
+        k8s-app: streams-by-order-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: streams-by-order-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-usgs-nhd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: streams-by-order-yamls
+  namespace: biodiversity

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-convert.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-convert
+  labels:
+    k8s-app: streams-by-order-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: streams-by-order-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-usgs-nhd/streams-by-order.parquet \
+            s3://public-usgs-nhd/streams-by-order.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-hex-rechunk.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-hex-rechunk.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-hex-rechunk
+  labels:
+    k8s-app: streams-by-order-hex-rechunk
+spec:
+  completions: 3
+  parallelism: 3
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: streams-by-order-hex-rechunk
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        - name: DATASET
+          value: streams-by-order
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(2 9 37)
+          CID=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "Reprocessing chunk-id $CID"
+          cng-datasets vector --input s3://public-usgs-nhd/streams-by-order.parquet --output s3://public-usgs-nhd/streams-by-order/chunks --chunk-id $CID --chunk-size 151200 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-hex.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-hex
+  labels:
+    k8s-app: streams-by-order-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: streams-by-order-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        - name: DATASET
+          value: streams-by-order
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-usgs-nhd/streams-by-order.parquet --output s3://public-usgs-nhd/streams-by-order/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 151200 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-pmtiles.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-pmtiles.yaml
@@ -59,9 +59,15 @@ spec:
         - |
           set -e
           mkdir -p /scratch/tmp
-          # Use optimized GeoParquet (has ID column) from convert job
-          # GDAL can read parquet via vsicurl
-          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /scratch/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usgs-nhd/streams-by-order.parquet -progress
+          # tippecanoe opens many temp files for a 30M-feature input; the default soft
+          # fd limit (1024) triggers "Too many open files". Raise to the hard max.
+          ulimit -n "$(ulimit -Hn)" || true
+          echo "open-files limit now: $(ulimit -n)"
+          # Use optimized GeoParquet (has ID column) from convert job. Reuse an existing
+          # complete GeoJSONL on the PVC to avoid re-exporting on retries.
+          if [ ! -s /scratch/$DATASET.geojsonl ]; then
+            ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /scratch/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usgs-nhd/streams-by-order.parquet -progress
+          fi
 
           # Generate PMTiles from GeoJSONSeq
           # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
@@ -72,7 +78,11 @@ spec:
           # environment, not the shell. A plain assignment is invisible to it, so it
           # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
           export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
-          tippecanoe -o /scratch/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /scratch/$DATASET.geojsonl
+          # 30M line features make z13-14 tiles pathologically dense (tippecanoe stalls for
+          # hours on single tiles and the file balloons to >20GB). Cap maxzoom at 12 — a
+          # national stream-network overview layer; street-level detail is served by the hex
+          # and GeoParquet assets, not vector tiles. (extend-zooms removed for the same reason.)
+          tippecanoe -o /scratch/$DATASET.pmtiles -l $DATASET -z12 --drop-densest-as-needed --force /scratch/$DATASET.geojsonl
 
           # Upload to S3 using rclone
           rclone copy /scratch/$DATASET.pmtiles nrp:public-usgs-nhd/

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-pmtiles.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-pmtiles.yaml
@@ -78,11 +78,13 @@ spec:
           # environment, not the shell. A plain assignment is invisible to it, so it
           # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
           export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
-          # 30M line features make z13-14 tiles pathologically dense (tippecanoe stalls for
-          # hours on single tiles and the file balloons to >20GB). Cap maxzoom at 12 — a
-          # national stream-network overview layer; street-level detail is served by the hex
-          # and GeoParquet assets, not vector tiles. (extend-zooms removed for the same reason.)
-          tippecanoe -o /scratch/$DATASET.pmtiles -l $DATASET -z12 --drop-densest-as-needed --force /scratch/$DATASET.geojsonl
+          # 30M line features make z11+ tiles pathologically dense: tippecanoe's iterative
+          # --drop-densest fit stalls for hours on single tiles (z14 ballooned to 22GB; z12
+          # stalled at 99.9% on dense tiles). Cap maxzoom at 10 — a national stream-network
+          # overview layer that tiles reliably; street-level detail is served by the H3 hex
+          # and GeoParquet assets, not vector tiles. --simplification thins dense line
+          # vertices to keep tiles small and fast.
+          tippecanoe -o /scratch/$DATASET.pmtiles -l $DATASET -z10 --drop-densest-as-needed --simplification 10 --force /scratch/$DATASET.geojsonl
 
           # Upload to S3 using rclone
           rclone copy /scratch/$DATASET.pmtiles nrp:public-usgs-nhd/

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-pmtiles.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-pmtiles.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-pmtiles
+  labels:
+    k8s-app: streams-by-order-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: streams-by-order-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        # 30M-feature GeoJSONL + tippecanoe temp tiles exceed the 50Gi ephemeral cap,
+        # so the whole working dir + TMPDIR live on the shared scratch PVC.
+        - name: TMPDIR
+          value: /scratch/tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        - name: DATASET
+          value: streams-by-order
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /scratch
+          subPath: nhd-pmtiles-streams
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          mkdir -p /scratch/tmp
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /scratch/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usgs-nhd/streams-by-order.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /scratch/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /scratch/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /scratch/$DATASET.pmtiles nrp:public-usgs-nhd/
+          rm -f /scratch/$DATASET.geojsonl /scratch/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-repartition.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-repartition
+  labels:
+    k8s-app: streams-by-order-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: streams-by-order-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-usgs-nhd/streams-by-order/chunks --output-dir s3://public-usgs-nhd/streams-by-order/hex --source-parquet s3://public-usgs-nhd/streams-by-order.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-setup-bucket.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/streams-by-order-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-setup-bucket
+  labels:
+    k8s-app: streams-by-order-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: streams-by-order-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usgs-nhd/k8s/streams-by-order/workflow-rbac.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/usgs-nhd/k8s/streams-by-order/workflow.yaml
+++ b/catalog/usgs-nhd/k8s/streams-by-order/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: streams-by-order-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting streams-by-order workflow...\"\n\n# Step 0:\
+          \ Setup bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/streams-by-order-setup-bucket.yaml -n biodiversity\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/streams-by-order-setup-bucket -n biodiversity\n\n#\
+          \ Step 1: Convert to optimized GeoParquet (needed by both pmtiles and hex\
+          \ jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\nkubectl\
+          \ apply -f /yamls/streams-by-order-convert.yaml -n biodiversity\n\necho\
+          \ \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/streams-by-order-convert -n biodiversity\n\n# Step\
+          \ 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/streams-by-order-pmtiles.yaml -n biodiversity\n\
+          kubectl apply -f /yamls/streams-by-order-hex.yaml -n biodiversity\n\necho\
+          \ \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/streams-by-order-hex -n biodiversity\n\necho \"\
+          Step 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/streams-by-order-repartition.yaml\
+          \ -n biodiversity\n\necho \"Waiting for repartition to complete...\"\nkubectl\
+          \ wait --for=condition=complete --timeout=3600s job/streams-by-order-repartition\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs streams-by-order-setup-bucket\
+          \ streams-by-order-convert streams-by-order-pmtiles streams-by-order-hex\
+          \ streams-by-order-repartition streams-by-order-workflow -n biodiversity\"\
+          \necho \"  kubectl delete configmap streams-by-order-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: streams-by-order-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #235.

New bucket **`public-usgs-nhd`** — nationwide USGS NHD (High Resolution) stream network as cloud-native vector data. Both layers derive from the **same** source file `NHD_H_National_GDB.zip` (national seamless GDB, ~30 GB zipped).

## What's delivered

| Dataset | Features | Notes |
|---|---|---|
| `streams-by-order` | 30,221,659 | all `NHDFlowline`, with Strahler `STREAMORDER` + `STREAMLEVEL` joined from `NHDFlowlineVAA` |
| `perennial-streams` | 6,799,617 | `NHDFlowline` filtered to `FCODE = 46006` (perennial) |

Each: DuckDB-native **GeoParquet** + **PMTiles** + **H3 res-8 hex** (`…/hex/h0=*/data_0.parquet`), **OGC:CRS84**, license `public-domain`.

## Scope clarification (recorded on the issue)

Stream order is **not** a native `NHDFlowline` attribute — verified against the source GDB. It lives in the bundled non-spatial `NHDFlowlineVAA` table, so `streams-by-order` required a **join** on `PERMANENT_IDENTIFIER` (not the plain `cng-datasets workflow` in the original build sketch). NHD only computes order for the connected drainage network, so it is populated for ~4.6M of 30.2M flowlines and **NULL** elsewhere (clean Strahler 1–10 distribution; rare anomalous source values >10 documented in STAC). `FCODE = 46006` = perennial confirmed against the `NHDFCode` domain. The issue's "armada `--chunk-size 1`, `--max-completions = feature count`" was infeasible at 30M features; flowlines are uniform-size, so moderate chunking (200 completions, chunk-size = ceil(features/200)) was used instead.

## Validation (duckdb-geo MCP)

- `streams-by-order` hex: all 30,221,659 features present, 45.9M rows (1.52 cells/feature — no seam bloat), spans the antimeridian (Alaska), `streamorder` carried through.
- `perennial-streams` hex: all 6,799,617 features present, 10.4M rows, **0 non-perennial rows** (filter correct), spans the antimeridian.
- Geometry is DuckDB-native GeoParquet (queryable via MCP; no geopandas `stoi` crash).

## Catalog / publishing

- STAC bucket collection + 2 sub-collections (asset keys `streams-by-order-*` / `perennial-streams-*`, asset-level `table:columns` with FCODE/FType/stream-order value docs and hex dedup recipes) + README published to NRP S3; bucket registered as a child of the root catalog.
- MinIO sync job `catalog/sync/k8s/sync-public-usgs-nhd.yaml` added.
- source.coop eligible (public-domain) — follow-up per #158.

## Build notes

See `catalog/usgs-nhd/k8s/BUILD.md` for the exact (custom) sequence: stage-raw → convert → derive → hex (+rechunk for 3 preempted chunks per dataset) → repartition → pmtiles. The generated `*-convert.yaml` / `workflow.yaml` orchestrator scaffolding is kept for reference but superseded by `convert.yaml` + `derive.yaml` (which perform the VAA join).

⚠️ **In-flight:** `streams-by-order.pmtiles` is re-encoding (first run was evicted on the 50Gi ephemeral cap; re-running with the working dir on the `rechunk-scratch` PVC). It lands at `s3://public-usgs-nhd/streams-by-order.pmtiles` (the path already referenced by STAC). Everything else (parquet, hex, perennial pmtiles) is live.

Downstream ca-30x30 app integration (issue checklist) is a separate repo and gated on this STAC being live — not included here.
