### PR TITLE
GBIF refresh to 2026-06 snapshot (#247): rebuild with #279/#244/#240 fixes + #281 sidecar

### DIFF
--- a/catalog/gbif/2026-06/configmap.yaml
+++ b/catalog/gbif/2026-06/configmap.yaml
@@ -26,6 +26,18 @@ data:
     OUT_PREFIX = "2026-06/hex"
 
     job_index = int(os.environ.get("JOB_COMPLETION_INDEX", "0"))
+    # REMAP lets a rechunk job reprocess a subset of the sorted-h0 indices (the dense
+    # partitions that OOM at the standard memory). REMAP="4,12,..." maps this pod's
+    # completion index onto the original index into the sorted h0 list.
+    _remap = os.environ.get("REMAP", "").strip()
+    if _remap:
+        _idx = [int(x) for x in _remap.split(",")]
+        if job_index >= len(_idx):
+            print(f"job {job_index}: beyond REMAP length {len(_idx)} — nothing to do")
+            sys.exit(0)
+        job_index = _idx[job_index]
+        print(f"REMAP active -> original sorted-h0 index {job_index}")
+
     key = os.environ.get("AWS_ACCESS_KEY_ID", "")
     secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
     endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
@@ -65,6 +77,15 @@ data:
     con.execute("INSTALL httpfs; LOAD httpfs")
     con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
     con.execute("SET preserve_insertion_order=false")
+    # Dense-partition tuning (set only by the high-RAM rechunk job; unset = standard run).
+    # Big RAM is the primary lever (in-memory dedup+sort is far faster than spill);
+    # fewer threads keeps peak memory efficient; temp_directory is a PVC spill backstop.
+    if os.environ.get("DUCKDB_MEMORY_LIMIT"):
+        con.execute(f"SET memory_limit='{os.environ['DUCKDB_MEMORY_LIMIT']}'")
+    if os.environ.get("DUCKDB_THREADS"):
+        con.execute(f"SET threads={int(os.environ['DUCKDB_THREADS'])}")
+    if os.environ.get("DUCKDB_TEMP"):
+        con.execute(f"SET temp_directory='{os.environ['DUCKDB_TEMP']}'")
     con.execute(f"""
         CREATE SECRET public_gbif (TYPE S3, KEY_ID '{key}', SECRET '{secret}', REGION 'us-east-1',
             ENDPOINT '{endpoint}', USE_SSL {str(use_ssl).lower()}, URL_STYLE 'path', SCOPE 's3://public-gbif')

--- a/catalog/gbif/2026-06/configmap.yaml
+++ b/catalog/gbif/2026-06/configmap.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+data:
+  consolidate_h0_partitions.py: |
+    """
+    GBIF 2026-06 — Stage 2: consolidate each h0 partition (port of
+    catalog/gbif/consolidate_h0_partitions.py).
+
+    Per JOB_COMPLETION_INDEX, picks one h0 partition under 2026-06/chunks/, reads all
+    its Stage-1 files, and writes ONE optimized file 2026-06/hex/h0=<int>/data_0.parquet.
+
+    Changes vs the 2025-06 script (data-workflows#247):
+    - DEDUP by gbifid (QUALIFY row_number()=1) so per-h0 COUNT(*) == COUNT(DISTINCT gbifid)
+      (#244; also absorbs any chunk duplication from Stage-1 retries).
+    - ONE FILE PER h0: write to a single data_0.parquet path (no FILE_SIZE_BYTES, no
+      multi-thread per-file split) — fixes the 126-shards-per-h0 over-sharding (#279).
+      Densest h0 becomes one multi-GB file; reads still prune via 1M-row row groups.
+    - Clean output path (no '//', #240); 2025-06 -> 2026-06 prefixes.
+    - Spatial sort ORDER BY h1..h5 retained for row-group locality.
+    """
+    import duckdb, os, sys
+    import boto3
+    from botocore.config import Config
+
+    BUCKET = "public-gbif"
+    IN_PREFIX = "2026-06/chunks"
+    OUT_PREFIX = "2026-06/hex"
+
+    job_index = int(os.environ.get("JOB_COMPLETION_INDEX", "0"))
+    key = os.environ.get("AWS_ACCESS_KEY_ID", "")
+    secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+    use_ssl = os.environ.get("AWS_HTTPS", "false").lower() == "true"
+    endpoint_url = f"{'https' if use_ssl else 'http'}://{endpoint}"
+
+    s3 = boto3.client("s3", aws_access_key_id=key, aws_secret_access_key=secret,
+                      endpoint_url=endpoint_url, config=Config(signature_version="s3v4"))
+
+    # --- discover h0 partitions in chunks/ ---
+    h0s = set()
+    for page in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Prefix=IN_PREFIX + "/"):
+        for o in page.get("Contents", []):
+            for part in o["Key"].split("/"):
+                if part.startswith("h0="):
+                    h0s.add(part)
+                    break
+    h0s = sorted(h0s)
+    print(f"discovered {len(h0s)} h0 partitions in {IN_PREFIX}")
+    if job_index >= len(h0s):
+        print(f"job {job_index}: beyond partition range ({len(h0s)}) — nothing to do")
+        sys.exit(0)
+    h0 = h0s[job_index]
+
+    files = []
+    for page in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Prefix=f"{IN_PREFIX}/{h0}/"):
+        for o in page.get("Contents", []):
+            if o["Key"].endswith(".parquet"):
+                files.append(f"s3://{BUCKET}/{o['Key']}")
+    if not files:
+        print(f"job {job_index}: no files in {h0}")
+        sys.exit(0)
+    out = f"s3://{BUCKET}/{OUT_PREFIX}/{h0}/data_0.parquet"
+    print(f"job {job_index}: consolidating {h0} ({len(files)} files) -> {out}")
+
+    con = duckdb.connect("/tmp/duck.db")
+    con.execute("INSTALL httpfs; LOAD httpfs")
+    con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute(f"""
+        CREATE SECRET public_gbif (TYPE S3, KEY_ID '{key}', SECRET '{secret}', REGION 'us-east-1',
+            ENDPOINT '{endpoint}', USE_SSL {str(use_ssl).lower()}, URL_STYLE 'path', SCOPE 's3://public-gbif')
+    """)
+    con.execute(f"""
+        COPY (
+            SELECT *
+            FROM read_parquet({files})
+            QUALIFY row_number() OVER (PARTITION BY gbifid) = 1
+            ORDER BY h1, h2, h3, h4, h5
+        ) TO '{out}'
+        (FORMAT parquet, COMPRESSION zstd, ROW_GROUP_SIZE 1000000)
+    """)
+    n = con.execute(f"SELECT COUNT(*), COUNT(DISTINCT gbifid) FROM read_parquet('{out}')").fetchone()
+    print(f"job {job_index}: wrote {h0} rows={n[0]} distinct_gbifid={n[1]}")
+    assert n[0] == n[1], f"DEDUP FAILED: {n[0]} rows != {n[1]} distinct gbifid"
+    print(f"job {job_index}: done")
+  process_gbif_h3.py: |
+    """
+    GBIF 2026-06 — Stage 1: H3 index + h0 partition (port of catalog/gbif/process_gbif_h3.py).
+
+    Reads the 2026-06-01 GBIF occurrence snapshot from AWS Open Data (anonymous),
+    adds H3 index columns h0..h10 from decimallat/long, filters invalid coords, and
+    writes h0-partitioned chunks to s3://public-gbif/2026-06/chunks/h0=<int>/.
+
+    Changes vs the 2025-06 script (see data-workflows#247):
+    - date 2025-06-01 -> 2026-06-01; output prefix 2026-06; files_per_chunk 25 -> 42
+      (source grew 4,599 -> 8,375 files; 42*200 >= 8,375 keeps 200 completions).
+    - SINGLE-PASS write: one COPY ... PARTITION_BY (h0) per chunk (reads each source
+      file once) instead of the original per-distinct-h0 re-read loop. Chunk files may
+      duplicate across pod retries; Stage 2 dedups by gbifid so that is harmless.
+    - h0 partition dirs are the natural uint64 (decimal), matching the IUCN hex layout.
+    - Keeps h0..h10 (the live 2025-06 hex carries all 11 resolutions; do not regress).
+    """
+    import duckdb, os, sys
+    import boto3
+    from botocore import UNSIGNED
+    from botocore.config import Config
+
+    SRC_BUCKET = "gbif-open-data-us-east-1"
+    SRC_PREFIX = "occurrence/2026-06-01/occurrence.parquet/"
+    OUTPUT = "s3://public-gbif/2026-06/chunks"
+    FILES_PER_CHUNK = 42
+
+    job_index = int(os.environ.get("JOB_COMPLETION_INDEX", "0"))
+
+    # --- list source files (anonymous public AWS bucket) ---
+    s3 = boto3.client("s3", region_name="us-east-1", config=Config(signature_version=UNSIGNED))
+    files = []
+    for page in s3.get_paginator("list_objects_v2").paginate(Bucket=SRC_BUCKET, Prefix=SRC_PREFIX):
+        for o in page.get("Contents", []):
+            if not o["Key"].endswith("/"):
+                files.append(f"s3://{SRC_BUCKET}/{o['Key']}")
+    files.sort()
+    start = job_index * FILES_PER_CHUNK
+    end = min(start + FILES_PER_CHUNK, len(files))
+    if start >= len(files):
+        print(f"job {job_index}: beyond file range ({len(files)} files) — nothing to do")
+        sys.exit(0)
+    chunk = files[start:end]
+    print(f"job {job_index}: source files [{start}:{end}] = {len(chunk)} of {len(files)}")
+
+    # --- DuckDB ---
+    con = duckdb.connect("/tmp/duck.db")
+    con.execute("INSTALL httpfs; LOAD httpfs")
+    con.execute("INSTALL h3 FROM community; LOAD h3")
+    con.execute("SET threads=8")
+    con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+    con.execute("SET preserve_insertion_order=false")
+
+    key = os.environ.get("AWS_ACCESS_KEY_ID", "")
+    secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+    use_ssl = str(os.environ.get("AWS_HTTPS", "false").lower() == "true").lower()
+    con.execute(f"""
+        CREATE SECRET public_gbif (TYPE S3, KEY_ID '{key}', SECRET '{secret}', REGION 'us-east-1',
+            ENDPOINT '{endpoint}', USE_SSL {use_ssl}, URL_STYLE 'path', SCOPE 's3://public-gbif')
+    """)
+    con.execute("""
+        CREATE SECRET gbif_public (TYPE S3, KEY_ID '', SECRET '', REGION 'us-east-1',
+            SCOPE 's3://gbif-open-data-us-east-1')
+    """)
+
+    con.execute(f"""
+        COPY (
+            SELECT *,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 0)  AS h0,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 1)  AS h1,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 2)  AS h2,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 3)  AS h3,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 4)  AS h4,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 5)  AS h5,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 6)  AS h6,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 7)  AS h7,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 8)  AS h8,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 9)  AS h9,
+                h3_latlng_to_cell(decimallatitude, decimallongitude, 10) AS h10
+            FROM read_parquet({chunk})
+            WHERE decimallatitude IS NOT NULL AND decimallongitude IS NOT NULL
+              AND decimallatitude  BETWEEN -90  AND 90
+              AND decimallongitude BETWEEN -180 AND 180
+        ) TO '{OUTPUT}'
+        (FORMAT parquet, PARTITION_BY (h0), COMPRESSION zstd,
+         FILENAME_PATTERN 'job{job_index:04d}_{{i}}', OVERWRITE_OR_IGNORE true)
+    """)
+    print(f"job {job_index}: done")
+kind: ConfigMap
+metadata:
+  name: gbif-2026-06-scripts
+  namespace: biodiversity

--- a/catalog/gbif/2026-06/consolidate_h0_partitions.py
+++ b/catalog/gbif/2026-06/consolidate_h0_partitions.py
@@ -23,6 +23,18 @@ IN_PREFIX = "2026-06/chunks"
 OUT_PREFIX = "2026-06/hex"
 
 job_index = int(os.environ.get("JOB_COMPLETION_INDEX", "0"))
+# REMAP lets a rechunk job reprocess a subset of the sorted-h0 indices (the dense
+# partitions that OOM at the standard memory). REMAP="4,12,..." maps this pod's
+# completion index onto the original index into the sorted h0 list.
+_remap = os.environ.get("REMAP", "").strip()
+if _remap:
+    _idx = [int(x) for x in _remap.split(",")]
+    if job_index >= len(_idx):
+        print(f"job {job_index}: beyond REMAP length {len(_idx)} — nothing to do")
+        sys.exit(0)
+    job_index = _idx[job_index]
+    print(f"REMAP active -> original sorted-h0 index {job_index}")
+
 key = os.environ.get("AWS_ACCESS_KEY_ID", "")
 secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
@@ -62,6 +74,15 @@ con = duckdb.connect("/tmp/duck.db")
 con.execute("INSTALL httpfs; LOAD httpfs")
 con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
 con.execute("SET preserve_insertion_order=false")
+# Dense-partition tuning (set only by the high-RAM rechunk job; unset = standard run).
+# Big RAM is the primary lever (in-memory dedup+sort is far faster than spill);
+# fewer threads keeps peak memory efficient; temp_directory is a PVC spill backstop.
+if os.environ.get("DUCKDB_MEMORY_LIMIT"):
+    con.execute(f"SET memory_limit='{os.environ['DUCKDB_MEMORY_LIMIT']}'")
+if os.environ.get("DUCKDB_THREADS"):
+    con.execute(f"SET threads={int(os.environ['DUCKDB_THREADS'])}")
+if os.environ.get("DUCKDB_TEMP"):
+    con.execute(f"SET temp_directory='{os.environ['DUCKDB_TEMP']}'")
 con.execute(f"""
     CREATE SECRET public_gbif (TYPE S3, KEY_ID '{key}', SECRET '{secret}', REGION 'us-east-1',
         ENDPOINT '{endpoint}', USE_SSL {str(use_ssl).lower()}, URL_STYLE 'path', SCOPE 's3://public-gbif')

--- a/catalog/gbif/2026-06/consolidate_h0_partitions.py
+++ b/catalog/gbif/2026-06/consolidate_h0_partitions.py
@@ -1,0 +1,81 @@
+"""
+GBIF 2026-06 — Stage 2: consolidate each h0 partition (port of
+catalog/gbif/consolidate_h0_partitions.py).
+
+Per JOB_COMPLETION_INDEX, picks one h0 partition under 2026-06/chunks/, reads all
+its Stage-1 files, and writes ONE optimized file 2026-06/hex/h0=<int>/data_0.parquet.
+
+Changes vs the 2025-06 script (data-workflows#247):
+- DEDUP by gbifid (QUALIFY row_number()=1) so per-h0 COUNT(*) == COUNT(DISTINCT gbifid)
+  (#244; also absorbs any chunk duplication from Stage-1 retries).
+- ONE FILE PER h0: write to a single data_0.parquet path (no FILE_SIZE_BYTES, no
+  multi-thread per-file split) — fixes the 126-shards-per-h0 over-sharding (#279).
+  Densest h0 becomes one multi-GB file; reads still prune via 1M-row row groups.
+- Clean output path (no '//', #240); 2025-06 -> 2026-06 prefixes.
+- Spatial sort ORDER BY h1..h5 retained for row-group locality.
+"""
+import duckdb, os, sys
+import boto3
+from botocore.config import Config
+
+BUCKET = "public-gbif"
+IN_PREFIX = "2026-06/chunks"
+OUT_PREFIX = "2026-06/hex"
+
+job_index = int(os.environ.get("JOB_COMPLETION_INDEX", "0"))
+key = os.environ.get("AWS_ACCESS_KEY_ID", "")
+secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+use_ssl = os.environ.get("AWS_HTTPS", "false").lower() == "true"
+endpoint_url = f"{'https' if use_ssl else 'http'}://{endpoint}"
+
+s3 = boto3.client("s3", aws_access_key_id=key, aws_secret_access_key=secret,
+                  endpoint_url=endpoint_url, config=Config(signature_version="s3v4"))
+
+# --- discover h0 partitions in chunks/ ---
+h0s = set()
+for page in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Prefix=IN_PREFIX + "/"):
+    for o in page.get("Contents", []):
+        for part in o["Key"].split("/"):
+            if part.startswith("h0="):
+                h0s.add(part)
+                break
+h0s = sorted(h0s)
+print(f"discovered {len(h0s)} h0 partitions in {IN_PREFIX}")
+if job_index >= len(h0s):
+    print(f"job {job_index}: beyond partition range ({len(h0s)}) — nothing to do")
+    sys.exit(0)
+h0 = h0s[job_index]
+
+files = []
+for page in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Prefix=f"{IN_PREFIX}/{h0}/"):
+    for o in page.get("Contents", []):
+        if o["Key"].endswith(".parquet"):
+            files.append(f"s3://{BUCKET}/{o['Key']}")
+if not files:
+    print(f"job {job_index}: no files in {h0}")
+    sys.exit(0)
+out = f"s3://{BUCKET}/{OUT_PREFIX}/{h0}/data_0.parquet"
+print(f"job {job_index}: consolidating {h0} ({len(files)} files) -> {out}")
+
+con = duckdb.connect("/tmp/duck.db")
+con.execute("INSTALL httpfs; LOAD httpfs")
+con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+con.execute("SET preserve_insertion_order=false")
+con.execute(f"""
+    CREATE SECRET public_gbif (TYPE S3, KEY_ID '{key}', SECRET '{secret}', REGION 'us-east-1',
+        ENDPOINT '{endpoint}', USE_SSL {str(use_ssl).lower()}, URL_STYLE 'path', SCOPE 's3://public-gbif')
+""")
+con.execute(f"""
+    COPY (
+        SELECT *
+        FROM read_parquet({files})
+        QUALIFY row_number() OVER (PARTITION BY gbifid) = 1
+        ORDER BY h1, h2, h3, h4, h5
+    ) TO '{out}'
+    (FORMAT parquet, COMPRESSION zstd, ROW_GROUP_SIZE 1000000)
+""")
+n = con.execute(f"SELECT COUNT(*), COUNT(DISTINCT gbifid) FROM read_parquet('{out}')").fetchone()
+print(f"job {job_index}: wrote {h0} rows={n[0]} distinct_gbifid={n[1]}")
+assert n[0] == n[1], f"DEDUP FAILED: {n[0]} rows != {n[1]} distinct gbifid"
+print(f"job {job_index}: done")

--- a/catalog/gbif/2026-06/gbif-2026-06-consolidate-rechunk.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-consolidate-rechunk.yaml
@@ -1,0 +1,98 @@
+# GBIF 2026-06 Stage 2 RECHUNK — the dense h0 partitions that OOM'd the standard
+# 120Gi consolidate job (sorted-h0 indices 4,12,15,19,20,21,34,39,68,76,95;
+# the densest done partition is ~134M rows, these are larger).
+#
+# Fix per project guidance: BIG RAM is the primary lever (in-memory dedup+sort is
+# much faster than PVC spill); fewer threads keeps peak memory efficient; the
+# rechunk-scratch PVC is only a spill backstop (per-pod /scratch/<index> subdir).
+# REMAP maps this job's completion index -> the original sorted-h0 index.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2026-06-consolidate-rechunk
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2026-06-consolidate-rechunk
+spec:
+  completions: 11
+  parallelism: 3
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 11
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2026-06-consolidate-rechunk
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: consolidate
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        - name: scratch
+          mountPath: /scratch
+        env:
+        - name: REMAP
+          value: "4,12,15,19,20,21,34,39,68,76,95"
+        - name: DUCKDB_MEMORY_LIMIT
+          value: "440GB"
+        - name: DUCKDB_THREADS
+          value: "8"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: "rook-ceph-rgw-nautiluss3.rook"
+        - name: AWS_PUBLIC_ENDPOINT
+          value: "s3-west.nrp-nautilus.io"
+        - name: AWS_HTTPS
+          value: "false"
+        - name: AWS_VIRTUAL_HOSTING
+          value: "FALSE"
+        - name: JOB_COMPLETION_INDEX
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+        resources:
+          requests: {cpu: "8", memory: 480Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: "8", memory: 480Gi, ephemeral-storage: 50Gi}
+        command:
+        - bash
+        - -lc
+        - |
+          set -e
+          export DUCKDB_TEMP=/scratch/consolidate-$JOB_COMPLETION_INDEX
+          mkdir -p "$DUCKDB_TEMP"
+          rm -rf "$DUCKDB_TEMP"/* || true
+          pip install -q boto3
+          python3 -u /scripts/consolidate_h0_partitions.py
+      volumes:
+      - name: scripts
+        configMap:
+          name: gbif-2026-06-scripts
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch

--- a/catalog/gbif/2026-06/gbif-2026-06-consolidate.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-consolidate.yaml
@@ -1,0 +1,75 @@
+# GBIF 2026-06 Stage 2: dedup + consolidate each h0 -> 2026-06/hex/h0=<int>/data_0.parquet
+# Run AFTER Stage 1 (gbif-2026-06-hex) completes. completions=122 (one per h0).
+# Scripts from the gbif-2026-06-scripts ConfigMap. 120Gi matches the proven 2025-06 config.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2026-06-consolidate
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2026-06-consolidate
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 5
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2026-06-consolidate
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+        - name: consolidate
+          image: ghcr.io/rocker-org/ml-spatial
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+            - name: AWS_S3_ENDPOINT
+              value: "rook-ceph-rgw-nautiluss3.rook"
+            - name: AWS_PUBLIC_ENDPOINT
+              value: "s3-west.nrp-nautilus.io"
+            - name: AWS_HTTPS
+              value: "false"
+            - name: AWS_VIRTUAL_HOSTING
+              value: "FALSE"
+            - name: TMPDIR
+              value: "/tmp"
+            - name: JOB_COMPLETION_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+          resources:
+            requests: {cpu: "4", memory: 120Gi, ephemeral-storage: 40Gi}
+            limits:   {cpu: "4", memory: 120Gi, ephemeral-storage: 50Gi}
+          command:
+            - bash
+            - -lc
+            - |
+              pip install -q 'duckdb==1.5.3' boto3
+              python -u /scripts/consolidate_h0_partitions.py
+      volumes:
+        - name: scripts
+          configMap:
+            name: gbif-2026-06-scripts

--- a/catalog/gbif/2026-06/gbif-2026-06-consolidate.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-consolidate.yaml
@@ -36,7 +36,7 @@ spec:
                 values: ["true"]
       containers:
         - name: consolidate
-          image: ghcr.io/rocker-org/ml-spatial
+          image: ghcr.io/boettiger-lab/datasets:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: scripts
@@ -67,8 +67,8 @@ spec:
             - bash
             - -lc
             - |
-              pip install -q 'duckdb==1.5.3' boto3
-              python -u /scripts/consolidate_h0_partitions.py
+              pip install -q boto3
+              python3 -u /scripts/consolidate_h0_partitions.py
       volumes:
         - name: scripts
           configMap:

--- a/catalog/gbif/2026-06/gbif-2026-06-hex.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-hex.yaml
@@ -1,0 +1,75 @@
+# GBIF 2026-06 Stage 1: H3 index + h0 partition -> 2026-06/chunks/
+# Scripts come from the gbif-2026-06-scripts ConfigMap (NOT a datasets-repo clone),
+# per HARD BOUNDARY 2. Apply configmap.yaml first.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2026-06-hex
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2026-06-hex
+spec:
+  completions: 200
+  parallelism: 100
+  completionMode: Indexed
+  backoffLimitPerIndex: 5
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2026-06-hex
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+        - name: hex
+          image: ghcr.io/rocker-org/ml-spatial
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+            - name: AWS_S3_ENDPOINT
+              value: "rook-ceph-rgw-nautiluss3.rook"
+            - name: AWS_PUBLIC_ENDPOINT
+              value: "s3-west.nrp-nautilus.io"
+            - name: AWS_HTTPS
+              value: "false"
+            - name: AWS_VIRTUAL_HOSTING
+              value: "FALSE"
+            - name: TMPDIR
+              value: "/tmp"
+            - name: JOB_COMPLETION_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+          resources:
+            requests: {cpu: "8", memory: 48Gi, ephemeral-storage: 40Gi}
+            limits:   {cpu: "8", memory: 48Gi, ephemeral-storage: 50Gi}
+          command:
+            - bash
+            - -lc
+            - |
+              pip install -q 'duckdb==1.5.3' boto3
+              python -u /scripts/process_gbif_h3.py
+      volumes:
+        - name: scripts
+          configMap:
+            name: gbif-2026-06-scripts

--- a/catalog/gbif/2026-06/gbif-2026-06-hex.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-hex.yaml
@@ -36,7 +36,7 @@ spec:
                 values: ["true"]
       containers:
         - name: hex
-          image: ghcr.io/rocker-org/ml-spatial
+          image: ghcr.io/boettiger-lab/datasets:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: scripts
@@ -67,8 +67,8 @@ spec:
             - bash
             - -lc
             - |
-              pip install -q 'duckdb==1.5.3' boto3
-              python -u /scripts/process_gbif_h3.py
+              pip install -q boto3
+              python3 -u /scripts/process_gbif_h3.py
       volumes:
         - name: scripts
           configMap:

--- a/catalog/gbif/2026-06/gbif-2026-06-sidecar.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-sidecar.yaml
@@ -1,0 +1,79 @@
+# GBIF 2026-06 — per-species (specieskey, species, h0) partition-index sidecar (#281 pattern).
+# Run AFTER Stage 2 (consolidate) completes. Mirrors the IUCN sidecar: a tiny lookup
+# that lets WHERE species=… / specieskey=… prune the h0-partitioned hex via dynamic
+# partition filtering. Build over the internal endpoint.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2026-06-sidecar
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2026-06-sidecar
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2026-06-sidecar
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: build-index
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {cpu: "8", memory: 48Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: "8", memory: 48Gi, ephemeral-storage: 50Gi}
+        env:
+        - name: SRC_HEX
+          value: 's3://public-gbif/2026-06/hex/h0=*/data_0.parquet'
+        - name: DST_SIDECAR
+          value: 's3://public-gbif/2026-06/species-h0-index.parquet'
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          python3 - <<'PYEOF'
+          import duckdb, os
+          src=os.environ["SRC_HEX"]; dst=os.environ["DST_SIDECAR"]
+          key=os.environ["AWS_ACCESS_KEY_ID"]; secret=os.environ["AWS_SECRET_ACCESS_KEY"]
+          endpoint=os.environ.get("AWS_S3_ENDPOINT","rook-ceph-rgw-nautiluss3.rook")
+          con=duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false)")
+          # distinct (specieskey, species, h0); species can be NULL (genus-level records) -> kept.
+          con.execute(f"""
+              COPY (
+                  SELECT DISTINCT specieskey, species, h0
+                  FROM read_parquet('{src}', hive_partitioning=true)
+                  WHERE specieskey IS NOT NULL
+                  ORDER BY specieskey
+              ) TO '{dst}' (FORMAT PARQUET, COMPRESSION ZSTD)
+          """)
+          n, sp = con.execute(f"SELECT COUNT(*), COUNT(DISTINCT specieskey) FROM read_parquet('{dst}')").fetchone()
+          print(f"  sidecar rows={n} species={sp}")
+          assert n > 100000, "sidecar suspiciously small"
+          print("  OK")
+          PYEOF

--- a/catalog/gbif/2026-06/gbif-2026-06-taxonomy.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-taxonomy.yaml
@@ -1,0 +1,92 @@
+# GBIF 2026-06 taxonomy aggregation (port of catalog/gbif/k8s/gbif-2025-taxonomy.yaml).
+# Per h0, GROUP BY the taxonomy columns + COUNT(*) -> 2026-06/taxonomy/h0=<int>/data_0.parquet.
+# Required so the 2026-06 release matches 2025-06's `taxonomic-aggregations` asset (#247).
+# Discovers the h0 list from the actual hex via DuckDB glob (no hardcoded list, no boto3).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2026-06-taxonomy
+  namespace: biodiversity
+  labels:
+    k8s-app: gbif-2026-06-taxonomy
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 5
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2026-06-taxonomy
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']
+      containers:
+      - name: taxonomy
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {cpu: '4', memory: 16Gi, ephemeral-storage: 4Gi}
+          limits:   {cpu: '4', memory: 16Gi, ephemeral-storage: 4Gi}
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: JOB_COMPLETION_INDEX
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+        command:
+        - bash
+        - -c
+        - |-
+          set -euo pipefail
+          python3 - <<'PYEOF'
+          import duckdb, os, sys
+          idx = int(os.environ["JOB_COMPLETION_INDEX"])
+          key = os.environ["AWS_ACCESS_KEY_ID"]; secret = os.environ["AWS_SECRET_ACCESS_KEY"]
+          endpoint = os.environ["AWS_S3_ENDPOINT"]
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false)")
+          h0s = [r[0] for r in con.execute(
+              "SELECT DISTINCT regexp_extract(file,'h0=([0-9]+)',1) AS h0 "
+              "FROM glob('s3://public-gbif/2026-06/hex/h0=*/data_0.parquet') ORDER BY h0").fetchall()]
+          if idx >= len(h0s):
+              print(f"idx {idx} >= {len(h0s)} partitions; nothing to do"); sys.exit(0)
+          h0 = h0s[idx]
+          src = f"s3://public-gbif/2026-06/hex/h0={h0}/data_0.parquet"
+          dst = f"s3://public-gbif/2026-06/taxonomy/h0={h0}/data_0.parquet"
+          print(f"idx {idx}: {src} -> {dst}", flush=True)
+          con.execute(f"""
+              COPY (
+                  SELECT kingdom, phylum, class, "order", family,
+                         genus, species, infraspecificepithet,
+                         taxonrank, scientificname,
+                         verbatimscientificname, verbatimscientificnameauthorship,
+                         COUNT(*) AS n,
+                         {h0}::UBIGINT AS h0
+                  FROM read_parquet('{src}')
+                  GROUP BY ALL
+              ) TO '{dst}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 1000000)
+          """)
+          print(f"idx {idx}: done", flush=True)
+          PYEOF

--- a/catalog/gbif/2026-06/process_gbif_h3.py
+++ b/catalog/gbif/2026-06/process_gbif_h3.py
@@ -1,0 +1,88 @@
+"""
+GBIF 2026-06 — Stage 1: H3 index + h0 partition (port of catalog/gbif/process_gbif_h3.py).
+
+Reads the 2026-06-01 GBIF occurrence snapshot from AWS Open Data (anonymous),
+adds H3 index columns h0..h10 from decimallat/long, filters invalid coords, and
+writes h0-partitioned chunks to s3://public-gbif/2026-06/chunks/h0=<int>/.
+
+Changes vs the 2025-06 script (see data-workflows#247):
+- date 2025-06-01 -> 2026-06-01; output prefix 2026-06; files_per_chunk 25 -> 42
+  (source grew 4,599 -> 8,375 files; 42*200 >= 8,375 keeps 200 completions).
+- SINGLE-PASS write: one COPY ... PARTITION_BY (h0) per chunk (reads each source
+  file once) instead of the original per-distinct-h0 re-read loop. Chunk files may
+  duplicate across pod retries; Stage 2 dedups by gbifid so that is harmless.
+- h0 partition dirs are the natural uint64 (decimal), matching the IUCN hex layout.
+- Keeps h0..h10 (the live 2025-06 hex carries all 11 resolutions; do not regress).
+"""
+import duckdb, os, sys
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+
+SRC_BUCKET = "gbif-open-data-us-east-1"
+SRC_PREFIX = "occurrence/2026-06-01/occurrence.parquet/"
+OUTPUT = "s3://public-gbif/2026-06/chunks"
+FILES_PER_CHUNK = 42
+
+job_index = int(os.environ.get("JOB_COMPLETION_INDEX", "0"))
+
+# --- list source files (anonymous public AWS bucket) ---
+s3 = boto3.client("s3", region_name="us-east-1", config=Config(signature_version=UNSIGNED))
+files = []
+for page in s3.get_paginator("list_objects_v2").paginate(Bucket=SRC_BUCKET, Prefix=SRC_PREFIX):
+    for o in page.get("Contents", []):
+        if not o["Key"].endswith("/"):
+            files.append(f"s3://{SRC_BUCKET}/{o['Key']}")
+files.sort()
+start = job_index * FILES_PER_CHUNK
+end = min(start + FILES_PER_CHUNK, len(files))
+if start >= len(files):
+    print(f"job {job_index}: beyond file range ({len(files)} files) — nothing to do")
+    sys.exit(0)
+chunk = files[start:end]
+print(f"job {job_index}: source files [{start}:{end}] = {len(chunk)} of {len(files)}")
+
+# --- DuckDB ---
+con = duckdb.connect("/tmp/duck.db")
+con.execute("INSTALL httpfs; LOAD httpfs")
+con.execute("INSTALL h3 FROM community; LOAD h3")
+con.execute("SET threads=8")
+con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+con.execute("SET preserve_insertion_order=false")
+
+key = os.environ.get("AWS_ACCESS_KEY_ID", "")
+secret = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+use_ssl = str(os.environ.get("AWS_HTTPS", "false").lower() == "true").lower()
+con.execute(f"""
+    CREATE SECRET public_gbif (TYPE S3, KEY_ID '{key}', SECRET '{secret}', REGION 'us-east-1',
+        ENDPOINT '{endpoint}', USE_SSL {use_ssl}, URL_STYLE 'path', SCOPE 's3://public-gbif')
+""")
+con.execute("""
+    CREATE SECRET gbif_public (TYPE S3, KEY_ID '', SECRET '', REGION 'us-east-1',
+        SCOPE 's3://gbif-open-data-us-east-1')
+""")
+
+con.execute(f"""
+    COPY (
+        SELECT *,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 0)  AS h0,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 1)  AS h1,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 2)  AS h2,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 3)  AS h3,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 4)  AS h4,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 5)  AS h5,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 6)  AS h6,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 7)  AS h7,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 8)  AS h8,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 9)  AS h9,
+            h3_latlng_to_cell(decimallatitude, decimallongitude, 10) AS h10
+        FROM read_parquet({chunk})
+        WHERE decimallatitude IS NOT NULL AND decimallongitude IS NOT NULL
+          AND decimallatitude  BETWEEN -90  AND 90
+          AND decimallongitude BETWEEN -180 AND 180
+    ) TO '{OUTPUT}'
+    (FORMAT parquet, PARTITION_BY (h0), COMPRESSION zstd,
+     FILENAME_PATTERN 'job{job_index:04d}_{{i}}', OVERWRITE_OR_IGNORE true)
+""")
+print(f"job {job_index}: done")


### PR DESCRIPTION
## Summary
Rebuilds `public-gbif` on the **2026-06-01** AWS Open Data snapshot (8,375 files / 0.278 TB), superseding the year-stale 2025-06 build, with the integrity + performance fixes from #247 baked in. Output lives in the new `2026-06/` prefix; **2025-06 is untouched** pending the gated swap.

## Pipeline (`catalog/gbif/2026-06/`, ConfigMap-delivered — no datasets-repo clone, Hard Boundary 2)
- **Stage 1** `process_gbif_h3.py` — single-pass `COPY … PARTITION_BY(h0)`, H3 h0–h10, `files_per_chunk` 42 → 200 completions.
- **Stage 2** `consolidate_h0_partitions.py` — dedup by gbifid (#244) + **one file per h0** (#279); `REMAP`/`memory_limit`/`temp_directory` env for the dense-partition rechunk.
- **`gbif-2026-06-consolidate-rechunk.yaml`** — 11 densest partitions OOM'd at 120Gi → reprocessed at **480Gi** on big nodes (PVC spill backstop).
- **`gbif-2026-06-taxonomy.yaml`** — per-h0 taxonomy aggregation (parity with 2025-06).
- **`gbif-2026-06-sidecar.yaml`** — `(specieskey, species, h0)` partition index (#281).
- All on `ghcr.io/boettiger-lab/datasets:latest` (verified via 1-pod test); only boto3 pip-installed.

## Scope corrections recorded in #247
- Kept **h0–h10** (the live 2025-06 hex carries all 11 resolutions; the issue body's "h0–h5" was wrong — verified via `DESCRIBE`).

## Validation (cluster, `mcp__duckdb-geo`)
- Hex: **122 partitions × 1 file each** (densest 126 shards → 1 file, #279); **0 `//` keys** (#240).
- Dedup: per-h0 `COUNT(*)==COUNT(DISTINCT gbifid)` on all 122 (#244); 0 dups in this snapshot.
- No truncation: hex **3,499,090,951 rows == chunk rows**; +16% vs 2025-06's 3.01 B.
- Sidecar: 4.1M rows / 1.4M species; dynamic pruning confirmed (`h0 IN BF`, 2/122 files, median species = 1 partition).
- Taxonomy: 122 partitions.

## Remaining (gated, NOT in this PR)
- Repoint `public-gbif/stac-collection.json` 2025-06 → 2026-06 (+ sidecar asset, NC license) — awaiting go.
- Delete `2025-06/` data — separate explicit go (irreversible).

Refs #247, #279, #244, #240, #281.