### PR TITLE
WDPA family #303 final batch + verify-stac whitespace-trim fold

### DIFF
--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -648,8 +648,12 @@ def check_values_match_distinct(doc: dict, mcp: MCPClient) -> list[Finding]:
         # (the cng-datasets raster `mode` reducer emits the value column as DOUBLE,
         # so code 11 reads back as "11.0") compares equal to the int declared in the
         # `values` array ("11"). Genuine string codes ('FED', 'STAT') and real
-        # fractional codes ('11.5') are left untouched.
-        norm = lambda e: f"regexp_replace(CAST({e} AS VARCHAR), '\\.0+$', '')"
+        # fractional codes ('11.5') are left untouched. Also strip leading/trailing
+        # whitespace before comparing — surrounding whitespace is never a meaningful
+        # category distinction (WDPA NO_TAKE ships 'All ' with a trailing space), and
+        # requiring the declared `values` array to carry the wart would pollute the
+        # schema. Applied to both sides, same spirit as the .0 / null normalizations.
+        norm = lambda e: f"regexp_replace(trim(CAST({e} AS VARCHAR)), '\\.0+$', '')"
         # Treat missing-value artifacts as absence, like NULL: an empty/whitespace string
         # and the literal conversion tokens 'null'/'nan'/'none' (pandas/str(None) leakage,
         # case-insensitive) are not real category codes. Requiring them in a `values`


### PR DESCRIPTION
Closes the **#303 one-time categorical-completeness audit** — last remaining batch: the **WDPA family** (`wdpa`, `wdoecm-may-2026`).

## STAC fixes (published to NRP S3, verified live `0 HARD`)
All `values`==ingested `DISTINCT` verified via the duckdb-geo MCP (WDPA data **is** reachable on public S3 despite the MinIO note — the data-check ran).

**`wdpa`** (`wdpa-parquet` + `wdpa-hex`):
- `INT_CRIT` — Ramsar/World-Heritage criteria, semicolon-separated combinations → **multi-value fold** (existing).
- `PRNT_ISO3` — reworded to `ISO-3166-1 alpha-3` → **ISO-3166 fold** (existing).
- `SUPP_INFO` — mostly `Not Applicable`/`Not Reported` + a tail of Ramsar RIS URLs → **free-text fold** (existing).
- `CONS_OBJ` — small enum `{Not Applicable, Primary}` → `values` + inline map.
- `NO_TAKE` — inline `CODE=Definition` added (parquet + hex).
- `IUCN_CAT` (hex) — inline IUCN category map mirrored from parquet.
- PMTiles `table:columns` mirrored from GeoParquet (closes the #283/#320 deferral for this collection).

**`wdoecm-may-2026`** (`wdoecm-parquet` + `wdoecm-hex`):
- `IUCN_CAT` — all records `Not Applicable` (OECMs aren't assigned an IUCN category) → `values=["Not Applicable"]`.
- `PRNT_ISO3` — ISO-3166 fold.
- Dropped a stale **collection-level `table:columns`** (a 34-col subset of the real 35-col asset schema).
- PMTiles `table:columns` mirrored (#283/#320).

## Code change (this PR)
`scripts/verify-stac.py`: the data-backed `values`==`DISTINCT` check now **trims leading/trailing whitespace on both sides** before comparing. WDPA `NO_TAKE` stores `'All '` (trailing space) — surrounding whitespace is never a meaningful category, and forcing the wart into the declared `values` array would pollute the schema. Same normalization spirit as the existing trailing-`.0` and null/nan/none/empty handling. No `lint-stac-categorical.py` change needed — every WDPA column folded via existing folds.

Remaining advisory (`NO_TAKE` `None`) is intentional: `None` = "no no-take zone" is a genuine category that the verifier's absence-filter drops; it stays documented.

🔖 With this batch, all **46/46** flagged collections are complete. The go-forward CI gate (#302) prevents recurrence.