### PR TITLE
lint-stac-categorical: precision fixes (identifiers, string-coded enums) [#294]

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -115,6 +115,24 @@ def lint(source: str) -> list[str]:
             desc = col.get("description", "")
             values_arr = col.get("values")
 
+            # Skip pure index/geometry columns up front
+            if col_type in ("uint64", "int64", "geometry") and col_name.startswith("h"):
+                continue
+            if col_name in ("h0", "h1", "h2", "h3", "h4", "h5", "h6", "h7", "h8", "h9", "h10",
+                            "geometry", "geom", "shape", "_cng_fid", "bbox"):
+                continue
+
+            # Skip identifier columns — these are unique keys, not categorical classes,
+            # even though their names often end in "num"/"id" or types are integer.
+            # Discriminator: the description calls it a number/identifier, NOT a code/class.
+            mentions_code = bool(re.search(r"\bcode\b|\bclass\b|categor", desc, re.I))
+            looks_like_identifier = (
+                bool(re.search(r"\b(number|identifier|unique id|object\s*id)\b", desc, re.I))
+                or bool(re.fullmatch(r"(?i).*(_id|objectid|fid|guid|uuid)", col_name))
+            )
+            if looks_like_identifier and not mentions_code:
+                continue
+
             # Detect coded categorical columns:
             # - has a "values" array already (opt-in explicit)
             # - or the description mentions "categorical", "code", or "class code"
@@ -128,16 +146,11 @@ def lint(source: str) -> list[str]:
             if not is_coded:
                 continue
 
-            # Skip pure index/geometry columns
-            if col_type in ("uint64", "int64", "geometry") and col_name.startswith("h"):
-                continue
-            if col_name in ("h0", "h1", "h2", "h3", "h4", "h5", "h6", "h7", "h8", "h9", "h10",
-                            "geometry", "geom", "shape", "_cng_fid", "bbox"):
-                continue
-
-            # Check for inline CODE=Definition list in description
-            # Pattern: one or more "digits=Word" tokens separated by commas
-            has_inline_codes = bool(re.search(r"\d+=\w", desc))
+            # Check for an inline CODE=Definition list in the description.
+            # Accepts numeric codes (1=Lightning) and alphanumeric/string codes
+            # (USF=US Forest Service, OGC:CRS84-style excluded). A single TOKEN=word
+            # pair is a strong signal once the column is already known to be coded.
+            has_inline_codes = bool(re.search(r"[A-Za-z0-9][\w/.-]*\s*=\s*\w", desc))
             if not has_inline_codes:
                 errors.append(
                     f"[{collection_id}] asset '{asset_key}', column '{col_name}': "
@@ -152,9 +165,16 @@ def lint(source: str) -> list[str]:
                     f"coded categorical column missing 'values' array."
                 )
 
-            # Cross-check hex values ⊆ COG classification:classes
-            if values_arr is not None and cog_classes:
-                hex_set = set(int(v) for v in values_arr)
+            # Cross-check hex values ⊆ COG classification:classes.
+            # Only meaningful for numeric codes that line up with raster class values.
+            numeric_vals = None
+            if values_arr is not None:
+                try:
+                    numeric_vals = set(int(v) for v in values_arr)
+                except (ValueError, TypeError):
+                    numeric_vals = None  # string-coded enum (e.g. AGENCY) — no COG to cross-check
+            if numeric_vals is not None and cog_classes:
+                hex_set = numeric_vals
                 for cog_key, cog_map in cog_classes.items():
                     cog_set = set(cog_map.keys())
                     extra = hex_set - cog_set


### PR DESCRIPTION
Part of #294. Refines the categorical lint gate (#292) after sweeping the full catalog.

## Why
The first-pass gate had two false-positive classes that made it impossible for a real dataset to "pass" without polluting metadata — exactly the kind of noise that lets genuine issues hide (the #291 spirit):

1. **Identifier columns** — `INC_NUM` ("Local incident number"), `FIRE_NUM` ("Historical fire number"), `*_id`, `objectid` were flagged as coded categoricals purely on the `*num`/`*id` name suffix. They are unique keys, not classes. Now skipped when the description says *number*/*identifier* and does **not** mention *code*/*class*.
2. **String-coded enums** — e.g. `AGENCY` documented inline as `USF=US Forest Service, CDF=CAL FIRE, …` were flagged "missing inline CODE=Definition list" because the regex only matched numeric `1=Lightning` pairs. Inline detection now accepts alphanumeric `CODE=Definition` pairs.
3. **Cross-check hardening** — string-valued `values` arrays no longer crash the `int()` coercion in the hex⊆COG subset check (it simply skips, since string enums have no COG to cross-check).

## Regression-tested
- CWHR fixed (`cwhr13`, `cwhr`) — still **pass**.
- CWHR pre-fix — still **fail** (64 real issues).
- `calfire-2025-firep` pre-fix — flags only the genuine gaps (`CAUSE`/`OBJECTIVE`/`C_METHOD` missing maps); `INC_NUM`/`FIRE_NUM` no longer flagged.
- `calfire-2025-firep` + `wyoming-nlcd-2024` post-fix — **pass**.

## Companion data fixes (published to NRP S3 this pass, per AGENTS.md — not in repo)
- **`wyoming-nlcd-2024`** `nlcd` hex column: inlined the 20-class NLCD code→name map + `values` from the COG.
- **`calfire-2025-firep`** `CAUSE`/`C_METHOD`/`OBJECTIVE`/`AGENCY` on both parquet and hex assets, sourced from the authoritative CAL FIRE FRAP ArcGIS domain and verified against the actual ingested values. This **corrected real label errors** in the prior CAUSE map (`11`=Electrical Power not "Power Line", `17`=Volcanic, `18`=Escaped Prescribed Burn, added missing `19`=Illegal Alien Campfire) and added the missing `OTH` agency code.