### PR TITLE
lint-stac-categorical: 2 folds + taxonomy/biodiversity batch (#303)

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -221,6 +221,18 @@ def lint(source: str) -> list[str]:
                 if re.fullmatch(r"(?i)(iso|un)_(sov|ter)\d*|eco_code(_x)?", col_name):
                     continue
 
+                # Skip ISO 3166 country codes (alpha-2/alpha-3) — a universal external
+                # standard (~250 codes) the geo-agent resolves natively, not a dataset
+                # enum. Listing 226+ codes as `values` is a key dump, and the canonical
+                # CODE=Name map is the published ISO standard, not a dataset value list.
+                # Same rationale as the ISO/UN sibling-code fold above. Signal: the
+                # description names ISO 3166, or the column is an unambiguous country-code
+                # field (countrycode / iso_a2 / iso_a3 — a bare `country` only folds via
+                # the ISO-3166 description, since `country` can also be a full-name column).
+                if (re.search(r"iso[\s-]?3166", desc_l)
+                        or re.fullmatch(r"(?i)(countrycode|country_code|iso_a[23]|iso3166[\w-]*)", col_name)):
+                    continue
+
                 # Skip US state/territory two-letter POSTAL abbreviations — a universal
                 # external standard (CA=California, …) the geo-agent resolves natively,
                 # not a dataset-specific enum (same rationale as the ISO/UN codes above).
@@ -258,6 +270,25 @@ def lint(source: str) -> list[str]:
                 # this subwatershed flows to". High-cardinality (one per upstream unit).
                 if (re.search(r"downstream\b.{0,30}\b(code|huc)|\bflows? to\b|\brouting\b", desc_l)
                         or re.fullmatch(r"(?i)tohuc|to_huc", col_name)):
+                    continue
+
+                # Skip Linnaean taxonomic-rank columns — scientific nomenclature (class,
+                # order, family, genus, kingdom, phylum, scientific name) is an OPEN
+                # external naming system maintained by taxonomic authorities (the GBIF
+                # backbone, IUCN, Catalogue of Life), not a dataset-controlled enum. The
+                # values are self-describing taxon names (Mammalia, Actinopterygii) and
+                # high-cardinality (GBIF carries 650+ classes incl. provisional codes), so
+                # neither an inline CODE=Definition map nor a finite `values` array applies
+                # — the meaning is defined by the nomenclature, not a dataset value list.
+                # Distinct from a dataset's OWN taxon-grouping vocabulary (e.g. MegaMove
+                # `taxon`'s 8 fixed groups), which IS enumerable and keeps its `values`
+                # array. Signal: the description names it a taxonomic/Linnaean rank or a
+                # scientific name (a deliberate author signal, like is_source/heterogeneous).
+                is_taxonomic_rank = bool(re.search(
+                    r"\blinnaean\b|\btaxonomic\s+(class|rank|order|family|genus|kingdom|"
+                    r"phylum|division)\b|\bscientific name\b|open (scientific )?nomenclature|"
+                    r"taxonomic authorit|gbif backbone|catalogue of life", desc_l))
+                if is_taxonomic_rank:
                     continue
 
                 # Skip identifier columns — unique keys / external record codes, not


### PR DESCRIPTION
## Batch 7 — Taxonomy / biodiversity (5 collections), part of #303

All coded-categorical metadata added/folded and **verified against the authoritative ingested data** (duckdb-geo MCP `values`==`DISTINCT`), published to NRP S3. PMTiles mirrored in the same pass (closes 2 of the #283/#320 deferrals). `verify-stac.py --no-recall` → **0 HARD** on each.

| Collection | Outcome |
|---|---|
| **iucn-ranges-2025** | `latest_category_code` → 11-value IUCN Red List category map+values (EX/EW/RE/CR/EN/VU/NT/LR-nt/LC/DD/NA, authoritative IUCN categories incl. legacy LR/nt); `class` folded as Linnaean rank; added IUCN Red List terms license link. parquet+hex. |
| **iucn-taxonomy** | `class` folded as Linnaean rank; `redlist_criteria` (1657 compositional A–E criteria strings) folded as compositional/published-classification code. |
| **gbif-derived** | `class` (650 incl. provisional codes) folded as Linnaean rank on hex + taxonomic-aggregations; `countrycode` (252) folded as ISO 3166; added `table:columns` to the `taxa-list` asset (was empty); added GBIF terms license link. |
| **overture-divisions-regions** | `class` (land/maritime) given values+map; `country` folded as ISO 3166; **moved the stale collection-level `table:columns` onto the `regions-parquet` asset** (declared the real 17-col schema, the collection-level list was wrong/stale); hex `class` parity. |
| **megamove-tracked-individuals** | `class` folded as Linnaean rank (its dataset grouping vocab stays in the sibling `taxon` column). |

### Two precision folds (this PR)
1. **Linnaean taxonomic-rank** — scientific nomenclature (class/order/family/genus/kingdom/phylum/scientific name) is an open external naming system (GBIF backbone, IUCN, Catalogue of Life), not a dataset enum: high-cardinality self-describing taxon names, so neither inline map nor finite `values` array applies. Distinct from a dataset's *own* taxon-grouping vocabulary (MegaMove `taxon`), which keeps its values array. Keyed on a deliberate taxonomic/Linnaean/scientific-name description signal.
2. **ISO 3166 country code** — alpha-2/alpha-3 codes (~250) are a universal external standard the geo-agent resolves natively (same rationale as the existing ISO/UN sibling-code fold). Folds `countrycode`/`iso_a2`/`iso_a3` by name and bare `country` via an explicit ISO-3166 description.

### Surfaced (out of #303 scope)
- **overture-regions** still carries the dotted version `2026-02-18.0` in its S3 path/id — a naming-standard fix (no dots) that needs an S3 re-layout, tracked separately.
- iucn-taxonomy `license: proprietary` and gbif `license: various` — license-track concern (links added; real per-dataset terms verification is separate).

**Remaining #303 backlog:** WDPA family (joint with #309), icca, hazard (flood-hazard) — see the triage comment.