### PR TITLE
CA/CDFW/EPA #303 batch (8 collections) + 3 linter folds + PMTiles mirror

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -139,6 +139,7 @@ def lint(source: str) -> list[str]:
             col_name = col.get("name", "")
             col_type = col.get("type", "")
             desc = col.get("description", "")
+            desc_l = desc.lower()
             values_arr = col.get("values")
 
             # Skip pure index/geometry columns up front
@@ -152,8 +153,6 @@ def lint(source: str) -> list[str]:
             # column that lacks one. A column that already declares `values` is an
             # explicit opt-in to categorical validation and is never skipped here.
             if values_arr is None:
-                desc_l = desc.lower()
-
                 # Skip date columns — a date is never a categorical class, even when its
                 # description names the "code" it dates (e.g. "Date the GAP Status Code
                 # was assigned in YYYYMMDD"). Signals: name ends in dt/date, or a date-ish
@@ -184,11 +183,18 @@ def lint(source: str) -> list[str]:
                 # federal-trails-2026 trail_class/trail_surface/trail_type fuse USFS numeric
                 # codes, NPS descriptive labels, and BLM passthrough strings. Signal: the
                 # description explicitly says the values are heterogeneous / unnormalized /
-                # raw across sources (an author writes this deliberately, like is_source).
+                # raw across sources (an author writes this deliberately, like is_source),
+                # or that the column is free-text with uncontrolled source variants (e.g.
+                # epa-sab-v3-cws Data_Provider_Type "Free-text — values include
+                # typographical variants from the source"). A "free-text" declaration on a
+                # column that ships no `values` array is the author asserting it is not a
+                # controlled vocabulary — enumerating its typo/casing variants documents
+                # noise, not a domain.
                 is_heterogeneous_source = bool(re.search(
                     r"heterogeneous|unharmoni|unnormali[sz]ed|not normali[sz]ed|"
                     r"verbatim across|raw .*(source|agenc)|treat as informational|"
-                    r"unnormalized across|across (agencies|sources)", desc_l))
+                    r"unnormalized across|across (agencies|sources)|"
+                    r"free[\s-]?text|typographical variant", desc_l))
                 if is_heterogeneous_source:
                     continue
 
@@ -299,11 +305,40 @@ def lint(source: str) -> list[str]:
             # (USF=US Forest Service, OGC:CRS84-style excluded). A single TOKEN=word
             # pair is a strong signal once the column is already known to be coded.
             has_inline_codes = bool(re.search(r"[A-Za-z0-9][\w/.-]*\s*=\s*\w", desc))
+
+            # Geographic proper-name columns — the description identifies the values as
+            # geographic NAMES (county/state/country/territory/ecoregion/region/place …
+            # "name"), which are self-describing external identifiers needing no code→name
+            # map. values_self_describing() already folds mixed-case names ('Mojave
+            # Desert'), but source data often ships them ALL-CAPS ('ALAMEDA', ace County's
+            # 58 CA counties), which the lowercase requirement there rejects — yet they are
+            # no less self-describing. Key on the deliberate "<geo-word> name" phrasing so
+            # opaque all-caps acronyms (CCAMLR, RFB) still flag. Still requires `values`.
+            is_geo_name = bool(re.search(
+                r"\b(count(y|ies)|state|province|country|territor\w+|ecoregion|"
+                r"region|place|borough|parish|municipalit\w+|island)\s+names?\b", desc_l))
+
+            # COG-classification-defined numeric codes — for a raster→hex dataset, the
+            # authoritative code→name legend lives in the COG asset's
+            # classification:classes, which the geo-agent reads directly. When every
+            # numeric value of this column is defined there, an inline map on the hex
+            # column would just duplicate the legend (e.g. ca-climate-zones `zone` 1–10,
+            # each defined as "Zone N" in the COG). Completeness is still enforced by the
+            # data check (values == DISTINCT) and the hex⊆COG cross-check below.
+            cog_defined = False
+            if cog_classes and values_arr:
+                try:
+                    vnums = set(int(v) for v in values_arr)
+                    cog_defined = any(vnums <= set(m.keys()) for m in cog_classes.values())
+                except (ValueError, TypeError):
+                    cog_defined = False
+
             # Self-describing label enums (values are full words/phrases, not codes)
             # carry no code→name mapping, so an inline CODE=Definition list would be
             # redundant. Skip the inline requirement for them — but still require the
             # `values` array below (a documented value set is always useful). #303.
-            if not has_inline_codes and not values_self_describing(values_arr):
+            if (not has_inline_codes and not values_self_describing(values_arr)
+                    and not is_geo_name and not cog_defined):
                 errors.append(
                     f"[{collection_id}] asset '{asset_key}', column '{col_name}': "
                     f"coded categorical column missing inline CODE=Definition list in description. "


### PR DESCRIPTION
## #303 Batch 6 — CA / CDFW / EPA (8 collections)

Categorical-completeness fixes verified against the **authoritative ingested data** (duckdb-geo MCP); PMTiles `table:columns` mirrored in the same pass (closes 5 of the #283/#320 deferrals). Every edited collection passes `verify-stac.py` (static + data) with **0 HARD**.

| Collection | Outcome |
|---|---|
| **ace-terrestrial-biodiversity-summary** | `*RankEco` (Bio/Rar/Ntv/Rwi) got the same 0–5 quintile inline map as their `*RankSW` siblings (parquet+hex); `County` (58 CA counties) folded as geographic proper-name. |
| **ca30x30-ecoregion** | Already categorical-clean; PMTiles mirrored. |
| **fmmp-2022** | `county_nam` 13-abbrev map + values **sourced from the data's own `County` column** (ala=Alameda … tuo=Tuolumne); `polygon_ty` hex parity; `polygon_ac` reworded (it's float acres — "category" in the dedup recipe was a linter FP). |
| **ca-climate-zones** | `zone` 1–10 folded via the new COG-classification fold (legend lives in the COG `classification:classes`). |
| **sierra-nevada-atlas** | Already clean. |
| **groundwater-dependent-ecosystems** | Already clean. |
| **sea-level-rise** | `state` 28-state/territory map + values (parquet+hex). |
| **epa-sab-v3-cws** | `Primacy_Agency` 62-code scheme + values (**fixed the wrong `R08` description — the data stores bare EPA-region digits `8`**); `Data_Provider_Type` folded as free-text; `Pop_Cat_5`/`Model_Method` hex parity. Data check surfaced two more: `Service_Area_Type` missing the `#N/A` sentinel (added), `Model_Method` `''`→stored as NULL (removed from values). |

### Three precision folds (this PR's code change)
1. **Geographic proper-name** — all-caps place names (`<geo-word> name`) are self-describing like the mixed-case names `values_self_describing()` already folds; the lowercase floor wrongly flagged them. Still requires a `values` array.
2. **COG-classification-defined numeric codes** — a hex value column whose numeric codes are all in a sibling COG `classification:classes` needs no duplicate inline map. Completeness still enforced by the data check + hex⊆COG cross-check.
3. **Free-text** — `free-text` / `typographical variant` joins the heterogeneous source-passthrough class.

All keyed on deliberate description signals so opaque codes (CCAMLR, MTFCC, …) still flag.

**Note:** the GitHub `verify-stac` check reads the live S3 STAC; all 8 are already published and pass, so re-firing the check should be green.

Refs #303. PMTiles work refs #283 / #320.