### PR TITLE
Add PreToolUse safety hook + shared Claude guardrails (hardening step 1)

### DIFF
--- a/.claude/hooks/guard-destructive.py
+++ b/.claude/hooks/guard-destructive.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+PreToolUse safety guard — Claude Code, boettiger-lab/data-workflows.
+
+Blocks (exit 2) destructive Bash commands that target RECOVERY COPIES (the MinIO
+backup / source.coop mirror) or are catastrophic at the cluster/bucket level.
+This is the bypass-proof backstop for running Claude in
+--dangerously-skip-permissions (YOLO): PreToolUse hooks still fire and can block
+even when permission prompts are skipped.
+
+SCOPE / LIMITS: this matches command-STRING patterns. It reliably stops
+ACCIDENTS; it is NOT a boundary against obfuscation (base64, indirection,
+wrapper scripts). The real boundary is credential + namespace isolation — see
+boettiger-lab/geo-agent-ops/DATA_WORKFLOWS_HARDENING.md. Keep both layers.
+
+Deliberately does NOT block normal workflow ops: kubectl delete job / -f,
+rclone purge/delete on an nrp: SUBPATH (staging), rclone copy/ls/sync FROM a
+backup, aws s3 rm of a single key, rm -rf under /tmp.
+"""
+import json
+import re
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+if data.get("tool_name") != "Bash":
+    sys.exit(0)
+
+cmd = (data.get("tool_input") or {}).get("command") or ""
+if not cmd.strip():
+    sys.exit(0)
+
+
+def has(pattern):
+    return re.search(pattern, cmd, re.IGNORECASE)
+
+
+def block(reason):
+    sys.stderr.write(
+        "BLOCKED by data-workflows safety hook: %s.\n"
+        "Protects recovery copies / cluster from accidental destruction "
+        "(geo-agent-ops/DATA_WORKFLOWS_HARDENING.md).\n"
+        "If intentional, run it directly in a terminal outside Claude.\n" % reason
+    )
+    sys.exit(2)
+
+
+# --- Backup / mirror destruction (the recovery copies) ---
+if has(r"\brclone\s+(purge|delete|deletefile|rmdir|rmdirs)\b.*\b(minio:|source:|opendata\.source\.coop)"):
+    block("rclone destructive op against the MinIO backup / source.coop mirror")
+if has(r"\brclone\s+sync\b.*\b(minio:|source:|opendata\.source\.coop)"):
+    block("rclone sync targeting the MinIO backup / source.coop mirror (mirrors deletes)")
+
+# --- Wiping an ENTIRE canonical NRP bucket (staging subpaths are allowed) ---
+if has(r"""\brclone\s+(purge|delete|rmdirs?)\s+["']?nrp:[A-Za-z0-9._-]+["']?(\s|;|&|\||$)"""):
+    block("rclone purge/delete of a whole nrp: bucket root (use a subpath for staging)")
+
+# --- S3 bucket-level destruction on ANY endpoint ---
+if has(r"\baws\s+s3\s+rb\b"):
+    block("aws s3 rb (remove bucket)")
+if has(r"\baws\s+s3api\s+delete-bucket\b"):
+    block("aws s3api delete-bucket")
+if has(r"\baws\s+s3\s+rm\b.*--recursive"):
+    block("aws s3 rm --recursive (mass delete)")
+if has(r"\bmc\s+rb\b"):
+    block("mc rb (remove bucket)")
+if has(r"\bmc\s+rm\b.*(--recursive|--force|\s-r\b)"):
+    block("mc rm --recursive/--force (mass delete)")
+
+# --- Catastrophic kubernetes ops (normal `delete job` / `delete -f` allowed) ---
+if has(r"\bkubectl\b.*\bdelete\b"):
+    if has(r"\bdelete\s+(ns|namespaces?)\b"):
+        block("kubectl delete namespace")
+    if has(r"\bdelete\s+(pvc|persistentvolumeclaims?|pv|persistentvolumes?)\b"):
+        block("kubectl delete of a PVC/PV (data loss)")
+    if has(r"(-n|--namespace)[=\s]+(rook|kube-system|boettiger-lab)\b"):
+        block("kubectl delete in a protected namespace (rook / kube-system / boettiger-lab)")
+    if has(r"\bdelete\b.*--all\b"):
+        block("kubectl delete --all (mass delete)")
+
+# --- Filesystem catastrophe (belt-and-suspenders; Claude has a built-in guard too) ---
+if has(r"""\brm\s+-[A-Za-z]*(rf|fr)[A-Za-z]*\s+["']?(/|~|\$HOME)["']?(\s|;|&|\||$)"""):
+    block("rm -rf of / or $HOME")
+
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-destructive.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,12 @@ Thumbs.db
 *~
 .idea/
 .vscode/
-.claude/
+# Claude Code: share guardrails (settings.json + hooks/), keep the rest local
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+# git worktrees (relocated out of .claude/)
+.worktrees/
 # Private datasets — keep off public GitHub
 catalog/wyoming/
 **/*.min..css


### PR DESCRIPTION
## Step 1 of the security-hardening plan

Tracking doc: `boettiger-lab/geo-agent-ops/DATA_WORKFLOWS_HARDENING.md`.

The goal is to make it safe to run Claude Code in `--dangerously-skip-permissions`
(YOLO) mode. In that mode Claude's own allow/deny rules are skipped — but
**PreToolUse hooks still fire and can block (`exit 2`)**, so a hook is the
bypass-proof backstop.

### What this adds

**`.claude/hooks/guard-destructive.py`** — a PreToolUse hook (matcher `Bash`)
that hard-blocks destructive commands aimed at our **recovery copies** or that
are **catastrophic at the cluster/bucket level**:

- `rclone purge|delete|sync` against the MinIO backup (`minio:`) or source.coop
  mirror (`source:` / `opendata.source.coop`)
- `rclone purge|delete` of a whole `nrp:` **bucket root** (staging subpaths stay
  allowed)
- bucket removal on any endpoint: `aws s3 rb`, `aws s3api delete-bucket`,
  `aws s3 rm --recursive`, `mc rb`, `mc rm --recursive/--force`
- `kubectl delete namespace`, `kubectl delete pvc/pv`, deletes in protected
  namespaces (`rook` / `kube-system` / `boettiger-lab`), `kubectl delete --all`
- `rm -rf /` or `$HOME`

**Deliberately still allowed** (normal workflow): `kubectl delete job …`,
`kubectl delete -f ….yaml`, `rclone purge nrp:<bucket>/<dataset>/staging`,
`rclone copy/ls`, `aws s3 rm <single-key>`, `rm -rf /tmp/…`.

A 27-case block/allow test suite passes (17 block, 10 allow), including the
order-independent kubectl checks and the staging-subpath vs bucket-root
distinction.

### Repo-structure changes

- **`.gitignore`**: stop ignoring all of `.claude/`. Commit `settings.json` +
  `hooks/` as **shared team guardrails** so they travel on clone and into every
  worktree; keep `settings.local.json` ignored. **Permission *grants*
  (allow-rules) stay local — only guardrails are shared.** The secret-read
  allow-rules previously in `settings.json` were moved to local settings.
- **Worktrees** relocated out of `.claude/worktrees/` to top-level
  `.worktrees/` (now ignored), so `.claude/` can be committed config.

### Known limitation

The hook matches command **strings**, so it reliably stops *accidents* but is
**not** a boundary against obfuscation (base64, indirection, wrapper scripts) —
and it will occasionally false-positive when a command merely *mentions* a
blocked token (e.g. a commit message describing the hook). The real boundary is
credential + namespace isolation (later steps in the plan). Keep both layers.
