### PR TITLE
nci-frontiers: suitability/slope/irrigation masks + carbon-zones hex recipes

### DIFF
--- a/catalog/nci-frontiers/k8s/carbon-zones/carbon-zones-hex.yaml
+++ b/catalog/nci-frontiers/k8s/carbon-zones/carbon-zones-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: carbon-zones-hex
+  labels:
+    k8s-app: carbon-zones-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: carbon-zones-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/carbon/new_ecoregions.tif"
+          --output-parquet s3://public-nci-frontiers/carbon-zones/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          carbon_zone --hex-resampling mode --nodata 0.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/carbon-zones/carbon-zones-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/carbon-zones/carbon-zones-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: carbon-zones-setup-bucket
+  labels:
+    k8s-app: carbon-zones-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: carbon-zones-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/carbon-zones/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/carbon-zones/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset carbon-zones --source-url "s3://public-nci-frontiers/raw/inputs/carbon/new_ecoregions.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  carbon-zones-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: carbon-zones-hex
+      labels:
+        k8s-app: carbon-zones-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: carbon-zones-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/carbon/new_ecoregions.tif" --output-parquet s3://public-nci-frontiers/carbon-zones/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column carbon_zone --hex-resampling mode --nodata 0.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  carbon-zones-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: carbon-zones-setup-bucket
+      labels:
+        k8s-app: carbon-zones-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: carbon-zones-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: carbon-zones-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/carbon-zones/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/carbon-zones/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/carbon-zones/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/carbon-zones/workflow.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: carbon-zones-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting carbon-zones raster workflow...\"\n\n# Step 0:\
+          \ Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply -f\
+          \ /yamls/carbon-zones-setup-bucket.yaml -n biodiversity\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/carbon-zones-setup-bucket -n biodiversity\n\n# Step\
+          \ 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal tiling...\"\nkubectl\
+          \ apply -f /yamls/carbon-zones-hex.yaml -n biodiversity\nkubectl wait --for=condition=complete\
+          \ --timeout=7200s job/carbon-zones-hex -n biodiversity\n\necho \"\u2713\
+          \ Workflow complete!\"\necho \"Clean up with:\"\necho \"  kubectl delete\
+          \ jobs carbon-zones-setup-bucket carbon-zones-hex carbon-zones-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap carbon-zones-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: carbon-zones-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/k8s/mask-expansion-suit/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/mask-expansion-suit/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mask-expansion-suit --source-url "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_natural_expansion_potential/suitability_expansion_potential_mask_ESAaligned.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  mask-expansion-suit-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-expansion-suit-hex
+      labels:
+        k8s-app: mask-expansion-suit-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-expansion-suit-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_natural_expansion_potential/suitability_expansion_potential_mask_ESAaligned.tif" --output-parquet s3://public-nci-frontiers/mask-expansion-suit/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column expansion_suit --hex-resampling mode --nodata 7.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mask-expansion-suit-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-expansion-suit-setup-bucket
+      labels:
+        k8s-app: mask-expansion-suit-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-expansion-suit-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mask-expansion-suit-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/mask-expansion-suit/mask-expansion-suit-hex.yaml
+++ b/catalog/nci-frontiers/k8s/mask-expansion-suit/mask-expansion-suit-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-expansion-suit-hex
+  labels:
+    k8s-app: mask-expansion-suit-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-expansion-suit-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_natural_expansion_potential/suitability_expansion_potential_mask_ESAaligned.tif"
+          --output-parquet s3://public-nci-frontiers/mask-expansion-suit/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          expansion_suit --hex-resampling mode --nodata 7.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/mask-expansion-suit/mask-expansion-suit-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/mask-expansion-suit/mask-expansion-suit-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-expansion-suit-setup-bucket
+  labels:
+    k8s-app: mask-expansion-suit-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-expansion-suit-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/mask-expansion-suit/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/mask-expansion-suit/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/mask-expansion-suit/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/mask-expansion-suit/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-expansion-suit-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mask-expansion-suit raster workflow...\"\n\n\
+          # Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply\
+          \ -f /yamls/mask-expansion-suit-setup-bucket.yaml -n biodiversity\nkubectl\
+          \ wait --for=condition=complete --timeout=600s job/mask-expansion-suit-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/mask-expansion-suit-hex.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=7200s job/mask-expansion-suit-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs mask-expansion-suit-setup-bucket\
+          \ mask-expansion-suit-hex mask-expansion-suit-workflow -n biodiversity\"\
+          \necho \"  kubectl delete configmap mask-expansion-suit-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mask-expansion-suit-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/k8s/mask-irrigation/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/mask-irrigation/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mask-irrigation --source-url "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_crop_suitability_maps/irrigation_mask_ESAaligned.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  mask-irrigation-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-irrigation-hex
+      labels:
+        k8s-app: mask-irrigation-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-irrigation-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_crop_suitability_maps/irrigation_mask_ESAaligned.tif" --output-parquet s3://public-nci-frontiers/mask-irrigation/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column irrigation_suit --hex-resampling mode --nodata 7.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mask-irrigation-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-irrigation-setup-bucket
+      labels:
+        k8s-app: mask-irrigation-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-irrigation-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mask-irrigation-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/mask-irrigation/mask-irrigation-hex.yaml
+++ b/catalog/nci-frontiers/k8s/mask-irrigation/mask-irrigation-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-irrigation-hex
+  labels:
+    k8s-app: mask-irrigation-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-irrigation-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_crop_suitability_maps/irrigation_mask_ESAaligned.tif"
+          --output-parquet s3://public-nci-frontiers/mask-irrigation/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          irrigation_suit --hex-resampling mode --nodata 7.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/mask-irrigation/mask-irrigation-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/mask-irrigation/mask-irrigation-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-irrigation-setup-bucket
+  labels:
+    k8s-app: mask-irrigation-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-irrigation-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/mask-irrigation/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/mask-irrigation/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/mask-irrigation/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/mask-irrigation/workflow.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-irrigation-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mask-irrigation raster workflow...\"\n\n# Step\
+          \ 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply\
+          \ -f /yamls/mask-irrigation-setup-bucket.yaml -n biodiversity\nkubectl wait\
+          \ --for=condition=complete --timeout=600s job/mask-irrigation-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/mask-irrigation-hex.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=7200s job/mask-irrigation-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs mask-irrigation-setup-bucket mask-irrigation-hex\
+          \ mask-irrigation-workflow -n biodiversity\"\necho \"  kubectl delete configmap\
+          \ mask-irrigation-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mask-irrigation-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/k8s/mask-rainfed/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/mask-rainfed/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mask-rainfed --source-url "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_crop_suitability_maps/rainfed_mask_ESAaligned.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  mask-rainfed-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-rainfed-hex
+      labels:
+        k8s-app: mask-rainfed-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-rainfed-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_crop_suitability_maps/rainfed_mask_ESAaligned.tif" --output-parquet s3://public-nci-frontiers/mask-rainfed/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column rainfed_suit --hex-resampling mode --nodata 7.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mask-rainfed-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-rainfed-setup-bucket
+      labels:
+        k8s-app: mask-rainfed-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-rainfed-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mask-rainfed-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/mask-rainfed/mask-rainfed-hex.yaml
+++ b/catalog/nci-frontiers/k8s/mask-rainfed/mask-rainfed-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-rainfed-hex
+  labels:
+    k8s-app: mask-rainfed-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-rainfed-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_crop_suitability_maps/rainfed_mask_ESAaligned.tif"
+          --output-parquet s3://public-nci-frontiers/mask-rainfed/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          rainfed_suit --hex-resampling mode --nodata 7.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/mask-rainfed/mask-rainfed-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/mask-rainfed/mask-rainfed-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-rainfed-setup-bucket
+  labels:
+    k8s-app: mask-rainfed-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-rainfed-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/mask-rainfed/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/mask-rainfed/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/mask-rainfed/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/mask-rainfed/workflow.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-rainfed-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mask-rainfed raster workflow...\"\n\n# Step 0:\
+          \ Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply -f\
+          \ /yamls/mask-rainfed-setup-bucket.yaml -n biodiversity\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/mask-rainfed-setup-bucket -n biodiversity\n\n# Step\
+          \ 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal tiling...\"\nkubectl\
+          \ apply -f /yamls/mask-rainfed-hex.yaml -n biodiversity\nkubectl wait --for=condition=complete\
+          \ --timeout=7200s job/mask-rainfed-hex -n biodiversity\n\necho \"\u2713\
+          \ Workflow complete!\"\necho \"Clean up with:\"\necho \"  kubectl delete\
+          \ jobs mask-rainfed-setup-bucket mask-rainfed-hex mask-rainfed-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap mask-rainfed-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mask-rainfed-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/k8s/mask-slope-expansion/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-expansion/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mask-slope-expansion --source-url "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_slope_exclusion_masks/expansion_full.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  mask-slope-expansion-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-slope-expansion-hex
+      labels:
+        k8s-app: mask-slope-expansion-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-slope-expansion-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_slope_exclusion_masks/expansion_full.tif" --output-parquet s3://public-nci-frontiers/mask-slope-expansion/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column slope_exp_ok --hex-resampling mode --nodata 255.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mask-slope-expansion-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-slope-expansion-setup-bucket
+      labels:
+        k8s-app: mask-slope-expansion-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-slope-expansion-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mask-slope-expansion-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/mask-slope-expansion/mask-slope-expansion-hex.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-expansion/mask-slope-expansion-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-slope-expansion-hex
+  labels:
+    k8s-app: mask-slope-expansion-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-slope-expansion-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_slope_exclusion_masks/expansion_full.tif"
+          --output-parquet s3://public-nci-frontiers/mask-slope-expansion/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          slope_exp_ok --hex-resampling mode --nodata 255.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/mask-slope-expansion/mask-slope-expansion-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-expansion/mask-slope-expansion-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-slope-expansion-setup-bucket
+  labels:
+    k8s-app: mask-slope-expansion-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-slope-expansion-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/mask-slope-expansion/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-expansion/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/mask-slope-expansion/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-expansion/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-slope-expansion-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mask-slope-expansion raster workflow...\"\n\n\
+          # Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply\
+          \ -f /yamls/mask-slope-expansion-setup-bucket.yaml -n biodiversity\nkubectl\
+          \ wait --for=condition=complete --timeout=600s job/mask-slope-expansion-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/mask-slope-expansion-hex.yaml -n\
+          \ biodiversity\nkubectl wait --for=condition=complete --timeout=7200s job/mask-slope-expansion-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs mask-slope-expansion-setup-bucket\
+          \ mask-slope-expansion-hex mask-slope-expansion-workflow -n biodiversity\"\
+          \necho \"  kubectl delete configmap mask-slope-expansion-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mask-slope-expansion-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/k8s/mask-slope-intensif/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-intensif/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mask-slope-intensif --source-url "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_slope_exclusion_masks/intensification_full.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  mask-slope-intensif-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-slope-intensif-hex
+      labels:
+        k8s-app: mask-slope-intensif-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-slope-intensif-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_slope_exclusion_masks/intensification_full.tif" --output-parquet s3://public-nci-frontiers/mask-slope-intensif/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column slope_int_ok --hex-resampling mode --nodata 255.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mask-slope-intensif-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-slope-intensif-setup-bucket
+      labels:
+        k8s-app: mask-slope-intensif-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-slope-intensif-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mask-slope-intensif-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/mask-slope-intensif/mask-slope-intensif-hex.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-intensif/mask-slope-intensif-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-slope-intensif-hex
+  labels:
+    k8s-app: mask-slope-intensif-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-slope-intensif-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_slope_exclusion_masks/intensification_full.tif"
+          --output-parquet s3://public-nci-frontiers/mask-slope-intensif/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          slope_int_ok --hex-resampling mode --nodata 255.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/mask-slope-intensif/mask-slope-intensif-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-intensif/mask-slope-intensif-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-slope-intensif-setup-bucket
+  labels:
+    k8s-app: mask-slope-intensif-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-slope-intensif-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/mask-slope-intensif/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-intensif/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/mask-slope-intensif/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/mask-slope-intensif/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-slope-intensif-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mask-slope-intensif raster workflow...\"\n\n\
+          # Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl apply\
+          \ -f /yamls/mask-slope-intensif-setup-bucket.yaml -n biodiversity\nkubectl\
+          \ wait --for=condition=complete --timeout=600s job/mask-slope-intensif-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/mask-slope-intensif-hex.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=7200s job/mask-slope-intensif-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs mask-slope-intensif-setup-bucket\
+          \ mask-slope-intensif-hex mask-slope-intensif-workflow -n biodiversity\"\
+          \necho \"  kubectl delete configmap mask-slope-intensif-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mask-slope-intensif-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/k8s/mask-sustainable-irrig/configmap.yaml
+++ b/catalog/nci-frontiers/k8s/mask-sustainable-irrig/configmap.yaml
@@ -1,0 +1,175 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset mask-sustainable-irrig --source-url "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_irrigation_potential/sustainable_irrigation_mask.tif" --bucket public-nci-frontiers --h3-resolution 8 --parent-resolutions "7,6,5,0"
+apiVersion: v1
+data:
+  mask-sustainable-irrig-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-sustainable-irrig-hex
+      labels:
+        k8s-app: mask-sustainable-irrig-hex
+    spec:
+      completions: 122
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-sustainable-irrig-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_irrigation_potential/sustainable_irrigation_mask.tif" --output-parquet s3://public-nci-frontiers/mask-sustainable-irrig/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column sustain_irrig --hex-resampling mode --nodata 7.0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mask-sustainable-irrig-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mask-sustainable-irrig-setup-bucket
+      labels:
+        k8s-app: mask-sustainable-irrig-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mask-sustainable-irrig-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-nci-frontiers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mask-sustainable-irrig-yamls
+  namespace: biodiversity

--- a/catalog/nci-frontiers/k8s/mask-sustainable-irrig/mask-sustainable-irrig-hex.yaml
+++ b/catalog/nci-frontiers/k8s/mask-sustainable-irrig/mask-sustainable-irrig-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-sustainable-irrig-hex
+  labels:
+    k8s-app: mask-sustainable-irrig-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-sustainable-irrig-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/scenario_construction/ag_irrigation_potential/sustainable_irrigation_mask.tif"
+          --output-parquet s3://public-nci-frontiers/mask-sustainable-irrig/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          sustain_irrig --hex-resampling mode --nodata 7.0'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10

--- a/catalog/nci-frontiers/k8s/mask-sustainable-irrig/mask-sustainable-irrig-setup-bucket.yaml
+++ b/catalog/nci-frontiers/k8s/mask-sustainable-irrig/mask-sustainable-irrig-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-sustainable-irrig-setup-bucket
+  labels:
+    k8s-app: mask-sustainable-irrig-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mask-sustainable-irrig-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/nci-frontiers/k8s/mask-sustainable-irrig/workflow-rbac.yaml
+++ b/catalog/nci-frontiers/k8s/mask-sustainable-irrig/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/nci-frontiers/k8s/mask-sustainable-irrig/workflow.yaml
+++ b/catalog/nci-frontiers/k8s/mask-sustainable-irrig/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mask-sustainable-irrig-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting mask-sustainable-irrig raster workflow...\"\n\
+          \n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/mask-sustainable-irrig-setup-bucket.yaml -n biodiversity\n\
+          kubectl wait --for=condition=complete --timeout=600s job/mask-sustainable-irrig-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/mask-sustainable-irrig-hex.yaml -n\
+          \ biodiversity\nkubectl wait --for=condition=complete --timeout=7200s job/mask-sustainable-irrig-hex\
+          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs mask-sustainable-irrig-setup-bucket\
+          \ mask-sustainable-irrig-hex mask-sustainable-irrig-workflow -n biodiversity\"\
+          \necho \"  kubectl delete configmap mask-sustainable-irrig-yamls -n biodiversity\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mask-sustainable-irrig-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/nci-frontiers/scripts/gen_stac.py
+++ b/catalog/nci-frontiers/scripts/gen_stac.py
@@ -59,6 +59,36 @@ k,a=asset("esa-lc-2025-hex","ESA CCI Land Cover 2025 (current land-use mask)",8,
      "190 urban / 200–202 bare / 210 water / 220 ice → no production. Codes: "+", ".join(f"{c}={_ESA[c]}" for c in _esa_codes)+". "+SRC),
    "values":_esa_codes}); assets[k]=a
 
+# Wave 4 — allowed-alternative constraint masks (binary 0/1) + carbon zones (res 8, mode reducer)
+# Masks gate which land-use alternatives are admissible per parcel in the Polasky et al. frontier.
+for key,title,col,nd,m0,m1 in [
+  ("mask-irrigation-hex","Mask: irrigated cropland suitability","irrigation_suit",7,
+     "not suitable for irrigated cropland","suitable for irrigated cropland"),
+  ("mask-rainfed-hex","Mask: rainfed cropland suitability","rainfed_suit",7,
+     "not suitable for rainfed cropland","suitable for rainfed cropland"),
+  ("mask-sustainable-irrig-hex","Mask: sustainable irrigation potential","sustain_irrig",7,
+     "no sustainable irrigation potential","has sustainable irrigation potential"),
+  ("mask-expansion-suit-hex","Mask: agricultural expansion suitability","expansion_suit",7,
+     "not suitable for natural-to-agriculture expansion","suitable for natural-to-agriculture expansion"),
+  ("mask-slope-expansion-hex","Mask: slope allows agricultural expansion","slope_exp_ok",255,
+     "excluded by slope (too steep for expansion)","slope permits agricultural expansion"),
+  ("mask-slope-intensif-hex","Mask: slope allows agricultural intensification","slope_int_ok",255,
+     "excluded by slope (too steep for intensification)","slope permits agricultural intensification")]:
+    k,a=asset(key,title,8,col,
+      {"name":col,"type":"int64",
+       "description":(f"Binary scenario-construction constraint mask, dominant value per H3 cell (reducer=mode). "
+         f"Values: 0={m0}, 1={m1}. nodata {nd} (no data / not applicable) excluded before aggregation. "
+         "Restricts which land-use alternatives are admissible per parcel in the Polasky et al. frontier. "+SRC),
+       "values":[0,1]}); assets[k]=a
+# carbon zones (new_ecoregions.tif) — ecoregion-based zone ID; the Spawn et al. carbon_table join key (res 8, mode)
+k,a=asset("carbon-zones-hex","Carbon zones (new_ecoregions)",8,"carbon_zone",
+  {"name":"carbon_zone","type":"int64",
+   "description":("Integer carbon-zone ID, dominant zone per H3 cell (reducer=mode; 830 distinct zones, range 1–846). "
+     "A high-cardinality identifier that joins to the Spawn et al. carbon_table lookup (per-zone x land-use "
+     "above/below-ground carbon density), used to derive graded per-land-use carbon for each frontier alternative — "
+     "not an enumerable thematic vocabulary, so no `values` array is listed. nodata 0 (no zone / ocean) excluded "
+     "before aggregation. "+SRC)}); assets[k]=a
+
 # COG assets (visualization) for any economic layer that has a published <dataset>-cog.tif (COG_LAYERS env)
 import os as _os
 _COGMETA={
@@ -86,7 +116,10 @@ coll={"stac_version":"1.0.0",
    "unit (~8000 ha, the paper's parcel). Revenue/methane/FLII are per-ha/index DENSITIES (mean reducer — aggregate "
    "with AVG, never SUM); transition costs are per-cell USD TOTALS (sum reducer). Sourced from the CC0 Dryad deposit "
    "(doi:10.5061/dryad.qjq2bvqw5); see also iucn-richness-2025, wwf-ecoregions-2017, irrecoverable-carbon for the "
-   "biodiversity and carbon objectives, and wdpa for the IUCN I–IV constraint."),
+   "biodiversity and carbon objectives, and wdpa for the IUCN I–IV constraint. Also included are the "
+   "scenario-construction constraint masks (binary suitability/slope eligibility, mode reducer, res 8) that "
+   "restrict admissible land-use alternatives per parcel, and the carbon-zone ID raster (mode reducer, res 8) "
+   "that keys the Spawn et al. carbon_table for graded per-land-use carbon."),
  "license":"CC0-1.0",
  "keywords":["land use","biodiversity","carbon","agriculture","ecosystem services","H3","Polasky","efficiency frontier"],
  "extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2010-01-01T00:00:00Z","2022-12-31T00:00:00Z"]]}},


### PR DESCRIPTION
Res-8 `mode` hex (64Gi, hardened) for the 6 allowed-alternative constraint masks + the carbon-zone raster (`new_ecoregions.tif`, the Spawn `carbon_table` lookup key). Data published to `public-nci-frontiers/<layer>/hex/` (all 122/99/101 partitions). Toward per-land-use carbon and the full 13-alternative frontier (tracked in #334). STAC assets for these support layers to follow.