### PR TITLE
Import: ca-climate-zones — Ackerly/Kling 10-class CA climate zones (#268)

### DIFF
--- a/catalog/ca30x30/k8s/climate-zones-kling/ca-climate-zones-hex.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/ca-climate-zones-hex.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ca-climate-zones-hex
+  labels:
+    k8s-app: ca-climate-zones-hex
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ca-climate-zones-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-ca30x30
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/clusters_10.tif" --output-parquet s3://public-ca30x30/ca-climate-zones/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column zone --hex-resampling mode
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/ca30x30/k8s/climate-zones-kling/ca-climate-zones-setup-bucket.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/ca-climate-zones-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ca-climate-zones-setup-bucket
+  labels:
+    k8s-app: ca-climate-zones-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ca-climate-zones-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-ca30x30
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/ca30x30/k8s/climate-zones-kling/configmap.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/configmap.yaml
@@ -1,5 +1,5 @@
 # Auto-generated ConfigMap for raster workflow
-# Generation command: cng-datasets raster-workflow --dataset ca-climate-zones --source-url "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/clusters_10.tif" --bucket public-ca30x30 --h3-resolution 8 --parent-resolutions "0"
+# Generation command: cng-datasets raster-workflow --dataset ca-climate-zones --source-url "https://s3-west.nrp-nautilus.io/public-ca30x30/ca-climate-zones-cog.tif" --bucket public-ca30x30 --h3-resolution 8 --parent-resolutions "0"
 apiVersion: v1
 data:
   ca-climate-zones-hex.yaml: |
@@ -65,7 +65,7 @@ data:
             - |-
               set -e
 
-              cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/clusters_10.tif" --output-parquet s3://public-ca30x30/ca-climate-zones/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column zone --hex-resampling mode
+              cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-ca30x30/ca-climate-zones-cog.tif" --output-parquet s3://public-ca30x30/ca-climate-zones/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column zone --hex-resampling mode
             resources:
               requests:
                 cpu: '4'

--- a/catalog/ca30x30/k8s/climate-zones-kling/configmap.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset ca-climate-zones --source-url "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/clusters_10.tif" --bucket public-ca30x30 --h3-resolution 8 --parent-resolutions "0"
+apiVersion: v1
+data:
+  ca-climate-zones-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ca-climate-zones-hex
+      labels:
+        k8s-app: ca-climate-zones-hex
+    spec:
+      completions: 122
+      parallelism: 61
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ca-climate-zones-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-ca30x30
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/clusters_10.tif" --output-parquet s3://public-ca30x30/ca-climate-zones/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column zone --hex-resampling mode
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  ca-climate-zones-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ca-climate-zones-setup-bucket
+      labels:
+        k8s-app: ca-climate-zones-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: ca-climate-zones-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-ca30x30
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: ca-climate-zones-yamls
+  namespace: biodiversity

--- a/catalog/ca30x30/k8s/climate-zones-kling/download-raw.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/download-raw.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ca-climate-zones-download-raw
+  labels:
+    k8s-app: ca-climate-zones-download-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ca-climate-zones-download-raw
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: download-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Downloading clusters_10.tif from matthewkling/climclust..."
+          curl -fL --retry 5 -o /tmp/clusters_10.tif \
+            "https://raw.githubusercontent.com/matthewkling/climclust/master/hclust/clusters_10.tif"
+          echo "Upload to S3 raw..."
+          rclone copyto /tmp/clusters_10.tif nrp:public-ca30x30/raw/clusters_10.tif -v
+          echo "Pre-flight: gdalinfo"
+          gdalinfo /tmp/clusters_10.tif
+          echo "Done."
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+            ephemeral-storage: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+            ephemeral-storage: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/ca30x30/k8s/climate-zones-kling/preprocess-cog.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/preprocess-cog.yaml
@@ -1,28 +1,22 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ca-climate-zones-hex
+  name: ca-climate-zones-preprocess-cog
   labels:
-    k8s-app: ca-climate-zones-hex
+    k8s-app: ca-climate-zones-preprocess-cog
 spec:
-  completions: 122
-  parallelism: 61
-  completionMode: Indexed
-  backoffLimit: 0
-  podFailurePolicy:
-    rules:
-    - action: Ignore
-      onPodConditions:
-      - type: DisruptionTarget
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
   ttlSecondsAfterFinished: 10800
   template:
     metadata:
       labels:
-        k8s-app: ca-climate-zones-hex
+        k8s-app: ca-climate-zones-preprocess-cog
     spec:
       restartPolicy: Never
       containers:
-      - name: hex-task
+      - name: preprocess-cog-task
         image: ghcr.io/boettiger-lab/datasets:latest
         imagePullPolicy: Always
         env:
@@ -38,18 +32,10 @@ spec:
               key: AWS_SECRET_ACCESS_KEY
         - name: AWS_S3_ENDPOINT
           value: rook-ceph-rgw-nautiluss3.rook
-        - name: AWS_PUBLIC_ENDPOINT
-          value: s3-west.nrp-nautilus.io
         - name: AWS_HTTPS
           value: 'false'
         - name: AWS_VIRTUAL_HOSTING
           value: 'FALSE'
-        - name: GDAL_DATA
-          value: /usr/share/gdal
-        - name: PYTHONPATH
-          value: /usr/lib/python3/dist-packages
-        - name: BUCKET
-          value: public-ca30x30
         volumeMounts:
         - name: rclone-config
           mountPath: /root/.config/rclone
@@ -57,19 +43,42 @@ spec:
         command:
         - bash
         - -c
-        - |-
+        - |
           set -e
+          echo "Localizing raw TIF via rclone..."
+          rclone copyto nrp:public-ca30x30/raw/clusters_10.tif /tmp/clusters_10_raw.tif -v
 
-          cng-datasets raster --input "https://s3-west.nrp-nautilus.io/public-ca30x30/ca-climate-zones-cog.tif" --output-parquet s3://public-ca30x30/ca-climate-zones/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column zone --hex-resampling mode
+          echo "Reprojecting to WGS84 (nearest-neighbor for categorical data)..."
+          gdalwarp \
+            -t_srs EPSG:4326 \
+            -r near \
+            -dstnodata -9999 \
+            -of GTiff \
+            /tmp/clusters_10_raw.tif /tmp/clusters_10_wgs84.tif
+
+          echo "Creating COG..."
+          gdal_translate \
+            -of COG \
+            -co COMPRESS=LZW \
+            -co OVERVIEW_RESAMPLING=NEAREST \
+            /tmp/clusters_10_wgs84.tif /tmp/ca-climate-zones-cog.tif
+
+          echo "Verifying COG..."
+          gdalinfo /tmp/ca-climate-zones-cog.tif | grep -E "Size|Type|NoData|Min|Max|EPSG|WGS"
+
+          echo "Uploading COG to S3..."
+          rclone copyto /tmp/ca-climate-zones-cog.tif nrp:public-ca30x30/ca-climate-zones-cog.tif -v
+
+          echo "Done."
         resources:
           requests:
             cpu: '4'
-            memory: 32Gi
-            ephemeral-storage: 20Gi
+            memory: 8Gi
+            ephemeral-storage: 2Gi
           limits:
             cpu: '4'
-            memory: 32Gi
-            ephemeral-storage: 20Gi
+            memory: 8Gi
+            ephemeral-storage: 2Gi
       volumes:
       - name: rclone-config
         secret:

--- a/catalog/ca30x30/k8s/climate-zones-kling/workflow-rbac.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/ca30x30/k8s/climate-zones-kling/workflow.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/workflow.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ca-climate-zones-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting ca-climate-zones raster workflow...\"\n\n# Step\
+          \ 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply\
+          \ -f /yamls/ca-climate-zones-setup-bucket.yaml -n biodiversity\nkubectl\
+          \ wait --for=condition=complete --timeout=600s job/ca-climate-zones-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/ca-climate-zones-hex.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=7200s job/ca-climate-zones-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs ca-climate-zones-setup-bucket ca-climate-zones-hex\
+          \ ca-climate-zones-workflow -n biodiversity\"\necho \"  kubectl delete configmap\
+          \ ca-climate-zones-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: ca-climate-zones-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
## Summary

- Downloads `clusters_10.tif` (270 m Albers EA, NAD83) from matthewkling/climclust to `s3://public-ca30x30/raw/`
- Adds `preprocess-cog.yaml`: reprojects to WGS84 COG (`gdalwarp -r near -dstnodata -9999`) since the unnamed Albers CRS fails `AutoIdentifyEPSG` in cng-datasets
- Runs 122-pod raster hex (H3 res 8, `mode` → `zone` column) against the WGS84 COG
- Uploads STAC + README to `s3://public-ca30x30/ca-climate-zones/`; adds child link to bucket parent catalog

## Validation

```
zone | cells
1    | 44035
2    | 78310
3    | 79421
4    | 78731
5    | 30251
6    | 67542
7    | 39695
8    | 103961
9    | 42756
10   | 50919
```
All 10 zones present. ✅

## Test plan

- [ ] Confirm `SELECT DISTINCT zone FROM read_parquet('s3://public-ca30x30/ca-climate-zones/hex/h0=*/data_0.parquet')` returns 10 values
- [ ] Confirm COG renders in titiler over California
- [ ] Confirm STAC child link appears in `public-ca30x30/stac-collection.json`

Closes #268