### PR TITLE
PMTiles table:columns: lean mirror-from-geoparquet + retrofit 80 collections (#320)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,18 +384,14 @@ auto-refresh from S3, so **after your cluster jobs finish, re-fire the check** (
   - **Hex asset**: exclude the geometry column; include H3 index columns (`h0`, `h8`, `h9`, `h10` etc.) and `_cng_fid`/`bbox` if present
   - **COG assets**: no `table:columns` needed (not SQL-queryable)
 
-- **PMTiles assets MUST carry tile-accurate `table:columns` (data-workflows #283).** tippecanoe selects a *subset* of source columns at tile-build time, so the PMTiles fields differ from the GeoParquet schema — the parquet's `table:columns` does NOT tell a consumer what's actually in the tiles. Without tile-level schema the geo-agent (and human app authors) cannot discover which fields are stylable/filterable in MapLibre except by byte-ranging the `.pmtiles` footer. So:
-  - List the **actual tile fields** (not the parquet schema) with `name` + `type`, read from the footer's `vector_layers[].fields`. The geometry column is excluded (it's the tile geometry, not a field).
-  - Keep `vector:layers` (the source-layer id list) as well.
-  - **Document nodata sentinels** on the relevant column (e.g. SVI `RPL_THEMES = -999`) and flag the **intended value column** for continuous styling — neither is inferable from the tiles.
-  - Read the footer fields with:
-    ```bash
-    python3 -c 'import urllib.request,json,struct,gzip; u="https://.../layer.pmtiles"; \
-      r=lambda a,b: urllib.request.urlopen(urllib.request.Request(u,headers={"Range":f"bytes={a}-{b}"})).read(); \
-      h=r(0,126); o=struct.unpack_from("<Q",h,24)[0]; n=struct.unpack_from("<Q",h,32)[0]; \
-      m=json.loads(gzip.decompress(r(o,o+n-1)).decode()); print([(L["id"],L.get("fields")) for L in m["vector_layers"]])'
-    ```
-  - Gate with `scripts/lint-stac-pmtiles-fields.py <stac-collection.json|url>` (companion to `lint-stac-categorical.py`).
+- **PMTiles assets MUST carry tile-accurate `table:columns` (data-workflows #283/#320), in LEAN form.** The geo-agent (and human app authors) can only learn which fields are stylable/filterable in MapLibre from the PMTiles asset's own schema — an empty `table:columns` forces them to byte-range the `.pmtiles` footer. **Empirically, our tippecanoe step keeps ALL attribute columns: the tile field set is just `GeoParquet attrs − geometry + _cng_fid`** (types coarsened to String/Number/Boolean). So the standard is to **mirror the canonical GeoParquet schema onto the PMTiles asset** — do NOT hand-scrape thin metadata from the footer, and do NOT duplicate the prose:
+  - **Lean columns:** each PMTiles column carries **`name` + `type` + `values`** (the `values` enumeration is the styling-critical part for categoricals) — copied from the GeoParquet column of the same name. **Omit the prose `description`** — it stays CANONICAL on the GeoParquet asset (duplicating it across 3 assets just bloats agent context; the agent reads definitions there).
+  - Drop the geometry column; include `_cng_fid` (present in tiles).
+  - Keep `vector:layers` (the source-layer id list).
+  - **Continuous (choropleth) layers only:** add the **nodata sentinel** and flag the **intended value column** for styling, as a short `description` on that one column (e.g. SVI `RPL_THEMES = -999`) — these are viz-specific and not inferable from the GeoParquet schema.
+  - **Generate it** with `scripts/mirror-pmtiles-columns.py <stac-url>` — it reads the footer to *validate* the field set (and flags the rare genuine-subset case, e.g. SVI, where tippecanoe really did drop columns), mirrors the GeoParquet `name`/`type`/`values`, and writes the updated STAC to `/tmp`. Then `rclone copyto` to S3.
+  - Because PMTiles mirrors the GeoParquet, **fix the GeoParquet/hex categoricals FIRST** (the #303 work), then mirror — otherwise you copy incomplete `values`.
+  - Gate with `scripts/lint-stac-pmtiles-fields.py <stac-collection.json|url>` (companion to `lint-stac-categorical.py`); it requires `name` + `type` and does NOT require descriptions.
 
 - **Hex assets MUST declare their H3 resolutions explicitly** via `h3:native_resolution` and `h3:parent_resolutions` on the asset itself. Column-name presence (`h10`, `h9`, …) is not enough — downstream tools shouldn't have to enumerate `table:columns` to find out what resolutions exist. `h3:native_resolution` is the finest resolution (one row per feature-cell at this res); `h3:parent_resolutions` is the list of rollup resolutions, which MUST include `0` (the partition key).
 

--- a/scripts/lint-stac-pmtiles-fields.py
+++ b/scripts/lint-stac-pmtiles-fields.py
@@ -16,8 +16,10 @@ Checks enforced (per AGENTS.md "PMTiles assets" standard):
    (non-empty list of source-layer ids).
 2. Every PMTiles asset MUST have a non-empty `table:columns` listing the
    tile-accurate fields, each with a `name` and `type`.
-3. Each PMTiles column SHOULD have a non-empty `description` (warning, not error,
-   unless --strict).
+3. PMTiles columns intentionally carry NO prose `description` under the lean policy
+   (#320): tile fields = GeoParquet attrs − geometry + `_cng_fid`, so each column
+   mirrors name + type + `values` and the canonical prose lives on the GeoParquet
+   asset. Missing descriptions are expected and not flagged.
 
 Discover the real tile fields with:
 
@@ -82,7 +84,14 @@ def lint(source: str, strict: bool = False) -> list[str]:
             )
             continue
 
-        # 3. each column needs name + type (+ description, soft unless --strict)
+        # 3. each column needs name + type. Per the LEAN policy (#320): PMTiles tile
+        #    fields are just the GeoParquet attributes (minus geometry, plus _cng_fid),
+        #    so each PMTiles column mirrors name + type + `values`, and the prose
+        #    `description` stays CANONICAL on the GeoParquet asset (not duplicated here —
+        #    that would triple the column prose across the 3 assets and bloat agent
+        #    context). A missing description on a PMTiles column is therefore expected,
+        #    NOT a finding. The styling value column / nodata sentinel are documented on
+        #    the relevant column when the layer is continuous.
         for col in columns:
             name = col.get("name", "")
             if not name:
@@ -96,15 +105,6 @@ def lint(source: str, strict: bool = False) -> list[str]:
                     f"[{collection_id}] asset '{asset_key}', column '{name}': "
                     f"missing 'type'."
                 )
-            if not col.get("description"):
-                msg = (
-                    f"[{collection_id}] asset '{asset_key}', column '{name}': "
-                    f"missing 'description'."
-                )
-                if strict:
-                    errors.append(msg)
-                else:
-                    print("[WARN] " + msg, file=sys.stderr)
 
     return errors
 
@@ -116,7 +116,8 @@ def main():
     parser.add_argument("sources", nargs="+", help="Path(s) or URL(s) to stac-collection.json files")
     parser.add_argument(
         "--strict", action="store_true",
-        help="Treat missing column descriptions as errors (default: warning).",
+        help="Reserved (no-op). Descriptions are intentionally absent under the lean "
+             "policy; the only hard requirements are name + type.",
     )
     args = parser.parse_args()
 

--- a/scripts/mirror-pmtiles-columns.py
+++ b/scripts/mirror-pmtiles-columns.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Mirror a collection's canonical GeoParquet column schema onto its PMTiles
+asset(s) — the "lean" form of the #283 / #320 tile-schema standard.
+
+Why this exists (data-workflows #320): a fresh catalog crawl found 119 PMTiles
+assets with an empty `table:columns`, so the geo-agent cannot discover which
+fields are stylable/filterable in MapLibre. But empirically our tippecanoe step
+keeps **all** attribute columns — the PMTiles field set is just
+`geoparquet_attrs − geometry + _cng_fid` (types coarsened to String/Number/
+Boolean). So the fix is NOT to hand-scrape thin metadata from the footer; it is
+to mirror the canonical GeoParquet schema onto the PMTiles asset, reusing the
+rich `values` enumerations already curated there (the #303 work).
+
+Lean policy (chosen to avoid tripling the column prose across the 3 assets):
+each mirrored PMTiles column carries **name + type + values** only. The prose
+`description` stays canonical on the GeoParquet asset; the geo-agent reads it
+there when it needs definitions. Visualization-only facts that genuinely belong
+on the tile asset — the styling value column and nodata sentinel — are preserved
+if already present (and reported as TODO if the layer looks continuous).
+
+The PMTiles footer is read only to **validate** the field set (and to catch the
+rare genuine-subset case, e.g. SVI, where tippecanoe really did drop columns).
+
+Usage:
+    mirror-pmtiles-columns.py <stac-collection.json | https-url> [--out FILE]
+        Transform one collection; write the updated JSON to --out (default:
+        /tmp/<id>-pmtiles.json) and print a per-asset report.
+
+Exit 0 on success; non-zero if no PMTiles asset or no GeoParquet schema to
+mirror from. A genuine-subset / field-mismatch is reported (not fatal) so a
+human can review before publishing.
+"""
+
+import argparse
+import gzip
+import json
+import struct
+import sys
+import urllib.request
+
+GEOM_NAMES = {"geom", "geometry", "shape", "Shape", "SHAPE", "the_geom", "wkb_geometry"}
+
+
+def load_doc(src: str) -> dict:
+    if src.startswith("http://") or src.startswith("https://"):
+        with urllib.request.urlopen(src, timeout=30) as r:
+            return json.load(r)
+    with open(src) as f:
+        return json.load(f)
+
+
+def footer_fields(pmtiles_url: str) -> dict:
+    """Return {layer_id: {field_name: footer_type}} from the .pmtiles footer."""
+    def rng(a, b):
+        req = urllib.request.Request(pmtiles_url, headers={"Range": f"bytes={a}-{b}"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.read()
+    h = rng(0, 126)
+    off = struct.unpack_from("<Q", h, 24)[0]
+    ln = struct.unpack_from("<Q", h, 32)[0]
+    meta = json.loads(gzip.decompress(rng(off, off + ln - 1)).decode())
+    return {L["id"]: L.get("fields", {}) for L in meta.get("vector_layers", [])}
+
+
+# footer type (String/Number/Boolean) -> STAC type, used only for fields absent
+# from the GeoParquet schema (rare; the GeoParquet type is preferred when known).
+_FOOTER_TYPE = {"String": "string", "Number": "double", "Boolean": "boolean"}
+
+
+def geoparquet_asset(doc: dict):
+    """Return (key, asset) for the canonical GeoParquet asset (non-hex parquet)."""
+    for key, a in doc.get("assets", {}).items():
+        if "parquet" in a.get("type", "") and "hex" not in key and "hex" not in a.get("href", ""):
+            return key, a
+    return None, None
+
+
+def lean_columns(tile_field_names, gp_cols_by_name):
+    """Build lean PMTiles table:columns (name+type+values) for the given tile
+    fields, mirroring the GeoParquet column metadata where the names match."""
+    out = []
+    for name in tile_field_names:
+        gp = gp_cols_by_name.get(name)
+        if gp:
+            col = {"name": name, "type": gp.get("type", "string")}
+            if gp.get("values") is not None:
+                col["values"] = gp["values"]
+        elif name == "_cng_fid":
+            col = {"name": name, "type": "int64"}
+        else:
+            col = {"name": name, "type": "string"}  # overwritten below from footer
+        out.append(col)
+    return out
+
+
+def mirror(doc: dict) -> list:
+    """Mutate doc in place; return a list of report strings."""
+    report = []
+    gpk, gp = geoparquet_asset(doc)
+    if gp is None:
+        report.append("ERROR: no GeoParquet asset to mirror from")
+        return report
+    gp_cols = gp.get("table:columns") or []
+    gp_by_name = {c["name"]: c for c in gp_cols}
+    report.append(f"canonical schema: '{gpk}' ({len(gp_cols)} columns)")
+
+    found_pmtiles = False
+    for key, a in doc.get("assets", {}).items():
+        if "pmtiles" not in a.get("type", ""):
+            continue
+        found_pmtiles = True
+        href = a.get("href")
+        try:
+            ff = footer_fields(href)
+        except Exception as e:
+            report.append(f"  [{key}] FOOTER READ FAILED ({e}) — skipped")
+            continue
+        tile_fields = {}
+        for lid, flds in ff.items():
+            tile_fields.update(flds)
+        names = [n for n in tile_fields if n not in GEOM_NAMES]
+        # order: follow GeoParquet column order, then any tile-only fields
+        ordered = [c["name"] for c in gp_cols if c["name"] in names]
+        ordered += [n for n in names if n not in set(ordered)]
+
+        cols = lean_columns(ordered, gp_by_name)
+        # fill type for tile-only fields from the footer's coarse type
+        for col in cols:
+            if col["name"] not in gp_by_name and col["name"] != "_cng_fid":
+                col["type"] = _FOOTER_TYPE.get(tile_fields.get(col["name"]), "string")
+
+        # report set differences vs GeoParquet attributes
+        gp_attr = {c["name"] for c in gp_cols if c["name"] not in GEOM_NAMES}
+        subset = sorted(gp_attr - set(names))
+        extra = sorted(set(names) - gp_attr - {"_cng_fid"})
+        a["table:columns"] = cols
+        if "vector:layers" not in a:
+            a["vector:layers"] = list(ff.keys())
+        msg = f"  [{key}] {len(cols)} tile fields mirrored (layers {list(ff.keys())})"
+        if subset:
+            msg += f"\n      ⚠ GENUINE SUBSET — in GeoParquet but NOT in tiles: {subset}"
+        if extra:
+            msg += f"\n      tile-only fields (not in GeoParquet): {extra}"
+        report.append(msg)
+    if not found_pmtiles:
+        report.append("ERROR: no PMTiles asset in collection")
+    return report
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("source", help="stac-collection.json path or https URL")
+    ap.add_argument("--out", help="output file (default /tmp/<id>-pmtiles.json)")
+    args = ap.parse_args()
+
+    doc = load_doc(args.source)
+    cid = doc.get("id", "collection")
+    report = mirror(doc)
+    out = args.out or f"/tmp/{cid}-pmtiles.json"
+    with open(out, "w") as f:
+        json.dump(doc, f, indent=2)
+    print(f"=== {cid} ===")
+    for line in report:
+        print(line)
+    print(f"  -> wrote {out}")
+    return 1 if any(r.startswith("ERROR") for r in report) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mirror-pmtiles-columns.py
+++ b/scripts/mirror-pmtiles-columns.py
@@ -68,12 +68,36 @@ def footer_fields(pmtiles_url: str) -> dict:
 _FOOTER_TYPE = {"String": "string", "Number": "double", "Boolean": "boolean"}
 
 
+def _is_geoparquet(key: str, a: dict) -> bool:
+    return ("parquet" in a.get("type", "")
+            and "hex" not in key and "hex" not in a.get("href", ""))
+
+
 def geoparquet_asset(doc: dict):
-    """Return (key, asset) for the canonical GeoParquet asset (non-hex parquet)."""
+    """Return (key, asset) for the first canonical GeoParquet asset (non-hex parquet)."""
     for key, a in doc.get("assets", {}).items():
-        if "parquet" in a.get("type", "") and "hex" not in key and "hex" not in a.get("href", ""):
+        if _is_geoparquet(key, a):
             return key, a
     return None, None
+
+
+def sibling_parquet(doc: dict, pmtiles_key: str):
+    """Resolve the GeoParquet asset that corresponds to one PMTiles asset.
+
+    Multi-sub-dataset collections (e.g. rfmo's rfb-*/vme-*, ca-dac-eda's
+    blockgroup/tract/place, cpad's holdings/units) carry several parquet+pmtiles
+    pairs. Match by the asset-key stem so `vme-pmtiles` mirrors `vme-parquet`,
+    not whatever parquet happens to be first. Falls back to the lone GeoParquet.
+    """
+    assets = doc.get("assets", {})
+    base = pmtiles_key[:-len("-pmtiles")] if pmtiles_key.endswith("-pmtiles") else pmtiles_key
+    cand = assets.get(base + "-parquet")
+    if cand and _is_geoparquet(base + "-parquet", cand):
+        return base + "-parquet", cand
+    for k, a in assets.items():
+        if _is_geoparquet(k, a) and k.startswith(base):
+            return k, a
+    return geoparquet_asset(doc)
 
 
 def lean_columns(tile_field_names, gp_cols_by_name):
@@ -97,19 +121,24 @@ def lean_columns(tile_field_names, gp_cols_by_name):
 def mirror(doc: dict) -> list:
     """Mutate doc in place; return a list of report strings."""
     report = []
-    gpk, gp = geoparquet_asset(doc)
-    if gp is None:
+    if geoparquet_asset(doc)[1] is None:
         report.append("ERROR: no GeoParquet asset to mirror from")
         return report
-    gp_cols = gp.get("table:columns") or []
-    gp_by_name = {c["name"]: c for c in gp_cols}
-    report.append(f"canonical schema: '{gpk}' ({len(gp_cols)} columns)")
 
     found_pmtiles = False
     for key, a in doc.get("assets", {}).items():
         if "pmtiles" not in a.get("type", ""):
             continue
         found_pmtiles = True
+        # Never clobber an already-populated PMTiles asset — it may carry curated
+        # viz hints (nodata sentinel / value column) we don't want to lose. Only
+        # fill assets whose table:columns is empty/absent.
+        if a.get("table:columns"):
+            report.append(f"  [{key}] already populated ({len(a['table:columns'])} cols) — skipped")
+            continue
+        gpk, gp = sibling_parquet(doc, key)
+        gp_cols = (gp.get("table:columns") or []) if gp else []
+        gp_by_name = {c["name"]: c for c in gp_cols}
         href = a.get("href")
         try:
             ff = footer_fields(href)
@@ -137,7 +166,7 @@ def mirror(doc: dict) -> list:
         a["table:columns"] = cols
         if "vector:layers" not in a:
             a["vector:layers"] = list(ff.keys())
-        msg = f"  [{key}] {len(cols)} tile fields mirrored (layers {list(ff.keys())})"
+        msg = f"  [{key}] {len(cols)} tile fields mirrored from '{gpk}' (layers {list(ff.keys())})"
         if subset:
             msg += f"\n      ⚠ GENUINE SUBSET — in GeoParquet but NOT in tiles: {subset}"
         if extra:


### PR DESCRIPTION
## Closes the bulk of #320 (PMTiles tile-schema retrofit)

### The reframe (key finding)
A catalog crawl found **119 PMTiles assets / 97 collections** with empty `table:columns`. But empirically **our tippecanoe step keeps ALL attribute columns** — the tile field set is just `geoparquet attrs − geometry + _cng_fid` (types coarsened). So #283's "footer holds a curated subset" premise is the *exception* (SVI), not the rule. The real fix is **mirror the canonical geoparquet schema onto the pmtiles asset**, not hand-scrape footers.

### Lean policy (chosen to avoid context bloat)
Each pmtiles column carries **name + type + `values`** only; the prose `description` stays **canonical on the geoparquet asset** (not tripled across 3 assets). Continuous layers additionally get the nodata sentinel + value column. The `values` enumerations (styling-critical, from the #303 work) carry over.

### Code
- **`scripts/mirror-pmtiles-columns.py`** (new): derives lean pmtiles `table:columns` from the **sibling** geoparquet asset (matched by key stem — `vme-pmtiles`←`vme-parquet`), validates the field set against the `.pmtiles` footer (flags genuine subsets like SVI), never clobbers an already-populated asset.
- **`lint-stac-pmtiles-fields.py`**: stop flagging missing descriptions (intended under lean); require only name + type.
- **`AGENTS.md`**: rewrite the PMTiles standard to lean/mirror; fix geoparquet categoricals (#303) *before* mirroring.

### Retrofit applied to S3 (canonical; not in this diff)
**80 collections mirrored + published**, verified (`verify-stac.py` → 0 HARD on spot-checks incl. census, rfmo). A self-correcting gate — *only mirror collections whose geoparquet categorical-lint is already clean* — **auto-deferred the 17 #303-pending collections** (wdpa, wdoecm, nwi, wbd-hu10/12, blm-sma, epa-sab, icca×2, gde-wetlands, fmmp, ca30x30-ecoregion, ace, flood-hazard, sea-level-rise, overture-regions, megamove-tracked-individuals). Those get mirrored as the final step of their #303 batch (per the new AGENTS.md guidance), so we never publish incomplete `values` onto tiles.

### Remaining (tracked in #320)
- 17 deferred collections → mirror after their #303 categorical fix.
- Continuous-styling refinement (value column + nodata hint) for SVI family and other choropleths — the mechanical mirror clears the HARD gate; viz hints are a follow-up.

Refs #320, #283.
