### PR TITLE
lint-stac-categorical: fold per-entity FK code identifiers + USFWS batch (#303)

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -204,6 +204,15 @@ def lint(source: str) -> list[str]:
                 mentions_class = bool(re.search(r"\bclass\b|categor", desc, re.I))
                 strong_identifier = bool(
                     re.search(r"\b(site code|record code|unique (id|identifier)|object\s*id)\b", desc_l)
+                    # Per-entity foreign-key codes — a code that identifies/joins one
+                    # specific species/office/entity record (a high-cardinality key),
+                    # not an enumerable thematic class. e.g. usfws critical-habitat
+                    # `spcode` "4-character species code (joins to ECOS species records)"
+                    # is 1:1 with species (724 codes); `leadoffice` "regional office code"
+                    # is an FK to FWS field offices (55 codes). Listing these as `values`
+                    # would be a per-record key dump, not a class enumeration (#303).
+                    or re.search(r"\b(species|office|entity)\s+code\b", desc_l)
+                    or re.search(r"\bjoins?\s+to\b", desc_l)
                 )
                 if strong_identifier:
                     continue


### PR DESCRIPTION
## #303 batch 3 — USFWS critical habitat (final + proposed)

Continues the one-time categorical-completeness audit (#303). Per-collection verification against the **authoritative data** (not guessing) per the #294/#114 lesson.

### Findings & resolution (verified via duckdb-geo MCP)
| Column | Distinct | Verdict | Action |
|---|---|---|---|
| `spcode` | 724 (exactly 1:1 with `sciname`) | per-species **join key**, "joins to ECOS species records" | fold into linter identifier exclusion |
| `leadoffice` | 55 numeric office codes | **FK** to FWS field offices | fold into linter identifier exclusion |
| `status` | 1 per layer (Final/Proposed) | self-describing label | already cleared by #316 fold |
| `vipcode` | 10 (incl. `V13` in proposed) | genuine categorical, **incomplete** | added `V13` + fixed `V01-V13` range, published to S3 |

Listing 724 species codes or 55 office codes as `values` would be a per-record key dump, not a class enumeration — so these are folded into the linter (same precision-FP pattern as ISO/UN/MEOW #310 and self-describing #316), **not** papered over with bogus maps.

### Code change
`scripts/lint-stac-categorical.py`: extend `strong_identifier` to recognize per-entity foreign-key codes via description signals `"<species|office|entity> code"` and `"joins to"`.

### S3 (not in this diff — STAC is canonical on NRP S3)
`critical-habitat/{final,proposed}/stac-collection.json`: added `V13` to `vipcode` values + corrected variant range, on both parquet and hex assets.

### Verification
`verify-stac.py --bucket public-usfws --dataset critical-habitat/{final,proposed}` → **0 categorical/data HARD findings** on each. The 1 remaining HARD per collection is the out-of-scope empty-PMTiles `table:columns` gap (#283).

Refs #303.