### PR TITLE
GYE private-parcels MinIO workflow recipe (2026-05-18 delivery)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ Thumbs.db
 !.claude/hooks/
 # git worktrees (relocated out of .claude/)
 .worktrees/
+# Private-dataset STAC/README must never land on public GitHub (canonical copy
+# lives on the private MinIO bucket). k8s recipe YAMLs disclose no data and ARE tracked.
+catalog/wyoming/**/stac/
+catalog/wyoming/**/*stac*.json
+catalog/wyoming/**/collection.json
+catalog/wyoming/**/README.md
 **/*.min..css
 **/*.min..js
 .ipynb_checkpoints/.gitignore-checkpoint

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ Thumbs.db
 !.claude/hooks/
 # git worktrees (relocated out of .claude/)
 .worktrees/
-# Private datasets — keep off public GitHub
-catalog/wyoming/
 **/*.min..css
 **/*.min..js
 .ipynb_checkpoints/.gitignore-checkpoint

--- a/catalog/wyoming/k8s/gye-parcels/gye-parcels-convert.yaml
+++ b/catalog/wyoming/k8s/gye-parcels/gye-parcels-convert.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gye-parcels-convert
+  labels:
+    k8s-app: gye-parcels-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gye-parcels-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_PUBLIC_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_HTTPS
+          value: 'true'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: private-wyoming
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Private bucket: GDAL/ST_Read can't open s3:// on MinIO (no anon https),
+          # so localize the raw with authenticated rclone first, then convert from disk.
+          rclone copy nrp:private-wyoming/gye-parcels/raw/Parcels_GYE_Cleaned_20260518.gpkg /tmp/
+          cng-convert-to-parquet \
+            /tmp/Parcels_GYE_Cleaned_20260518.gpkg \
+            s3://private-wyoming/gye-parcels/gye-parcels.parquet \
+            --row-group-size 100000 \
+            --layer Parcels_GYE_Cleaned_20260518
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config-private-wyoming-rw
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wyoming/k8s/gye-parcels/gye-parcels-hex.yaml
+++ b/catalog/wyoming/k8s/gye-parcels/gye-parcels-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gye-parcels-hex
+  labels:
+    k8s-app: gye-parcels-hex
+spec:
+  completions: 6
+  parallelism: 6
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gye-parcels-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_PUBLIC_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_HTTPS
+          value: 'true'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: private-wyoming
+        - name: DATASET
+          value: gye-parcels
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://private-wyoming/gye-parcels/gye-parcels.parquet --output s3://private-wyoming/gye-parcels/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wyoming/k8s/gye-parcels/gye-parcels-pmtiles.yaml
+++ b/catalog/wyoming/k8s/gye-parcels/gye-parcels-pmtiles.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gye-parcels-pmtiles
+  labels:
+    k8s-app: gye-parcels-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gye-parcels-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_PUBLIC_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_HTTPS
+          value: 'true'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: private-wyoming
+        - name: DATASET
+          value: gye-parcels
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsis3/private-wyoming/gye-parcels/gye-parcels.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:private-wyoming/gye-parcels/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config-private-wyoming-rw
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wyoming/k8s/gye-parcels/gye-parcels-repartition.yaml
+++ b/catalog/wyoming/k8s/gye-parcels/gye-parcels-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gye-parcels-repartition
+  labels:
+    k8s-app: gye-parcels-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gye-parcels-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: private-wyoming-rw
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_PUBLIC_ENDPOINT
+          value: minio.carlboettiger.info
+        - name: AWS_HTTPS
+          value: 'true'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: private-wyoming
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://private-wyoming/gye-parcels/chunks --output-dir s3://private-wyoming/gye-parcels/hex --source-parquet s3://private-wyoming/gye-parcels/gye-parcels.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config-private-wyoming-rw
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wyoming/k8s/gye-parcels/private-wyoming.profile.yaml
+++ b/catalog/wyoming/k8s/gye-parcels/private-wyoming.profile.yaml
@@ -1,0 +1,52 @@
+# Cluster profile: private MinIO (minio.carlboettiger.info), bucket-scoped write creds.
+#
+# Retargets the standard `cng-datasets workflow` generator at a PRIVATE MinIO bucket
+# instead of NRP. Pass with `--profile catalog/wyoming/k8s/gye-parcels/private-wyoming.profile.yaml`.
+#
+# ---------------------------------------------------------------------------
+# PREREQUISITE SECRETS — minted control-plane-side (laptop + root `mc`), NOT in git.
+# No privileged MinIO credential is kept on the cluster; mint scoped, run, revoke.
+#
+#   # 1) Least-privilege svcacct scoped to ONLY this bucket (root used locally, never on cluster):
+#   cat > /tmp/pw.json <<'JSON'
+#   {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],
+#     "Resource":["arn:aws:s3:::private-wyoming","arn:aws:s3:::private-wyoming/*"]}]}
+#   JSON
+#   read AK SK < <(mc admin user svcacct add minio root --policy /tmp/pw.json --json \
+#                  | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d["accessKey"],d["secretKey"])')
+#
+#   # 2) S3 secret (standard AWS_* key names the YAMLs reference):
+#   kubectl -n biodiversity create secret generic private-wyoming-rw \
+#     --from-literal=AWS_ACCESS_KEY_ID="$AK" --from-literal=AWS_SECRET_ACCESS_KEY="$SK"
+#
+#   # 3) rclone secret — remote name MUST be [nrp] (the generated YAMLs use `nrp:`):
+#   printf '[nrp]\ntype = s3\nprovider = Other\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = https://minio.carlboettiger.info\nforce_path_style = true\n' "$AK" "$SK" > /tmp/rc.conf
+#   kubectl -n biodiversity create secret generic rclone-config-private-wyoming-rw --from-file=rclone.conf=/tmp/rc.conf
+#
+#   # 4) After the run, revoke (keys are job-scoped; clean up):
+#   mc admin user svcacct rm minio "$AK"
+#   kubectl -n biodiversity delete secret private-wyoming-rw rclone-config-private-wyoming-rw
+#
+# ---------------------------------------------------------------------------
+# DIVERGENCES from the standard NRP recipe (already baked into the sibling step YAMLs):
+#   - AWS_HTTPS: 'true'             (MinIO is https-only; NRP internal is http)
+#   - NO setup-bucket step          (it sets public-read + CORS — never on a PRIVATE bucket)
+#   - convert localizes the raw via rclone first, then converts from disk
+#       (GDAL/ST_Read cannot open s3:// on MinIO — there is no anon https path)
+#   - pmtiles reads the parquet via /vsis3 (authenticated), not anon /vsicurl
+#   - parquet + pmtiles land under gye-parcels/ (matches the app's STAC/configmap paths)
+#
+# RUN ORDER (apply step YAMLs directly; there is no orchestrator for the private path):
+#   kubectl -n biodiversity apply -f gye-parcels-convert.yaml      # wait for Complete
+#   kubectl -n biodiversity apply -f gye-parcels-hex.yaml \
+#                                 -f gye-parcels-pmtiles.yaml      # parallel; wait for hex
+#   kubectl -n biodiversity apply -f gye-parcels-repartition.yaml  # merges chunks -> hex/
+# ---------------------------------------------------------------------------
+name: private-wyoming-minio
+s3_endpoint: minio.carlboettiger.info
+s3_public_endpoint: minio.carlboettiger.info
+s3_secret_name: private-wyoming-rw
+rclone_secret_name: rclone-config-private-wyoming-rw
+rclone_remote: nrp
+priority_class: opportunistic
+node_affinity: gpu-avoid


### PR DESCRIPTION
Captures the **private-bucket** variant of the standard `cng-datasets` vector workflow, used to rebuild the GYE private parcels (`private-wyoming` MinIO bucket) for the 2026-05-18 delivery (5,697 parcels). Previously this was an undocumented one-off; this commit makes it reproducible.

## What's here
A custom cluster profile + 4 patched step YAMLs under `catalog/wyoming/k8s/gye-parcels/`. The YAMLs disclose no parcel data.

## Private-bucket divergences from the standard NRP recipe
- **MinIO profile** (`private-wyoming.profile.yaml`): `minio.carlboettiger.info` endpoint + scoped-secret names, with a documented **mint/revoke** procedure for bucket-scoped svcacct creds. Minted control-plane-side (laptop + root `mc`); **no privileged MinIO key is kept on the cluster**.
- **convert**: localize raw via `rclone` before convert — GDAL/`ST_Read` can't open `s3://` on MinIO (no anon https path).
- **pmtiles**: read the parquet via authenticated `/vsis3`, not anon `/vsicurl`.
- `AWS_HTTPS=true`; parquet + pmtiles nested under `gye-parcels/` to match the app's STAC/configmap paths.
- **No `setup-bucket` step** — it sets public-read + CORS, which must never run on a private bucket.
- hex `completions` right-sized to the chunk count (6) instead of the 200-pod default.

## Also
Removes the stale `catalog/wyoming/` `.gitignore` rule — other `catalog/wyoming` recipes (nlcd-2024, rap-perennial-2025) are already tracked, so the rule was inconsistent.

## Validation (build already run)
- parquet: 5,697 rows = 5,697 distinct `_cng_fid` (reprojected EPSG:5072→CRS84)
- hex: 515,513 rows, 5,697 distinct `_cng_fid` (all features present), h10/h9/h8/h0
- pmtiles refreshed, source-layer `gye-parcels`