### PR TITLE
lint-stac-categorical: exclude sibling-coded ISO/UN/MEOW standards + district codes (#303)

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -157,9 +157,19 @@ def lint(source: str) -> list[str]:
                 # enums (MTFCC, CLASSFP, FUNCSTAT) carry neither signal and still flag.
                 is_geo_identifier = (
                     bool(re.search(r"\bfips code\b|\bcode \(\d+\s*digits?\)", desc_l))
-                    or bool(re.fullmatch(r"(?i)(fips|stcnty|iso3|geoid\w*)", col_name))
+                    or bool(re.fullmatch(r"(?i)(fips|stcnty|iso3|geoid\w*|sld[lu]st)", col_name))
                 )
                 if is_geo_identifier:
+                    continue
+
+                # Skip standardized sibling-coded geographic codes — ISO-3166 country
+                # codes (ISO_SOV*/ISO_TER*), UN M49 codes (UN_SOV*/UN_TER*), and MEOW
+                # ecoregion codes (ECO_CODE/ECO_CODE_X). These are universal external code
+                # systems, not dataset-specific enums, and the marineregions/MEOW sources
+                # always ship a sibling human-readable column (SOVEREIGN1, TERRITORY1,
+                # ECOREGION) — so the geo-agent resolves names via the sibling, not an
+                # inline values map. Confirmed false positives in #294 (iho/ecs/meow).
+                if re.fullmatch(r"(?i)(iso|un)_(sov|ter)\d*|eco_code(_x)?", col_name):
                     continue
 
                 # Skip identifier columns — unique keys / external record codes, not


### PR DESCRIPTION
Part of the #303 audit. Folds two more confirmed false-positive classes into the categorical linter rather than papering over them with bogus `values` (per the #294/#114 lesson).

- **Standardized sibling-coded geographic codes** — ISO-3166 country codes (`ISO_SOV*`/`ISO_TER*`), UN M49 codes (`UN_SOV*`/`UN_TER*`), MEOW ecoregion codes (`ECO_CODE`/`ECO_CODE_X`). These are universal external code systems, not dataset-specific enums, and the marineregions/MEOW sources always ship a sibling human-readable column (`SOVEREIGN1`, `TERRITORY1`, `ECOREGION`). Confirmed FP in #294 (iho/ecs/meow).
- **Legislative-district identifier codes** `SLDLST`/`SLDUST` (GEOID components, like `TRACTCE`).

Genuine enums (`POL_TYPE`, `REG_TYPE`, `LSAD`, `MTFCC`, `CLASSFP`, `FUNCSTAT`) carry neither signal and still flag.

**Effect on the audit:** running `verify-stac.py` across the 46 #303-flagged collections drops the categorical findings from **139 → 119** unique (collection, column) pairs — `iho` and `meow` clear entirely, `ecs` reduces to just `POL_TYPE`, census districts to `LSAD`/`MTFCC`. The remaining 119 are genuine and tracked in #303.