### PR TITLE
STAC: tile-accurate table:columns on PMTiles assets (#283)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,20 @@ rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.j
   Each parquet asset documents exactly the columns it contains:
   - **GeoParquet asset**: include the geometry column (`Shape`, `geom`, or `geometry`)
   - **Hex asset**: exclude the geometry column; include H3 index columns (`h0`, `h8`, `h9`, `h10` etc.) and `_cng_fid`/`bbox` if present
-  - **PMTiles / COG assets**: no `table:columns` needed (not SQL-queryable)
+  - **COG assets**: no `table:columns` needed (not SQL-queryable)
+
+- **PMTiles assets MUST carry tile-accurate `table:columns` (data-workflows #283).** tippecanoe selects a *subset* of source columns at tile-build time, so the PMTiles fields differ from the GeoParquet schema — the parquet's `table:columns` does NOT tell a consumer what's actually in the tiles. Without tile-level schema the geo-agent (and human app authors) cannot discover which fields are stylable/filterable in MapLibre except by byte-ranging the `.pmtiles` footer. So:
+  - List the **actual tile fields** (not the parquet schema) with `name` + `type`, read from the footer's `vector_layers[].fields`. The geometry column is excluded (it's the tile geometry, not a field).
+  - Keep `vector:layers` (the source-layer id list) as well.
+  - **Document nodata sentinels** on the relevant column (e.g. SVI `RPL_THEMES = -999`) and flag the **intended value column** for continuous styling — neither is inferable from the tiles.
+  - Read the footer fields with:
+    ```bash
+    python3 -c 'import urllib.request,json,struct,gzip; u="https://.../layer.pmtiles"; \
+      r=lambda a,b: urllib.request.urlopen(urllib.request.Request(u,headers={"Range":f"bytes={a}-{b}"})).read(); \
+      h=r(0,126); o=struct.unpack_from("<Q",h,24)[0]; n=struct.unpack_from("<Q",h,32)[0]; \
+      m=json.loads(gzip.decompress(r(o,o+n-1)).decode()); print([(L["id"],L.get("fields")) for L in m["vector_layers"]])'
+    ```
+  - Gate with `scripts/lint-stac-pmtiles-fields.py <stac-collection.json|url>` (companion to `lint-stac-categorical.py`).
 
 - **Hex assets MUST declare their H3 resolutions explicitly** via `h3:native_resolution` and `h3:parent_resolutions` on the asset itself. Column-name presence (`h10`, `h9`, …) is not enough — downstream tools shouldn't have to enumerate `table:columns` to find out what resolutions exist. `h3:native_resolution` is the finest resolution (one row per feature-cell at this res); `h3:parent_resolutions` is the list of rollup resolutions, which MUST include `0` (the partition key).
 

--- a/scripts/lint-stac-pmtiles-fields.py
+++ b/scripts/lint-stac-pmtiles-fields.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Lint a STAC collection JSON for PMTiles tile-field completeness.
+
+Rationale (data-workflows #283): tippecanoe selects a *subset* of source columns
+at tile-build time, so the PMTiles fields differ from the source GeoParquet schema.
+A consumer (the geo-agent, or a human app author) can only learn which fields are
+present — and therefore stylable / filterable in MapLibre — from the PMTiles asset
+itself. When `table:columns` is empty the only recovery is byte-ranging the
+`.pmtiles` footer's `vector_layers[].fields`. Nodata sentinels (e.g. SVI
+`RPL_THEMES = -999`) are likewise invisible unless documented.
+
+Checks enforced (per AGENTS.md "PMTiles assets" standard):
+
+1. Every PMTiles asset (`type` contains "pmtiles") MUST declare `vector:layers`
+   (non-empty list of source-layer ids).
+2. Every PMTiles asset MUST have a non-empty `table:columns` listing the
+   tile-accurate fields, each with a `name` and `type`.
+3. Each PMTiles column SHOULD have a non-empty `description` (warning, not error,
+   unless --strict).
+
+Discover the real tile fields with:
+
+    python3 -c 'import urllib.request,json,struct,gzip; \
+        u="https://.../layer.pmtiles"; \
+        r=lambda a,b: urllib.request.urlopen(urllib.request.Request(u,headers={"Range":f"bytes={a}-{b}"})).read(); \
+        h=r(0,126); o=struct.unpack_from("<Q",h,24)[0]; n=struct.unpack_from("<Q",h,32)[0]; \
+        m=json.loads(gzip.decompress(r(o,o+n-1)).decode()); \
+        print([(L["id"],L.get("fields")) for L in m["vector_layers"]])'
+
+Usage:
+    python3 scripts/lint-stac-pmtiles-fields.py path/to/stac-collection.json [...]
+    python3 scripts/lint-stac-pmtiles-fields.py --url https://s3-west.nrp-nautilus.io/...
+
+Exit 0 = all checks pass. Exit 1 = one or more failures.
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def load_doc(source: str) -> dict:
+    if source.startswith("http://") or source.startswith("https://"):
+        with urllib.request.urlopen(source) as r:
+            return json.load(r)
+    return json.loads(Path(source).read_text())
+
+
+def lint(source: str, strict: bool = False) -> list[str]:
+    """Return a list of error strings (empty = pass)."""
+    try:
+        doc = load_doc(source)
+    except Exception as e:
+        return [f"[LOAD ERROR] {e}"]
+
+    errors = []
+    collection_id = doc.get("id", source)
+
+    for asset_key, asset in doc.get("assets", {}).items():
+        mime = asset.get("type", "")
+        if "pmtiles" not in mime:
+            continue
+
+        # 1. vector:layers required
+        vlayers = asset.get("vector:layers")
+        if not vlayers:
+            errors.append(
+                f"[{collection_id}] asset '{asset_key}': PMTiles asset missing "
+                f"'vector:layers' (the MapLibre source-layer id(s))."
+            )
+
+        # 2. table:columns required and non-empty
+        columns = asset.get("table:columns")
+        if not columns:
+            errors.append(
+                f"[{collection_id}] asset '{asset_key}': PMTiles asset has empty "
+                f"'table:columns' — populate the tile-accurate fields from the "
+                f".pmtiles footer (vector_layers[].fields). See data-workflows #283."
+            )
+            continue
+
+        # 3. each column needs name + type (+ description, soft unless --strict)
+        for col in columns:
+            name = col.get("name", "")
+            if not name:
+                errors.append(
+                    f"[{collection_id}] asset '{asset_key}': a table:columns entry "
+                    f"is missing 'name'."
+                )
+                continue
+            if not col.get("type"):
+                errors.append(
+                    f"[{collection_id}] asset '{asset_key}', column '{name}': "
+                    f"missing 'type'."
+                )
+            if not col.get("description"):
+                msg = (
+                    f"[{collection_id}] asset '{asset_key}', column '{name}': "
+                    f"missing 'description'."
+                )
+                if strict:
+                    errors.append(msg)
+                else:
+                    print("[WARN] " + msg, file=sys.stderr)
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("sources", nargs="+", help="Path(s) or URL(s) to stac-collection.json files")
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Treat missing column descriptions as errors (default: warning).",
+    )
+    args = parser.parse_args()
+
+    all_errors = []
+    for src in args.sources:
+        errs = lint(src, strict=args.strict)
+        for e in errs:
+            print(e, file=sys.stderr)
+        all_errors.extend(errs)
+
+    if all_errors:
+        print(f"\n{len(all_errors)} issue(s) found.", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(f"All {len(args.sources)} collection(s) passed PMTiles-fields lint.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #283.

## What

PMTiles vector assets shipped with **empty `table:columns`**, so neither the geo-agent (which learns vector fields via STAC) nor a human app author could discover a layer's fields — or which column to style/filter by — without byte-ranging the `.pmtiles` footer. Nodata sentinels were undocumented too. Because tippecanoe selects a *subset* of source columns at tile-build time, the GeoParquet schema doesn't describe the tiles, so the PMTiles asset itself needs tile-accurate field metadata.

## Data fix (published to NRP S3 — canonical store, not this repo)

Verified each gap against live data before fixing:

- **`svi-2022`**: tiles carry only `COUNTY, FIPS, RPL_THEMES, ST_ABBR` (4 of ~150 parquet cols, confirmed from the footer). Added tile-accurate `table:columns` to `county-pmtiles` / `tract-pmtiles` / `tribal-pmtiles`; documented `RPL_THEMES = -999` nodata (**778 of 84,120 tracts**; county layer has none) and flagged `RPL_THEMES` as the choropleth value column. Also added `vector:layers` to `tribal-pmtiles` (was missing) and backfilled the empty `county-parquet` / `tract-parquet` schemas.
- **`conservation-almanac-2024-sites`**: tiles kept the full attribute set — mirrored the GeoParquet schema (geometry excluded) onto the PMTiles asset.

## Repo changes (this PR)

- **`scripts/lint-stac-pmtiles-fields.py`** — companion gate to `lint-stac-categorical.py`: every PMTiles asset must declare `vector:layers` and a non-empty, tile-accurate `table:columns`. Validated: passes both fixed collections; flags all 5 original gaps.
- **`AGENTS.md`** — updated the STAC standard: PMTiles assets MUST carry tile-accurate `table:columns` + nodata/value-column docs (supersedes the old "PMTiles needs no `table:columns`" line), with a footer-reading snippet.

## Upstream / systemic

Filed boettiger-lab/datasets#140 to populate PMTiles `table:columns` from the footer automatically at publish time — the root cause affects every PMTiles asset, so future datasets shouldn't reintroduce the gap. (nodata/value-column hints stay a per-dataset manual touch — they're source semantics the tool can't infer.)
