### PR TITLE
lint-stac-categorical: fold self-describing label-enum FPs + high-seas batch (#303)

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -48,6 +48,30 @@ def is_abbrev_name(name: str, value) -> bool:
     return False
 
 
+def values_self_describing(values_arr) -> bool:
+    """Return True if every value in the array is already a human-readable label
+    rather than an opaque code — i.e. the value text IS its own definition, so an
+    inline CODE=Definition map would be redundant.
+
+    A value is self-describing when it contains whitespace (a multi-word phrase like
+    'North Pacific' or '1.5M - 2M km2') or carries a lowercase letter and is longer
+    than four characters ('Mediterranean', 'NotApplicable'). Opaque codes — all-caps
+    acronyms (CCAMLR, RFB), short tokens (LSAD '00', MTFCC 'G4000'), and numeric codes
+    — are NOT self-describing and still require an inline map.
+
+    Used to fold a precision false-positive class: label enums that ship a `values`
+    array but legitimately have no code→name mapping to write (#303)."""
+    if not isinstance(values_arr, list) or not values_arr:
+        return False
+    for v in values_arr:
+        s = str(v)
+        has_space = bool(re.search(r"\s", s))
+        descriptive_word = bool(re.search(r"[a-z]", s)) and len(s) > 4
+        if not (has_space or descriptive_word):
+            return False
+    return True
+
+
 def lint(source: str) -> list[str]:
     """Return a list of error strings (empty = pass)."""
     try:
@@ -208,7 +232,11 @@ def lint(source: str) -> list[str]:
             # (USF=US Forest Service, OGC:CRS84-style excluded). A single TOKEN=word
             # pair is a strong signal once the column is already known to be coded.
             has_inline_codes = bool(re.search(r"[A-Za-z0-9][\w/.-]*\s*=\s*\w", desc))
-            if not has_inline_codes:
+            # Self-describing label enums (values are full words/phrases, not codes)
+            # carry no code→name mapping, so an inline CODE=Definition list would be
+            # redundant. Skip the inline requirement for them — but still require the
+            # `values` array below (a documented value set is always useful). #303.
+            if not has_inline_codes and not values_self_describing(values_arr):
                 errors.append(
                     f"[{collection_id}] asset '{asset_key}', column '{col_name}': "
                     f"coded categorical column missing inline CODE=Definition list in description. "


### PR DESCRIPTION
Continues the #303 categorical-completeness audit. **High-seas batch (6 collections) done.**

## Linter change (this PR)
`lint-stac-categorical.py` gains `values_self_describing()` — a precision FP fold (same spirit as #304/#310). Label-enum columns whose values are full words/phrases (`Workshop` region names, `Area_categ` size bands, ecs `POL_TYPE` claim types) carry no code→name mapping, so the inline `CODE=Definition` requirement was a false positive. The fold skips *only* the inline requirement when every value is self-describing (has whitespace, or a lowercase letter and length > 4); the `values`-array requirement is unchanged, and opaque codes (all-caps acronyms, short/numeric codes — MTFCC/LSAD/RFB/CCAMLR) still require the inline map. Verified: census collections still pass; a negative test confirms `['AAA','BBB']` still flags while `['North Pacific']` folds.

## STAC edits (published to NRP S3, not in this repo per Hard Boundary 1)
Authoritative code→name maps + `values` arrays added on **both** geoparquet and hex assets:

| Collection | Columns | Source |
|---|---|---|
| ebsa | `Crit_*` ×7 (added H/M/L/x inline to **hex**; parquet already had it) | CBD EBSA criteria |
| ecs | `POL_TYPE` (self-describing fold; `values` added to hex for parity) | marineregions |
| hydrothermal-vents | `max_temperature_category` | source data dictionary |
| mpa-candidates | `Area_categ` (self-describing); + opportunistic #309 hex-dup note on `Area` | — |
| rfmo | `RFB` (54 FAO RFB acronyms), vme `REG_TYPE` (14, via sibling `REG_NAME`), vme `OWNER` (corrected — prior inline list omitted GFCM, SIOFA) | FAO RFB directory + dataset siblings |
| longhurst | `ProvCode` (54, via sibling `ProvDescr`) | dataset sibling |

All `values` arrays verified `== ingested DISTINCT` via the duckdb-geo MCP. Post-publish `verify-stac.py --bucket public-high-seas --dataset <d>` is clean for #303 on all six — remaining HARDs are out-of-scope #283 (empty PMTiles `table:columns`) and the mpa-candidates `proprietary` license-link.

## Notes for follow-up (out of #303 scope)
- **rfb-hex is missing CCAMLR**: the declared value `CCAMLR` never appears in the hex data (verify-stac ADVISORY `values-extra`). The CCAMLR (Antarctic) polygon appears to have been dropped from the hex build — a completeness gap worth a separate look.
- mpa-candidates `proprietary` license needs real upstream terms sourced (#... license track).
- 6 collections carry empty PMTiles `table:columns` (#283).

Refs #303.