### PR TITLE
connectivity: CDFW Wildlife Movement Barriers (BIOS ds2867)

### DIFF
--- a/catalog/connectivity/k8s/wildlife-movement-barriers/configmap.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/configmap.yaml
@@ -1,0 +1,466 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: wildlife-movement-barriers-setup-bucket.yaml, wildlife-movement-barriers-convert.yaml, wildlife-movement-barriers-pmtiles.yaml, wildlife-movement-barriers-hex.yaml, wildlife-movement-barriers-repartition.yaml
+# Generation command: cng-datasets workflow --dataset wildlife-movement-barriers --source-url https://s3-west.nrp-nautilus.io/public-connectivity/raw/wildlife-movement-barriers.geojson --bucket public-connectivity --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap wildlife-movement-barriers-yamls \
+#     --from-file=wildlife-movement-barriers-setup-bucket.yaml \
+#     --from-file=wildlife-movement-barriers-convert.yaml \
+#     --from-file=wildlife-movement-barriers-pmtiles.yaml \
+#     --from-file=wildlife-movement-barriers-hex.yaml \
+#     --from-file=wildlife-movement-barriers-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  wildlife-movement-barriers-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wildlife-movement-barriers-convert
+      labels:
+        k8s-app: wildlife-movement-barriers-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wildlife-movement-barriers-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Localize the source ONCE via rclone (retried, proven path on this cluster), then
+              # convert from local disk. GDAL/DuckDB opens the source several times (CRS detect,
+              # geometry detect, ID check, main read); doing those over a flaky network endpoint
+              # fails intermittently, so we read from local disk instead.
+              rclone copyto nrp:public-connectivity/raw/wildlife-movement-barriers.geojson /tmp/src.geojson
+              cng-convert-to-parquet \
+                /tmp/src.geojson \
+                s3://public-connectivity/wildlife-movement-barriers.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+                  # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                    - hpc-nrp-g1.nmsu.edu
+                    - service-02.nrp.mghpcc.org
+  wildlife-movement-barriers-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wildlife-movement-barriers-hex
+      labels:
+        k8s-app: wildlife-movement-barriers-hex
+    spec:
+      completions: 1
+      parallelism: 1
+      completionMode: Indexed
+      backoffLimitPerIndex: 3
+      maxFailedIndexes: 1
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wildlife-movement-barriers-hex
+        spec:
+          restartPolicy: Never
+          # A running-hang on a flaky node (broken egress) never fails on its own; the deadline
+          # turns it into a Failure the Job retries (on another node, thanks to the exclusion below).
+          activeDeadlineSeconds: 900
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-connectivity
+            - name: DATASET
+              value: wildlife-movement-barriers
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-connectivity/wildlife-movement-barriers.parquet --output s3://public-connectivity/wildlife-movement-barriers/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+                  # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                    - hpc-nrp-g1.nmsu.edu
+                    - service-02.nrp.mghpcc.org
+  wildlife-movement-barriers-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wildlife-movement-barriers-pmtiles
+      labels:
+        k8s-app: wildlife-movement-barriers-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wildlife-movement-barriers-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-connectivity
+            - name: DATASET
+              value: wildlife-movement-barriers
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Localize the GeoParquet via rclone (internal endpoint, retried), then convert from
+              # local disk. Reading it via /vsicurl over the public endpoint fails on nodes with
+              # broken egress (ogr2ogr "cannot open datasource").
+              rclone copyto nrp:public-connectivity/wildlife-movement-barriers.parquet /tmp/$DATASET.parquet
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /tmp/$DATASET.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq.
+              # tippecanoe opens many temp files (one per shard); on many-core nodes the shard
+              # count can exceed the container's file-descriptor soft limit ("Too many open files").
+              # Raise the FD limit and cap threads to a modest power of 2 (also avoids the
+              # "N shards not a power of 2" assertion, felt/tippecanoe#216).
+              ulimit -n 65536 || true
+              TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=min(os.cpu_count() or 1, 8); print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-connectivity/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles /tmp/$DATASET.parquet
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+                  # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                    - hpc-nrp-g1.nmsu.edu
+                    - service-02.nrp.mghpcc.org
+  wildlife-movement-barriers-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wildlife-movement-barriers-repartition
+      labels:
+        k8s-app: wildlife-movement-barriers-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wildlife-movement-barriers-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-connectivity/wildlife-movement-barriers/chunks --output-dir s3://public-connectivity/wildlife-movement-barriers/hex --source-parquet s3://public-connectivity/wildlife-movement-barriers.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+                  # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                    - hpc-nrp-g1.nmsu.edu
+                    - service-02.nrp.mghpcc.org
+  wildlife-movement-barriers-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: wildlife-movement-barriers-setup-bucket
+      labels:
+        k8s-app: wildlife-movement-barriers-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: wildlife-movement-barriers-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-connectivity
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+                  # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                    - hpc-nrp-g1.nmsu.edu
+                    - service-02.nrp.mghpcc.org
+kind: ConfigMap
+metadata:
+  name: wildlife-movement-barriers-yamls
+  namespace: biodiversity

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-convert.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-convert.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wildlife-movement-barriers-convert
+  labels:
+    k8s-app: wildlife-movement-barriers-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wildlife-movement-barriers-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Localize the source ONCE via rclone (retried, proven path on this cluster), then
+          # convert from local disk. GDAL/DuckDB opens the source several times (CRS detect,
+          # geometry detect, ID check, main read); doing those over a flaky network endpoint
+          # fails intermittently, so we read from local disk instead.
+          rclone copyto nrp:public-connectivity/raw/wildlife-movement-barriers.geojson /tmp/src.geojson
+          cng-convert-to-parquet \
+            /tmp/src.geojson \
+            s3://public-connectivity/wildlife-movement-barriers.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-hex.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-hex.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wildlife-movement-barriers-hex
+  labels:
+    k8s-app: wildlife-movement-barriers-hex
+spec:
+  completions: 1
+  parallelism: 1
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 1
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wildlife-movement-barriers-hex
+    spec:
+      restartPolicy: Never
+      # A running-hang on a flaky node (broken egress) never fails on its own; the deadline
+      # turns it into a Failure the Job retries (on another node, thanks to the exclusion below).
+      activeDeadlineSeconds: 900
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-connectivity
+        - name: DATASET
+          value: wildlife-movement-barriers
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-connectivity/wildlife-movement-barriers.parquet --output s3://public-connectivity/wildlife-movement-barriers/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-pmtiles.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-pmtiles.yaml
@@ -1,0 +1,103 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wildlife-movement-barriers-pmtiles
+  labels:
+    k8s-app: wildlife-movement-barriers-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wildlife-movement-barriers-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-connectivity
+        - name: DATASET
+          value: wildlife-movement-barriers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Localize the GeoParquet via rclone (internal endpoint, retried), then convert from
+          # local disk. Reading it via /vsicurl over the public endpoint fails on nodes with
+          # broken egress (ogr2ogr "cannot open datasource").
+          rclone copyto nrp:public-connectivity/wildlife-movement-barriers.parquet /tmp/$DATASET.parquet
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /tmp/$DATASET.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # tippecanoe opens many temp files (one per shard); on many-core nodes the shard
+          # count can exceed the container's file-descriptor soft limit ("Too many open files").
+          # Raise the FD limit and cap threads to a modest power of 2.
+          ulimit -n 65536 || true
+          TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=min(os.cpu_count() or 1, 8); print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-connectivity/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles /tmp/$DATASET.parquet
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-repartition.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-repartition.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wildlife-movement-barriers-repartition
+  labels:
+    k8s-app: wildlife-movement-barriers-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wildlife-movement-barriers-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-connectivity/wildlife-movement-barriers/chunks --output-dir s3://public-connectivity/wildlife-movement-barriers/hex --source-parquet s3://public-connectivity/wildlife-movement-barriers.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              # Exclude nodes with observed broken egress/S3 connectivity (AGENTS.md).
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-setup-bucket.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/wildlife-movement-barriers-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wildlife-movement-barriers-setup-bucket
+  labels:
+    k8s-app: wildlife-movement-barriers-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: wildlife-movement-barriers-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/workflow-rbac.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/connectivity/k8s/wildlife-movement-barriers/workflow.yaml
+++ b/catalog/connectivity/k8s/wildlife-movement-barriers/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wildlife-movement-barriers-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting wildlife-movement-barriers workflow...\"\n\n\
+          # Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/wildlife-movement-barriers-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/wildlife-movement-barriers-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/wildlife-movement-barriers-convert.yaml -n biodiversity\n\
+          \necho \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait\
+          \ --for=condition=complete --timeout=3600s job/wildlife-movement-barriers-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/wildlife-movement-barriers-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/wildlife-movement-barriers-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/wildlife-movement-barriers-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/wildlife-movement-barriers-repartition.yaml -n biodiversity\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/wildlife-movement-barriers-repartition -n biodiversity\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs wildlife-movement-barriers-setup-bucket wildlife-movement-barriers-convert\
+          \ wildlife-movement-barriers-pmtiles wildlife-movement-barriers-hex wildlife-movement-barriers-repartition\
+          \ wildlife-movement-barriers-workflow -n biodiversity\"\necho \"  kubectl\
+          \ delete configmap wildlife-movement-barriers-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: wildlife-movement-barriers-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #336.

Adds the CDFW **Terrestrial Wildlife Connectivity Barriers** → **Wildlife Movement Barriers** layer (BIOS ds2867) to the `public-connectivity` bucket.

## What
- Source: CDFW BIOS ds2867 ArcGIS FeatureServer, 204 line segments (LineString/MultiLineString), priorities as of June 2024.
- `--dataset wildlife-movement-barriers` → GeoParquet, PMTiles (source-layer `wildlife-movement-barriers`), H3 hex res 8 (parents `0`, lines buffered by circumradius before polyfill).
- License **CC-BY-4.0**.

## Artifacts on NRP S3 (produced by the cluster run)
- `wildlife-movement-barriers.parquet` — 204 features (Barrier_ID unique 204/204)
- `wildlife-movement-barriers.pmtiles`
- `wildlife-movement-barriers/hex/h0=*/data_0.parquet` — 2 h0 partitions
- `stac-collection.json` (registered as a child of `public-connectivity`), README updated.

## Recipe robustness fixes (after observed cluster failures)
- **convert / pmtiles**: rclone-localize the source to disk, then read locally. `ST_Read`/`ogr2ogr` cannot open `s3://`, and `/vsicurl` over the public endpoint fails on nodes with broken egress.
- **hex**: `backoffLimitPerIndex` + `maxFailedIndexes` + `activeDeadlineSeconds` (turn a running-hang on a flaky node into a retryable failure); `completions: 1`.
- **all steps**: exclude known bad-egress nodes via nodeAffinity.
- **pmtiles**: raise FD ulimit + cap tippecanoe threads ("Too many open files").

## Verification
- GeoParquet count == 204, `Barrier_ID` unique (no upstream row duplication).
- `scripts/verify-stac.py --no-data` passes (0 hard findings).
- Data-backed `verify-stac.py --bucket public-connectivity --dataset wildlife-movement-barriers` to be re-fired once artifacts + STAC are live (CI re-runs on push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
