### PR TITLE
Two linter folds + TPL/trails batch (#303)

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -173,6 +173,23 @@ def lint(source: str) -> list[str]:
                 if is_source:
                     continue
 
+                # Skip heterogeneous, unnormalized source-passthrough columns — raw values
+                # copied verbatim from multiple upstream sources with no harmonization
+                # (mixed casing, agency-specific code systems, free-text all in one column).
+                # These are NOT a controlled vocabulary: an authoritative CODE=Definition
+                # map does not exist, and enumerating every casing/source variant as
+                # `values` documents data-quality noise rather than a domain. e.g. trails
+                # federal-trails-2026 trail_class/trail_surface/trail_type fuse USFS numeric
+                # codes, NPS descriptive labels, and BLM passthrough strings. Signal: the
+                # description explicitly says the values are heterogeneous / unnormalized /
+                # raw across sources (an author writes this deliberately, like is_source).
+                is_heterogeneous_source = bool(re.search(
+                    r"heterogeneous|unharmoni|unnormali[sz]ed|not normali[sz]ed|"
+                    r"verbatim across|raw .*(source|agenc)|treat as informational|"
+                    r"unnormalized across|across (agencies|sources)", desc_l))
+                if is_heterogeneous_source:
+                    continue
+
                 # Skip FIPS / fixed-width geographic identifier codes — GEOID-component
                 # keys (STATEFP/COUNTYFP/TRACTCE/SLDLST/SLDUST…) and FIPS/STCNTY/iso3.
                 # These are identifier components, not enumerable classes (#303). The

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -650,9 +650,17 @@ def check_values_match_distinct(doc: dict, mcp: MCPClient) -> list[Finding]:
         # `values` array ("11"). Genuine string codes ('FED', 'STAT') and real
         # fractional codes ('11.5') are left untouched.
         norm = lambda e: f"regexp_replace(CAST({e} AS VARCHAR), '\\.0+$', '')"
+        # Treat missing-value artifacts as absence, like NULL: an empty/whitespace string
+        # and the literal conversion tokens 'null'/'nan'/'none' (pandas/str(None) leakage,
+        # case-insensitive) are not real category codes. Requiring them in a `values`
+        # array pollutes the schema and breaks the self-describing fold — so exclude them
+        # from the ingested DISTINCT set, the same way SQL NULL is already excluded.
+        # Real "unknown" categories (UNK, Unknown, N/A) are intentional codes and stay.
         sql = (
             f'WITH ingested AS (SELECT DISTINCT {norm(chr(34)+col+chr(34))} AS v '
-            f"  FROM read_parquet('{s3}') WHERE \"{col}\" IS NOT NULL), "
+            f"  FROM read_parquet('{s3}') WHERE \"{col}\" IS NOT NULL "
+            f"    AND trim(CAST(\"{col}\" AS VARCHAR)) <> '' "
+            f"    AND lower(trim(CAST(\"{col}\" AS VARCHAR))) NOT IN ('null','nan','none')), "
             f"declared AS (SELECT {norm('v')} AS v FROM (VALUES {decl_rows}) t(v)) "
             f"SELECT 'missing' AS kind, v FROM ingested WHERE v NOT IN (SELECT v FROM declared) "
             f"UNION ALL "


### PR DESCRIPTION
## #303 batch 4 — Trails & land conservation (3 collections)

Continues the categorical-completeness audit (#303). Per-collection verification against the authoritative ingested data (duckdb-geo MCP).

### Two precision folds (the code change)
1. **`verify-stac.py`** — the data-backed `values`==DISTINCT check now treats empty strings and the literal conversion tokens `null`/`nan`/`none` (pandas/`str(None)` leakage) as **absence**, like SQL NULL. They're missing-value artifacts, not category codes; forcing them into `values` pollutes the schema and breaks the self-describing fold.
2. **`lint-stac-categorical.py`** — fold **heterogeneous source-passthrough** columns: a column documented as unnormalized/raw values fused from multiple sources (mixed casing, agency-specific code systems) is not a controlled vocabulary, so it needs neither a CODE=Definition map nor a `values` array.

### Collections fixed (published to NRP S3 — STAC is canonical there, not in this diff)
| Collection | Columns | Resolution |
|---|---|---|
| **conservation-almanac-2024-sites** | access_type, manager_type, purchase_type, purpose_type (+ owner_type `DIST`, easement_type `null` artifact) | inline maps already complete → added `values` arrays; added missing `DIST`; `null` folded as artifact. **Passes clean.** |
| **wcb-approved-projects** | Function (hex parity), Program/PrimPurp completeness | propagated Function values+map to hex; `''` folded as artifact; split `Tax Credit (b/c)`→`(b)`,`(c)`; added hex-dup warnings to Shape_Length/Shape_Area (#309). |
| **federal-trails-2026** | admin_agency, nts_designation, trail_class/surface/type, admin_unit | admin_agency inline map (USFS/NPS/BLM) + corrected stale hex values; propagated nts_designation's complete 16-trail map to hex; trail_class/surface/type documented as heterogeneous multi-agency passthroughs (folded); admin_unit reworded as 853-distinct identifier; **license `various (…)`→`public-domain`** (US federal works). |

### Verification
`verify-stac.py --bucket … --dataset …` → **0 categorical/data HARD findings** on all three. almanac passes fully; wcb & trails have only the out-of-scope empty-PMTiles `table:columns` gap (#283).

Refs #303.