### PR TITLE
Fix verify-stac CI trigger (paths + paths-ignore not allowed together)

### DIFF
--- a/.github/workflows/verify-stac.yml
+++ b/.github/workflows/verify-stac.yml
@@ -18,13 +18,13 @@ name: Verify STAC
 
 on:
   pull_request:
+    # sync/audit jobs aren't dataset recipes; they reference buckets via rclone (nrp:)
+    # not s3://, so they derive no targets anyway — negated here for clarity/speed.
+    # (GitHub forbids combining `paths` with `paths-ignore`; use `!` negation instead.)
     paths:
       - 'catalog/**'
-    # sync/audit jobs aren't dataset recipes; they reference buckets via rclone (nrp:)
-    # not s3://, so they derive no targets anyway — excluded here for clarity/speed.
-    paths-ignore:
-      - 'catalog/sync/**'
-      - 'catalog/audit/**'
+      - '!catalog/sync/**'
+      - '!catalog/audit/**'
   workflow_dispatch:
     inputs:
       collection:


### PR DESCRIPTION
Hotfix — the `verify-stac.yml` added in #306 failed to compile ("workflow file issue", 0s run on the merge to main) because GitHub forbids using both `paths` and `paths-ignore` on the same event.

Fix: express the sync/audit exclusion with `!` negation inside the single `paths` filter. Confirmed clean with `actionlint` (which validates the whole file — no other schema issues). The in-job `git diff … | grep -vE '^catalog/(sync|audit)/'` step already excludes those as a backstop.

```
.github/workflows/verify-stac.yml:25:5: both "paths" and "paths-ignore" filters cannot be used for the same event "pull_request"
```