### PR TITLE
verify-stac.py: enforce the STAC-correctness check suite via CI (#302)

### DIFF
--- a/.github/workflows/verify-stac.yml
+++ b/.github/workflows/verify-stac.yml
@@ -1,0 +1,97 @@
+name: Verify STAC
+
+# Enforce the STAC-correctness check suite (AGENTS.md Step 5) on every recipe PR.
+#
+# The gate evaluates the PRODUCED artifact, not the proposal: a recipe's STAC + data
+# are published to NRP S3 by the cluster run, which lands AFTER the PR is opened but
+# BEFORE merge. So this workflow runs against the LIVE S3 STAC.
+#
+#   - On pull_request: derive the affected collection(s) from the s3:// paths in the
+#     changed catalog/** workflow YAMLs and verify each. RED at PR-open (recipe hasn't
+#     run yet → STAC 404s) is correct — do not merge before the recipe has produced
+#     valid output. It goes GREEN once the cluster run publishes a conformant STAC.
+#   - GitHub status checks don't auto-refresh from S3, so RE-RUN this workflow via
+#     workflow_dispatch after the cluster jobs finish. Merge requires it green.
+#
+# The data-backed checks POST SQL to the public duckdb-geo MCP endpoint (no auth), so
+# they are not bound by runner resources or the slow public S3 endpoint.
+
+on:
+  pull_request:
+    paths:
+      - 'catalog/**'
+    # sync/audit jobs aren't dataset recipes; they reference buckets via rclone (nrp:)
+    # not s3://, so they derive no targets anyway — excluded here for clarity/speed.
+    paths-ignore:
+      - 'catalog/sync/**'
+      - 'catalog/audit/**'
+  workflow_dispatch:
+    inputs:
+      collection:
+        description: 'Collection STAC URL to verify (overrides bucket/dataset)'
+        required: false
+        type: string
+      bucket:
+        description: 'Bucket, e.g. public-census (with dataset)'
+        required: false
+        type: string
+      dataset:
+        description: 'Dataset path under the bucket, e.g. census-2024/tract'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-stac-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      # Optional bearer token, only if the MCP endpoint is ever locked down.
+      MCP_AUTH_TOKEN: ${{ secrets.MCP_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need the base ref to diff changed files
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify STAC for affected collection(s)
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -n "${{ inputs.collection }}" ]; then
+              echo "Manual dispatch: verifying ${{ inputs.collection }}"
+              python3 scripts/verify-stac.py "${{ inputs.collection }}"
+            elif [ -n "${{ inputs.bucket }}" ]; then
+              echo "Manual dispatch: verifying --bucket ${{ inputs.bucket }} --dataset ${{ inputs.dataset }}"
+              python3 scripts/verify-stac.py --bucket "${{ inputs.bucket }}" --dataset "${{ inputs.dataset }}"
+            else
+              echo "Dispatch with no collection/bucket input — verifying catalog/** changed vs origin/${{ github.event.repository.default_branch }}."
+              FILES=$(git diff --name-only "origin/${{ github.event.repository.default_branch }}" HEAD -- catalog/ \
+                | grep -E '\.ya?ml$' | grep -vE '^catalog/(sync|audit)/' || true)
+              [ -z "$FILES" ] && { echo "No changed catalog YAMLs."; exit 0; }
+              echo "$FILES"
+              python3 scripts/verify-stac.py --yaml $FILES
+            fi
+            exit $?
+          fi
+
+          # pull_request: verify collections derived from the changed workflow YAMLs.
+          BASE="origin/${{ github.base_ref }}"
+          FILES=$(git diff --name-only "$BASE" HEAD -- catalog/ \
+            | grep -E '\.ya?ml$' | grep -vE '^catalog/(sync|audit)/' || true)
+          if [ -z "$FILES" ]; then
+            echo "No changed dataset workflow YAMLs under catalog/** — nothing to verify."
+            exit 0
+          fi
+          echo "Changed workflow YAMLs:"
+          echo "$FILES"
+          python3 scripts/verify-stac.py --yaml $FILES

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,34 @@ rclone copyto /tmp/README.md nrp:<bucket>/README.md
 rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.json
 ```
 
+#### ⛔ Verify the STAC — don't hand-check the rules
+
+Every STAC rule below is enforced by **`scripts/verify-stac.py`** (license, nav links,
+asset keys, hex glob, `h3:*` resolutions, `vector:layers`, `table:columns` placement,
+per-feature-dup warnings, categorical completeness + PMTiles fields via the two
+sibling linters, and a **data-backed `values` == ingested `DISTINCT`** check via the
+MCP that automates the #114/#294 lesson). Do not re-verify these by hand or by
+spending agent context on MCP `SELECT DISTINCT` sweeps — run the gate.
+
+```bash
+# 1. PRE-PUBLISH (static, against the /tmp file you just wrote):
+scripts/verify-stac.py --no-data /tmp/stac-collection.json
+#    Fix every HARD finding before rclone copyto. (Data checks need the data live, so
+#    they run post-publish; --no-data skips them here.)
+
+# 2. POST-CLUSTER (full, against the live S3 STAC, once data + STAC are published):
+scripts/verify-stac.py --bucket <bucket> --dataset <dataset>
+#    Must exit 0 (no HARD findings). ADVISORY lines are informational.
+```
+
+CI runs the same verifier on the PR (`.github/workflows/verify-stac.yml`), deriving the
+collection(s) from the `s3://` paths in the changed `catalog/**` YAMLs. **The gate
+evaluates the produced artifact, not the proposal:** the cluster run lands after the PR
+opens, so a RED check at PR-open (STAC not published yet) is correct — don't merge
+before the recipe has actually produced valid output. GitHub status checks don't
+auto-refresh from S3, so **after your cluster jobs finish, re-fire the check** (Actions
+→ Verify STAC → *Run workflow*, or it re-runs on the next push). Merge requires it green.
+
 **README.md MUST include:**
 - A MapLibre GL JS example with the correct `source-layer` (= last segment of `--dataset`), documented prominently
 - A DuckDB example with the full public parquet URL

--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -149,6 +149,19 @@ def lint(source: str) -> list[str]:
                 if is_source:
                     continue
 
+                # Skip FIPS / fixed-width geographic identifier codes — GEOID-component
+                # keys (STATEFP/COUNTYFP/TRACTCE/SLDLST/SLDUST…) and FIPS/STCNTY/iso3.
+                # These are identifier components, not enumerable classes (#303). The
+                # discriminator is a "FIPS code" or "<thing> code (N digits)" description
+                # (a fixed-width numeric key) or a known identifier name; genuine small
+                # enums (MTFCC, CLASSFP, FUNCSTAT) carry neither signal and still flag.
+                is_geo_identifier = (
+                    bool(re.search(r"\bfips code\b|\bcode \(\d+\s*digits?\)", desc_l))
+                    or bool(re.fullmatch(r"(?i)(fips|stcnty|iso3|geoid\w*)", col_name))
+                )
+                if is_geo_identifier:
+                    continue
+
                 # Skip identifier columns — unique keys / external record codes, not
                 # categorical classes, even though their names often end in "num"/"id"/"cd"
                 # or their types are integer. Discriminator: the description calls it a

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python3
+"""
+verify-stac.py — one verifier for the whole STAC-correctness check suite.
+
+Promotes every written STAC rule in AGENTS.md from "an agent remembered it" to an
+enforced gate. Runs three tiers of checks against a published STAC collection:
+
+  HARD      — a real defect; exits non-zero. Blocks merge / publish.
+  ADVISORY  — informational; printed but never affects exit code (keeps the gate
+              precise — see the categorical recall gap below).
+
+Static checks (no data; just the STAC JSON):
+  - license present + a recognized SPDX id, or other/various/proprietary WITH a
+    license link
+  - nav links: self/root/parent present + well-formed; child (if any) well-formed
+  - asset keys follow {last-segment}-{format}; no generic keys
+    (pmtiles/geoparquet/hex/parquet/cog/h3-parquet)
+  - hex asset href uses the hive glob  …/hex/h0=*/data_0.parquet  (not a bare dir)
+  - hex asset declares h3:native_resolution + h3:parent_resolutions (incl 0)
+  - vector:layers on every PMTiles asset
+  - table:columns on each parquet asset (NOT collection-level); geometry column
+    included on the geoparquet asset, excluded on the hex asset
+  - per-feature-duplication warning on aggregatable hex columns (area/length/
+    count/amount/…)
+  - categorical raster COG classification:classes completeness  [reuses lint-stac-categorical]
+  - point datasets: a processing-resolution note in description/processing:notes
+  - categorical column completeness (values + inline CODE=Name)  [reuses lint-stac-categorical]
+  - PMTiles tile-accurate table:columns                          [reuses lint-stac-pmtiles-fields]
+
+Data-backed check (delegated to the duckdb-geo MCP server, --no-data to skip):
+  - every coded column's `values` array == the ingested DISTINCT set (automates the
+    #114/#294 lesson; column-projected, never decodes the geometry chunk)
+
+Advisory recall pass (never blocks):
+  - candidate string-categorical columns with a low DISTINCT count and no `values`
+    array — catches the recall gap that missed PAD-US IUCN_Cat / Pub_Access
+
+Usage:
+    scripts/verify-stac.py <collection-url-or-path> [...]
+    scripts/verify-stac.py --bucket public-census --dataset census-2024/tract
+    scripts/verify-stac.py --no-data <url>            # static + advisory only
+    scripts/verify-stac.py --strict <url>             # promote chosen advisories to hard
+
+Exit 0 = no HARD findings. Exit 1 = one or more HARD findings.
+
+The heavy data check POSTs SQL to the public duckdb-geo MCP endpoint
+(https://duckdb-mcp.nrp-nautilus.io/mcp, no auth), so it is not bound by GitHub
+runner resources or the slow public S3 endpoint. Set MCP_ENDPOINT to override and
+MCP_AUTH_TOKEN for a bearer token if the endpoint is ever locked down.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Severities & finding model
+# ---------------------------------------------------------------------------
+
+HARD = "HARD"
+ADVISORY = "ADVISORY"
+
+
+class Finding:
+    __slots__ = ("severity", "code", "message")
+
+    def __init__(self, severity: str, code: str, message: str):
+        self.severity = severity
+        self.code = code
+        self.message = message
+
+    def render(self, collection_id: str) -> str:
+        tag = "ADVISORY" if self.severity == ADVISORY else "HARD"
+        return f"[{tag}][{self.code}] [{collection_id}] {self.message}"
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+NRP = "https://s3-west.nrp-nautilus.io"
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def load_doc(source: str) -> dict:
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source, timeout=60) as r:
+            return json.load(r)
+    return json.loads(Path(source).read_text())
+
+
+# Buckets that hold pipeline infrastructure / the root catalog, never a dataset.
+INFRA_BUCKETS = {"public-grids", "public-data", "public-output", "public-test",
+                 "public-requests"}
+
+
+def targets_from_yaml(text: str) -> set[tuple[str, str]]:
+    """Extract (bucket, dataset) collection targets from a generated workflow YAML.
+
+    The cng-datasets manifests reference each dataset by its S3 paths — e.g.
+    s3://public-census/census-2024/tract.parquet, …/tract/hex, …/tract/chunks —
+    which all collapse to the dataset 'census-2024/tract'. We never see the STAC URL
+    in-repo (STAC lives only on S3), so the S3 path is the signal.
+    """
+    targets = set()
+    for bucket, rest in re.findall(r"s3://(public-[a-z0-9-]+)/([^\s'\"]+)", text):
+        if bucket in INFRA_BUCKETS:
+            continue
+        rest = rest.strip("/")
+        if not rest or rest == "raw" or rest.startswith("raw/"):
+            continue  # bucket-level / raw inputs aren't a dataset collection
+        rest = re.sub(r"\.(parquet|pmtiles|tif|tiff|gpkg|geojson)$", "", rest)
+        for marker in ("/hex/", "/hex", "/chunks/", "/chunks", "/temp_versions"):
+            i = rest.find(marker)
+            if i >= 0:
+                rest = rest[:i]
+                break
+        rest = rest.strip("/")
+        if rest and rest != "raw":
+            targets.add((bucket, rest))
+    return targets
+
+
+def derive_url(bucket: str, dataset: str) -> str:
+    """Collection URL from --bucket/--dataset, per the catalog's self-link convention:
+    https://s3-west.nrp-nautilus.io/<bucket>/<dataset>/stac-collection.json
+    A dataset of '' (bucket-level collection) → …/<bucket>/stac-collection.json.
+    """
+    bucket = bucket.strip("/")
+    dataset = (dataset or "").strip("/")
+    path = f"{bucket}/{dataset}" if dataset else bucket
+    return f"{NRP}/{path}/stac-collection.json"
+
+
+# ---------------------------------------------------------------------------
+# Reuse the two existing standalone linters (filenames have dashes → import by path)
+# ---------------------------------------------------------------------------
+
+def _load_sibling(modname: str, filename: str):
+    path = SCRIPT_DIR / filename
+    if not path.exists():
+        return None
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+_categorical = _load_sibling("lint_stac_categorical", "lint-stac-categorical.py")
+_pmtiles = _load_sibling("lint_stac_pmtiles_fields", "lint-stac-pmtiles-fields.py")
+
+
+# ---------------------------------------------------------------------------
+# SPDX
+# ---------------------------------------------------------------------------
+
+# Curated set of SPDX ids that actually appear (or plausibly will) in this catalog,
+# plus the sanctioned non-SPDX escape hatches. An id outside this set that still
+# matches the SPDX shape is ADVISORY, not HARD — we don't want to block on an
+# obscure-but-valid id we haven't enumerated.
+KNOWN_SPDX = {
+    "CC0-1.0", "CC-BY-1.0", "CC-BY-2.0", "CC-BY-2.5", "CC-BY-3.0", "CC-BY-4.0",
+    "CC-BY-SA-3.0", "CC-BY-SA-4.0", "CC-BY-NC-3.0", "CC-BY-NC-4.0",
+    "CC-BY-NC-SA-3.0", "CC-BY-NC-SA-4.0", "CC-BY-ND-4.0", "CC-BY-NC-ND-4.0",
+    "CDLA-Permissive-1.0", "CDLA-Permissive-2.0", "CDLA-Sharing-1.0",
+    "ODbL-1.0", "ODC-By-1.0", "PDDL-1.0",
+    "Apache-2.0", "MIT", "BSD-2-Clause", "BSD-3-Clause", "GPL-3.0-only",
+    "OGL-UK-3.0",
+}
+# Sanctioned non-SPDX values (AGENTS.md): escape hatches + US federal works.
+NON_SPDX_OK = {"other", "various", "proprietary", "public-domain"}
+# These REQUIRE an accompanying license link.
+NEED_LICENSE_LINK = {"other", "various", "proprietary"}
+SPDX_SHAPE = re.compile(r"^[A-Za-z0-9.+-]+$")
+
+GENERIC_ASSET_KEYS = {"pmtiles", "geoparquet", "hex", "parquet", "cog", "h3-parquet", "h3"}
+
+# Name tokens that mark a hex column as a per-feature magnitude — a value that is
+# wrong to SUM across the duplicated (feature, cell) rows. Matched against *name*
+# tokens only (never the description: e.g. PAD-US descriptions all contain
+# "protected area", which would match everything), and only when the column type
+# is numeric (a per-feature total is never a string/struct).
+AGGREGATABLE_TOKENS = {
+    "acre", "acres", "area", "areas", "length", "perimeter", "perim",
+    "population", "pop", "count", "counts", "amount", "funding", "fund",
+    "hectare", "hectares", "person", "persons", "dollar", "dollars", "cost",
+    "mile", "miles", "sum", "total", "aland", "awater",
+}
+SAFE_HEX_COLS = {"h0", "h1", "h2", "h3", "h4", "h5", "h6", "h7", "h8", "h9",
+                 "h10", "h11", "h12", "_cng_fid", "bbox"}
+GEOM_COLS = {"geometry", "geom", "shape", "the_geom", "wkb_geometry"}  # compared lowercased
+
+
+def _is_numeric_type(t: str) -> bool:
+    return t.lower().startswith(("int", "uint", "float", "double", "decimal", "number"))
+
+
+def _name_tokens(name: str) -> set[str]:
+    """Split a column name on underscores and camelCase boundaries; lowercase."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    return {t.lower() for t in re.split(r"[_\W]+", spaced) if t}
+
+
+def _is_geom_col(name: str) -> bool:
+    return name.lower() in GEOM_COLS
+
+
+def is_parquet(asset: dict) -> bool:
+    return "parquet" in asset.get("type", "")
+
+
+def is_hex_asset(key: str, asset: dict) -> bool:
+    href = asset.get("href", "")
+    return "/hex/" in href or key.endswith("-hex") or key == "hex"
+
+
+def is_pmtiles(asset: dict) -> bool:
+    return "pmtiles" in asset.get("type", "")
+
+
+def is_cog(asset: dict) -> bool:
+    t = asset.get("type", "")
+    return "tiff" in t or "geotiff" in t or bool(asset.get("raster:bands"))
+
+
+# ---------------------------------------------------------------------------
+# Static checks
+# ---------------------------------------------------------------------------
+
+def check_license(doc: dict) -> list[Finding]:
+    out = []
+    lic = doc.get("license")
+    links = doc.get("links", [])
+    has_license_link = any(l.get("rel") == "license" for l in links)
+
+    if not lic:
+        out.append(Finding(HARD, "license-missing",
+                            "collection has no top-level `license` — set the upstream "
+                            "SPDX id (or other/various/proprietary/public-domain)."))
+        return out
+
+    if lic in NON_SPDX_OK:
+        if lic in NEED_LICENSE_LINK and not has_license_link:
+            out.append(Finding(HARD, "license-link-missing",
+                                f"license is '{lic}' but there is no "
+                                f"{{'rel':'license'}} link to the canonical terms URL."))
+        return out
+
+    if lic in KNOWN_SPDX:
+        return out
+
+    if SPDX_SHAPE.match(lic):
+        out.append(Finding(ADVISORY, "license-unknown-spdx",
+                            f"license '{lic}' is not in the verifier's known-SPDX set — "
+                            f"confirm it is a valid SPDX identifier (verifier set is "
+                            f"curated, not exhaustive)."))
+    else:
+        out.append(Finding(HARD, "license-invalid",
+                            f"license '{lic}' is neither a recognized SPDX id nor one of "
+                            f"{sorted(NON_SPDX_OK)} — do not guess; verify upstream terms."))
+    return out
+
+
+def check_nav_links(doc: dict) -> list[Finding]:
+    out = []
+    links = doc.get("links", [])
+    by_rel = {}
+    for l in links:
+        by_rel.setdefault(l.get("rel"), []).append(l)
+
+    for rel in ("self", "root", "parent"):
+        got = by_rel.get(rel)
+        if not got:
+            out.append(Finding(HARD, f"nav-{rel}-missing",
+                                f"missing required navigation link rel='{rel}'."))
+            continue
+        href = got[0].get("href", "")
+        if not href.startswith(("http://", "https://")):
+            out.append(Finding(HARD, f"nav-{rel}-malformed",
+                                f"rel='{rel}' link href is not an absolute URL: {href!r}."))
+
+    # root should point at the canonical root catalog
+    root = by_rel.get("root")
+    if root and "public-data/stac/catalog.json" not in root[0].get("href", ""):
+        out.append(Finding(ADVISORY, "nav-root-noncanonical",
+                            f"rel='root' is {root[0].get('href')!r}; canonical root is "
+                            f"{NRP}/public-data/stac/catalog.json."))
+
+    # child is optional (leaf collections have none) but must be well-formed if present
+    for c in by_rel.get("child", []):
+        if not c.get("href", "").startswith(("http://", "https://")):
+            out.append(Finding(HARD, "nav-child-malformed",
+                                f"a rel='child' link href is not an absolute URL: "
+                                f"{c.get('href')!r}."))
+        if c.get("rel") == "item":
+            out.append(Finding(HARD, "nav-child-is-item",
+                                "sub-collections must use rel='child', not 'item' "
+                                "(item is for STAC Items/features)."))
+    return out
+
+
+def check_asset_keys(doc: dict) -> list[Finding]:
+    out = []
+    for key in doc.get("assets", {}):
+        if key in GENERIC_ASSET_KEYS:
+            out.append(Finding(HARD, "asset-key-generic",
+                                f"asset key '{key}' is a generic format name — use "
+                                f"'{{last-segment}}-{{format}}' (e.g. 'tract-{key}') so keys "
+                                f"don't collide across collections."))
+    return out
+
+
+def check_hex_assets(doc: dict) -> list[Finding]:
+    out = []
+    for key, asset in doc.get("assets", {}).items():
+        if not (is_parquet(asset) and is_hex_asset(key, asset)):
+            continue
+        href = asset.get("href", "")
+        # hive glob, not a bare directory
+        if not re.search(r"/hex/h0=\*/[^/]+\.parquet$", href):
+            out.append(Finding(HARD, "hex-href-not-glob",
+                                f"asset '{key}' hex href must be the hive glob "
+                                f"…/hex/h0=*/data_0.parquet, got {href!r}."))
+        # h3 resolutions declared
+        native = asset.get("h3:native_resolution")
+        parents = asset.get("h3:parent_resolutions")
+        if native is None:
+            out.append(Finding(HARD, "hex-no-native-res",
+                                f"asset '{key}' missing 'h3:native_resolution'."))
+        if parents is None:
+            out.append(Finding(HARD, "hex-no-parent-res",
+                                f"asset '{key}' missing 'h3:parent_resolutions'."))
+        elif 0 not in parents:
+            out.append(Finding(HARD, "hex-parent-res-no-0",
+                                f"asset '{key}' h3:parent_resolutions {parents} must "
+                                f"include 0 (the partition key)."))
+    return out
+
+
+def check_vector_layers(doc: dict) -> list[Finding]:
+    out = []
+    for key, asset in doc.get("assets", {}).items():
+        if is_pmtiles(asset) and not asset.get("vector:layers"):
+            out.append(Finding(HARD, "pmtiles-no-vector-layers",
+                                f"PMTiles asset '{key}' missing 'vector:layers' "
+                                f"(the MapLibre source-layer id)."))
+    return out
+
+
+def check_table_columns_placement(doc: dict) -> list[Finding]:
+    out = []
+    if "table:columns" in doc:
+        out.append(Finding(HARD, "table-columns-collection-level",
+                            "`table:columns` is at the collection level — it must live on "
+                            "each parquet asset, not the collection."))
+    for key, asset in doc.get("assets", {}).items():
+        if not is_parquet(asset):
+            continue
+        cols = asset.get("table:columns")
+        if not cols:
+            out.append(Finding(HARD, "parquet-no-table-columns",
+                                f"parquet asset '{key}' has no 'table:columns'."))
+            continue
+        has_geom = any(_is_geom_col(c.get("name", "")) for c in cols)
+        is_hex = is_hex_asset(key, asset)
+        if is_hex and has_geom:
+            out.append(Finding(HARD, "hex-has-geom-column",
+                                f"hex asset '{key}' lists a geometry column in "
+                                f"table:columns — hex parquet has no geometry; remove it."))
+        if not is_hex and not has_geom:
+            out.append(Finding(ADVISORY, "geoparquet-no-geom-column",
+                                f"geoparquet asset '{key}' table:columns lists no geometry "
+                                f"column ({sorted(GEOM_COLS)}); confirm it isn't a hex asset."))
+    return out
+
+
+def check_hex_dup_warning(doc: dict) -> list[Finding]:
+    """Any aggregatable per-feature column on a hex asset must warn that it is repeated
+    per (feature, cell) and give a dedup recipe."""
+    out = []
+    for key, asset in doc.get("assets", {}).items():
+        if not (is_parquet(asset) and is_hex_asset(key, asset)):
+            continue
+        for col in asset.get("table:columns", []):
+            name = col.get("name", "")
+            if name in SAFE_HEX_COLS or _is_geom_col(name):
+                continue
+            # Per-feature totals are numeric; a string/struct column is never one.
+            if not _is_numeric_type(col.get("type", "")):
+                continue
+            if not (_name_tokens(name) & AGGREGATABLE_TOKENS):
+                continue
+            desc = col.get("description", "")
+            warns = bool(re.search(
+                r"repeated (on|for) every|never (use )?sum|do not sum|don't sum|"
+                r"per[- ]?\(?feature|count\(distinct|row_number|select distinct|"
+                r"deduplicat|dedup", desc, re.I))
+            if not warns:
+                out.append(Finding(HARD, "hex-dup-warning-missing",
+                                    f"hex asset '{key}' column '{name}' looks like a "
+                                    f"per-feature total but its description has no "
+                                    f"duplication warning / dedup recipe (one hex row = one "
+                                    f"(feature, cell) pair — SUM over hex double-counts)."))
+    return out
+
+
+def check_point_note(doc: dict) -> list[Finding]:
+    """If this is a point dataset, it must document the processing resolution."""
+    out = []
+    gtype = (doc.get("properties", {}) or {}).get("geometry_type", "")
+    text = " ".join([
+        doc.get("description", ""),
+        json.dumps(doc.get("properties", {}).get("processing:notes", "")),
+        doc.get("properties", {}).get("processing:notes", "") if isinstance(
+            doc.get("properties", {}).get("processing:notes"), str) else "",
+    ]).lower()
+    is_pointish = "point" in gtype.lower() or "point observation" in text or "each point" in text
+    if not is_pointish:
+        return out
+    mentions_res = bool(re.search(r"h3 resolution\s*\d+|resolution\s*\d+|→\s*one h3|one h3 cell", text))
+    if not mentions_res:
+        out.append(Finding(ADVISORY, "point-no-resolution-note",
+                            "looks like a point dataset but description/processing:notes "
+                            "do not state the H3 processing resolution (each point → one "
+                            "cell at res N)."))
+    return out
+
+
+def run_sibling_linter(mod, doc_source: str, code: str) -> list[Finding]:
+    """Wrap an existing linter's `lint()` (returns list[str]) as HARD findings."""
+    if mod is None:
+        return [Finding(ADVISORY, f"{code}-unavailable",
+                        f"sibling linter for '{code}' not found next to verify-stac.py.")]
+    try:
+        errs = mod.lint(doc_source)
+    except Exception as e:  # never let a linter crash abort the whole verify
+        return [Finding(ADVISORY, f"{code}-error", f"sibling linter '{code}' raised: {e}")]
+    # The sibling linters prefix each message with "[collection_id] " — strip it so
+    # render() doesn't print the id twice.
+    return [Finding(HARD, code, re.sub(r"^\[[^\]]+\]\s*", "", e)) for e in errs]
+
+
+STATIC_CHECKS = [
+    check_license,
+    check_nav_links,
+    check_asset_keys,
+    check_hex_assets,
+    check_vector_layers,
+    check_table_columns_placement,
+    check_hex_dup_warning,
+    check_point_note,
+]
+
+
+# ---------------------------------------------------------------------------
+# MCP client (streamable HTTP, JSON-RPC 2.0, SSE-framed replies)
+# ---------------------------------------------------------------------------
+
+DEFAULT_MCP = os.environ.get("MCP_ENDPOINT", "https://duckdb-mcp.nrp-nautilus.io/mcp")
+
+
+class MCPError(Exception):
+    pass
+
+
+class MCPClient:
+    """Minimal client for the duckdb-geo MCP server's `query` tool. Stdlib only."""
+
+    def __init__(self, endpoint: str = DEFAULT_MCP, token: str | None = None, timeout: int = 300):
+        self.endpoint = endpoint
+        self.token = token or os.environ.get("MCP_AUTH_TOKEN")
+        self.timeout = timeout
+        self.session_id = None
+
+    def _headers(self) -> dict:
+        h = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self.token:
+            h["Authorization"] = f"Bearer {self.token}"
+        if self.session_id:
+            h["Mcp-Session-Id"] = self.session_id
+        return h
+
+    @staticmethod
+    def _parse_sse(body: bytes) -> dict:
+        """Pull the first JSON-RPC payload out of an SSE (or plain-JSON) body."""
+        text = body.decode("utf-8", "replace")
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                return json.loads(line[len("data:"):].strip())
+        # Some servers reply with bare JSON
+        text = text.strip()
+        if text:
+            return json.loads(text)
+        raise MCPError("empty MCP response")
+
+    def _post(self, payload: dict, capture_session: bool = False) -> dict:
+        data = json.dumps(payload).encode()
+        req = urllib.request.Request(self.endpoint, data=data, headers=self._headers(), method="POST")
+        with urllib.request.urlopen(req, timeout=self.timeout) as r:
+            if capture_session:
+                sid = r.headers.get("Mcp-Session-Id") or r.headers.get("mcp-session-id")
+                if sid:
+                    self.session_id = sid
+            return self._parse_sse(r.read())
+
+    def initialize(self):
+        resp = self._post({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "verify-stac", "version": "0.1"},
+            },
+        }, capture_session=True)
+        if "error" in resp:
+            raise MCPError(f"initialize failed: {resp['error']}")
+        # required follow-up notification (no response expected)
+        try:
+            note = json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}).encode()
+            req = urllib.request.Request(self.endpoint, data=note, headers=self._headers(), method="POST")
+            urllib.request.urlopen(req, timeout=30).read()
+        except Exception:
+            pass  # some servers don't require / don't reply to this
+
+    def query(self, sql: str) -> list[dict]:
+        """Run SQL via the `query` tool; return rows as a list of dicts (best-effort)."""
+        resp = self._post({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "query", "arguments": {"sql_query": sql}},
+        })
+        if "error" in resp:
+            raise MCPError(f"query error: {resp['error']}")
+        result = resp.get("result", {})
+        # MCP tool result: {"content": [{"type":"text","text": "..."}], "isError": bool}
+        if result.get("isError"):
+            txt = _first_text(result)
+            raise MCPError(f"query tool reported error: {txt}")
+        return _rows_from_tool_result(result)
+
+
+def _first_text(result: dict) -> str:
+    for block in result.get("content", []):
+        if block.get("type") == "text":
+            return block.get("text", "")
+    return ""
+
+
+def _rows_from_tool_result(result: dict):
+    """The query tool returns a markdown table in a text block. We only need the
+    single projected column's values, so parse the markdown table generically."""
+    text = _first_text(result)
+    # structuredContent is preferred if the server provides it
+    sc = result.get("structuredContent")
+    if isinstance(sc, dict) and isinstance(sc.get("rows"), list):
+        return sc["rows"]
+    return _parse_markdown_table(text)
+
+
+def _parse_markdown_table(text: str) -> list[dict]:
+    rows, header, seen_sep = [], None, False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("|"):
+            if header is not None and seen_sep:
+                break  # table ended
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if header is None:
+            header = cells
+            continue
+        if re.fullmatch(r"[:\-\s|]+", line):  # separator row
+            seen_sep = True
+            continue
+        rows.append(dict(zip(header, cells)))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Data-backed check: values arrays == ingested DISTINCT
+# ---------------------------------------------------------------------------
+
+def _coded_columns(doc: dict):
+    """Yield (asset_key, s3_path, column_name, declared_values) for every parquet
+    asset column that declares a `values` array. Prefer the geoparquet asset over
+    the hex asset when both carry the same column (smaller, no dup rows)."""
+    for key, asset in doc.get("assets", {}).items():
+        if not is_parquet(asset):
+            continue
+        href = asset.get("href", "")
+        s3 = _to_s3(href)
+        if not s3:
+            continue
+        for col in asset.get("table:columns", []):
+            vals = col.get("values")
+            if vals:
+                yield key, s3, col.get("name", ""), vals
+
+
+def _to_s3(href: str) -> str | None:
+    """Map a public https NRP href to an s3:// path the MCP can read internally."""
+    m = re.match(r"https?://s3-west\.nrp-nautilus\.io/(.+)$", href)
+    if m:
+        return "s3://" + m.group(1)
+    if href.startswith("s3://"):
+        return href
+    return None
+
+
+def _sql_str_tuples(values) -> str:
+    """Render declared values as DuckDB VALUES rows of escaped string literals."""
+    rows = []
+    for v in values:
+        s = str(v).replace("'", "''")
+        rows.append(f"('{s}')")
+    return ", ".join(rows)
+
+
+def check_values_match_distinct(doc: dict, mcp: MCPClient) -> list[Finding]:
+    """Compare each declared `values` array to the ingested DISTINCT set. The diff is
+    computed *in SQL* (not by parsing a DISTINCT row-list) because the MCP query tool
+    truncates large markdown tables — a parsed list would silently drop the tail and
+    fabricate findings. Pushing the set-difference into DuckDB returns only the
+    discrepancies, so the result is tiny and truncation-proof."""
+    out = []
+    seen = set()  # one (s3_path, column) may appear on multiple assets
+    for asset_key, s3, col, declared in _coded_columns(doc):
+        if not col or not declared or (s3, col) in seen:
+            continue
+        seen.add((s3, col))
+        decl_rows = _sql_str_tuples(declared)
+        sql = (
+            f'WITH ingested AS (SELECT DISTINCT CAST("{col}" AS VARCHAR) AS v '
+            f"  FROM read_parquet('{s3}') WHERE \"{col}\" IS NOT NULL), "
+            f"declared AS (SELECT * FROM (VALUES {decl_rows}) t(v)) "
+            f"SELECT 'missing' AS kind, v FROM ingested WHERE v NOT IN (SELECT v FROM declared) "
+            f"UNION ALL "
+            f"SELECT 'extra' AS kind, v FROM declared WHERE v NOT IN (SELECT v FROM ingested) "
+            f"ORDER BY kind, v"
+        )
+        try:
+            rows = mcp.query(sql)
+        except MCPError as e:
+            out.append(Finding(ADVISORY, "data-query-failed",
+                               f"asset '{asset_key}' column '{col}': could not verify "
+                               f"DISTINCT against data ({e})."))
+            continue
+        missing = sorted(str(r.get("v")) for r in rows if r.get("kind") == "missing")
+        extra = sorted(str(r.get("v")) for r in rows if r.get("kind") == "extra")
+        if missing:
+            out.append(Finding(HARD, "values-incomplete",
+                               f"asset '{asset_key}' column '{col}': ingested values "
+                               f"{missing[:25]} are NOT in the declared `values` array — "
+                               f"the code→name map is incomplete or wrong (#114/#294 class)."))
+        if extra:
+            out.append(Finding(ADVISORY, "values-extra",
+                               f"asset '{asset_key}' column '{col}': declared values "
+                               f"{extra[:25]} never appear in the data (stale or superset — "
+                               f"acceptable if intentional)."))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Advisory recall pass — candidate categoricals that declare no `values`
+# ---------------------------------------------------------------------------
+
+# Columns we already know are NOT categorical even at low cardinality.
+RECALL_SKIP_NAME = re.compile(
+    r"^(h\d+|_cng_fid|bbox|geometry|geom|shape)$|"
+    r"fp$|fips|geoid|^st$|iso3?$|_id$|objectid|guid|uuid|"
+    r"name|date|dt$|src$|source|_acres?$|area|length", re.I)
+RECALL_MAX_DISTINCT = 40
+
+
+def recall_pass(doc: dict, mcp: MCPClient) -> list[Finding]:
+    out = []
+    seen = set()
+    for key, asset in doc.get("assets", {}).items():
+        if not is_parquet(asset):
+            continue
+        s3 = _to_s3(asset.get("href", ""))
+        if not s3:
+            continue
+        for col in asset.get("table:columns", []):
+            name = col.get("name", "")
+            ctype = col.get("type", "")
+            if not name or col.get("values") or name in SAFE_HEX_COLS or _is_geom_col(name):
+                continue
+            if RECALL_SKIP_NAME.search(name):
+                continue
+            # only string/short-int columns are plausible enums
+            if not (ctype.startswith(("string", "varchar", "utf8")) or ctype in ("int16", "uint8", "int8")):
+                continue
+            if (s3, name) in seen:
+                continue
+            seen.add((s3, name))
+            sql = f'SELECT COUNT(DISTINCT "{name}") AS n FROM read_parquet(\'{s3}\')'
+            try:
+                rows = mcp.query(sql)
+                n = int(rows[0]["n"]) if rows else None
+            except (MCPError, ValueError, KeyError, IndexError):
+                continue
+            if n is not None and 2 <= n <= RECALL_MAX_DISTINCT:
+                out.append(Finding(ADVISORY, "recall-candidate-categorical",
+                                   f"asset '{key}' column '{name}' has {n} distinct values "
+                                   f"and no `values` array — possible undocumented "
+                                   f"categorical (recall-gap check)."))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def verify(source: str, do_data: bool = True, do_recall: bool = True,
+           mcp: MCPClient | None = None) -> tuple[str, list[Finding]]:
+    try:
+        doc = load_doc(source)
+    except Exception as e:
+        return source, [Finding(HARD, "load-error", f"could not load STAC: {e}")]
+
+    collection_id = doc.get("id", source)
+    findings: list[Finding] = []
+    for check in STATIC_CHECKS:
+        findings.extend(check(doc))
+
+    # Reuse the two standalone linters (these fetch/parse the doc themselves).
+    findings.extend(run_sibling_linter(_categorical, source, "categorical"))
+    findings.extend(run_sibling_linter(_pmtiles, source, "pmtiles-fields"))
+
+    if do_data or do_recall:
+        client = mcp
+        if client is None:
+            client = MCPClient()
+            try:
+                client.initialize()
+            except Exception as e:
+                findings.append(Finding(ADVISORY, "mcp-unavailable",
+                                        f"data checks skipped — MCP not reachable: {e}"))
+                client = None
+        if client is not None:
+            if do_data:
+                findings.extend(check_values_match_distinct(doc, client))
+            if do_recall:
+                findings.extend(recall_pass(doc, client))
+
+    return collection_id, findings
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sources", nargs="*",
+                   help="STAC collection URL(s) or local path(s).")
+    p.add_argument("--bucket", help="Bucket (with --dataset) to derive the collection URL.")
+    p.add_argument("--dataset", default="",
+                   help="Dataset path under the bucket (e.g. census-2024/tract). "
+                        "Empty = bucket-level collection.")
+    p.add_argument("--yaml", nargs="*", default=[],
+                   help="Generated workflow YAML file(s); derive collection target(s) "
+                        "from their s3:// paths (used by CI on changed catalog/** files).")
+    p.add_argument("--no-data", action="store_true",
+                   help="Skip the MCP-backed DISTINCT check (static + recall only).")
+    p.add_argument("--no-recall", action="store_true",
+                   help="Skip the advisory recall pass.")
+    p.add_argument("--strict", action="store_true",
+                   help="Promote the geoparquet-no-geom and unknown-SPDX advisories to hard.")
+    args = p.parse_args()
+
+    sources = list(args.sources)
+    if args.bucket:
+        sources.append(derive_url(args.bucket, args.dataset))
+    if args.yaml:
+        targets = set()
+        for path in args.yaml:
+            try:
+                targets |= targets_from_yaml(Path(path).read_text())
+            except OSError as e:
+                print(f"[warn] could not read {path}: {e}", file=sys.stderr)
+        for bucket, dataset in sorted(targets):
+            sources.append(derive_url(bucket, dataset))
+        if not targets:
+            print("No dataset collection targets derived from the given YAML(s) — "
+                  "nothing to verify.", file=sys.stderr)
+    if not sources:
+        # --yaml with no derivable targets is a clean no-op (e.g. a sync/infra PR).
+        if args.yaml:
+            sys.exit(0)
+        p.error("provide a collection URL/path, --bucket [--dataset], or --yaml FILE.")
+    # de-dup while preserving order
+    sources = list(dict.fromkeys(sources))
+
+    total_hard = 0
+    for src in sources:
+        collection_id, findings = verify(
+            src, do_data=not args.no_data, do_recall=not args.no_recall)
+        if args.strict:
+            for f in findings:
+                if f.code in ("geoparquet-no-geom-column", "license-unknown-spdx"):
+                    f.severity = HARD
+        hard = [f for f in findings if f.severity == HARD]
+        adv = [f for f in findings if f.severity == ADVISORY]
+        print(f"\n=== {collection_id} ({src}) ===", file=sys.stderr)
+        for f in hard:
+            print(f.render(collection_id), file=sys.stderr)
+        for f in adv:
+            print(f.render(collection_id), file=sys.stderr)
+        if not findings:
+            print("  ✓ all checks passed", file=sys.stderr)
+        else:
+            print(f"  {len(hard)} hard, {len(adv)} advisory", file=sys.stderr)
+        total_hard += len(hard)
+
+    if total_hard:
+        print(f"\nFAIL: {total_hard} hard finding(s) across {len(sources)} collection(s).",
+              file=sys.stderr)
+        sys.exit(1)
+    print(f"\nPASS: no hard findings across {len(sources)} collection(s).", file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #302.

Moves STAC correctness from "an agent remembered the rule" to an **enforced gate** that runs at authoring time, post-cluster, and in CI.

## What's here

**`scripts/verify-stac.py`** — one verifier, three tiers (HARD blocks; ADVISORY informational; exits non-zero only on HARD):

- **Static checks** (just the STAC JSON): license + SPDX (or `other`/`various`/`proprietary` with a license link); nav links (`self`/`root`/`parent` hard, `child` validated if present); `{last-segment}-{format}` asset keys; hex hive glob; `h3:native_resolution`/`h3:parent_resolutions` (incl `0`); `vector:layers`; `table:columns` placement (geom on geoparquet, excluded on hex); per-feature-duplication warning on aggregatable hex columns; point processing-resolution note.
- **Reuses the two existing linters** (`lint-stac-categorical`, `lint-stac-pmtiles-fields`) by importing their `lint()` — no reimplementation.
- **Data-backed check** (MCP): every declared `values` array == ingested `DISTINCT`, automating the #114/#294 lesson. The set-difference is computed **in SQL** so the result is tiny and **immune to the MCP query tool's markdown-table truncation** (a naive `SELECT DISTINCT` parse fabricates findings — see below). Stdlib-only MCP client (streamable HTTP / SSE) to the public `duckdb-geo` endpoint, no auth. `--no-data` skips it; degrades gracefully (advisory) if the MCP is unreachable.
- **Advisory recall pass**: low-cardinality string columns with no `values` array (catches the recall gap that missed PAD-US `IUCN_Cat`/`Pub_Access`). Never blocks.
- Targets a URL/path, `--bucket/--dataset`, or `--yaml` (derives collection(s) from the `s3://` paths in changed `catalog/**` YAMLs).

**`.github/workflows/verify-stac.yml`** — runs on PRs touching `catalog/**` (sync/audit excluded), deriving affected collections from the changed YAMLs, plus `workflow_dispatch` to re-fire after the cluster publishes the STAC. **Gates on the produced artifact**: red at PR-open is correct (recipe hasn't run); green once a conformant STAC+data are live. Re-run after the cluster jobs finish; merge needs it green.

**`scripts/lint-stac-categorical.py`** — folds in the FIPS / fixed-width geographic-identifier exclusion #303 asked for: `STATEFP`/`COUNTYFP`/`TRACTCE`/`SLDLST`/`SLDUST`, `FIPS`/`STCNTY`/`iso3` are GEOID components, not classes. Genuine enums (`MTFCC`, `CLASSFP`, `FUNCSTAT`) carry neither the "FIPS code"/"(N digits)" nor identifier-name signal and still flag.

**`AGENTS.md`** — Step 5 documents the pre-publish (static) / post-cluster (full) / re-run-to-merge flow.

## Validation

Ran against live collections — **PAD-US fee, census tract, longhurst, irrecoverable-carbon**:

- **False-positive sweep eliminated.** First pass over-flagged: `check_hex_dup_warning` matched "protected **area**" in PAD-US descriptions (hit `Comments`, `Unit_Nm`, `Date_Est`, `WDPA_Cd`, …); census `STATEFP/COUNTYFP/TRACTCE` flagged as categoricals; `SHAPE` geom column missed (case). Fixed by **numeric-type + name-token gating** (drop description matching), case-insensitive geom detection, and the FIPS exclusion above. Remaining findings are all genuine (e.g. `MTFCC`, `SHAPE_Area/Length` lacking dedup notes, empty PMTiles `table:columns`).
- **HARD data-check path confirmed** by a controlled tamper of PAD-US `Own_Type`: dropping a real code (`DIST`) → `values-incomplete` (HARD); injecting `BOGUS` → `values-extra` (ADVISORY). The untampered run is clean — `State_Nm`'s apparent "missing VA/VT/WA…" was MCP output truncation, the bug the in-SQL diff fixes.

## Follow-ups this unblocks
- **#303** (one-time 46-collection audit): the data-backed `values == DISTINCT` check is the engine; the FIPS exclusion removes that false-positive class.
- Defect classes from #283/#290/#291/#294/#114 are now mechanically caught.