### PR TITLE
guard hook: cover mc and rc (rustfs) clients

### DIFF
--- a/.claude/hooks/guard-destructive.py
+++ b/.claude/hooks/guard-destructive.py
@@ -65,10 +65,13 @@ if has(r"\baws\s+s3api\s+delete-bucket\b"):
     block("aws s3api delete-bucket")
 if has(r"\baws\s+s3\s+rm\b.*--recursive"):
     block("aws s3 rm --recursive (mass delete)")
-if has(r"\bmc\s+rb\b"):
-    block("mc rb (remove bucket)")
-if has(r"\bmc\s+rm\b.*(--recursive|--force|\s-r\b)"):
-    block("mc rm --recursive/--force (mass delete)")
+# MinIO/rustfs client: `mc` and `rc` (rustfs's drop-in for mc — same verbs).
+if has(r"\b(mc|rc)\s+rb\b"):
+    block("mc/rc rb (remove bucket)")
+if has(r"\b(mc|rc)\s+rm\b.*(--recursive|--force|\s-r\b)"):
+    block("mc/rc rm --recursive/--force (mass delete)")
+if has(r"\b(mc|rc)\s+mirror\b.*(--remove|--overwrite)"):
+    block("mc/rc mirror --remove/--overwrite (destructive mirror)")
 
 # --- Catastrophic kubernetes ops (normal `delete job` / `delete -f` allowed) ---
 if has(r"\bkubectl\b.*\bdelete\b"):


### PR DESCRIPTION
Extends the PreToolUse guard (from #266) beyond `rclone` to the **MinIO client
`mc`** and **`rc`** (rustfs's drop-in for `mc`, same verbs). `mc`/`rc` are the
*natural* tools for the MinIO/rustfs side, so they were a gap.

Now blocked (for both `mc` and `rc`):
- `rb` — remove bucket
- `rm --recursive` / `--force` / `-r` — mass object delete
- `mirror --remove` / `--overwrite` — the destructive equivalent of `sync`

Still allowed (false-positive guards in the test suite): `mc ls`, `rc ls`,
additive `mc mirror` (no `--remove`), and `rclone rc …` (rclone's remote-control
subcommand, e.g. `core/stats`).

27→32 case test suite passes.

**Caveat (unchanged):** per-tool string-matching is a backstop against
*accidents*, not a boundary — `boto3`, raw S3 API curl, etc. aren't covered. The
durable, tool-agnostic boundary is the scoped backup credential (a key that
can't list/delete the backup makes every tool fail equally), tracked in
geo-agent-ops/MINIO_AUDIT.md.
