### PR TITLE
nci-frontiers: carbon-by-zone-lulc reference lookup (per-land-use carbon, #334)

### DIFF
--- a/catalog/nci-frontiers/scripts/gen_stac.py
+++ b/catalog/nci-frontiers/scripts/gen_stac.py
@@ -89,6 +89,25 @@ k,a=asset("carbon-zones-hex","Carbon zones (new_ecoregions)",8,"carbon_zone",
      "not an enumerable thematic vocabulary, so no `values` array is listed. nodata 0 (no zone / ocean) excluded "
      "before aggregation. "+SRC)}); assets[k]=a
 
+# Reference lookup table (non-hex, non-geometry) — atomic, joinable in any context.
+# carbon_table reshaped long: one row per (carbon_zone, land-use class), value = carbon density.
+assets["carbon-by-zone-lulc-parquet"]={
+  "href":f"{BASE}/lookups/carbon-by-zone-lulc.parquet","type":"application/x-parquet",
+  "title":"Carbon density by carbon-zone × land-use class (Spawn/Polasky lookup)","roles":["data"],
+  "table:columns":[
+    {"name":"carbon_zone","type":"int64",
+     "description":"Carbon-zone ID (1–846; 830 zones). Joins to the carbon-zones-hex `carbon_zone` column (verified 1:1 key match). "+SRC},
+    {"name":"lulc_code","type":"int64",
+     "description":("Land-use / land-cover class code — ESA CCI classes plus Polasky et al. custom "
+       "intensification / oil-palm / plantation / grazing / forestry codes. Identifier that joins to the "
+       "ESA/PREDICTS land-use classes; full code→name definitions ship in the deposit `predicts` crosswalk "
+       "(published with the biodiversity layers). "+SRC)},
+    {"name":"carbon_mg_ha","type":"double",
+     "description":("Carbon density in metric tons of carbon per hectare (t C ha⁻¹ = Mg C ha⁻¹) for this "
+       "land-use class within this carbon zone (Spawn et al. via Polasky et al.). **Density, not a total — do NOT "
+       "SUM densities.** For a carbon stock multiply by ground area (paper: ×100 ha/km² × pixel_area_km²; on hex: "
+       "× the H3 cell area). Zero where there is no land use. "+SRC)}]}
+
 # COG assets (visualization) for any economic layer that has a published <dataset>-cog.tif (COG_LAYERS env)
 import os as _os
 _COGMETA={


### PR DESCRIPTION
Item 2 of the Polasky 2026 full-13-alternative frontier (#334): **per-land-use carbon**.

Publishes the Spawn et al. `carbon_table` (used by the paper's carbon objective) reshaped to a tidy, atomic **reference lookup** and registers it as a STAC asset:

- **`carbon-by-zone-lulc.parquet`** at `s3://public-nci-frontiers/lookups/` — 66,400 rows (830 carbon zones × 80 land-use classes): `carbon_zone, lulc_code, carbon_mg_ha`.
- **Join is a verified 1:1 key match** to the published `carbon-zones-hex.carbon_zone` (830 IDs, 1–846), so graded carbon under any frontier alternative = `carbon-zones` hex ⋈ this table on `carbon_zone`, selecting the alternative's `lulc_code`.
- `carbon_mg_ha` is a **density** (t C/ha = Mg C/ha; confirmed from the code deposit `carbon_new.py`) — documented as area-integrate-not-SUM.
- Standalone/atomic by design (reusable outside the frontier); no hex/geometry, no cluster compute.

STAC now 28 assets. `verify-stac.py --no-data` and `--bucket public-nci-frontiers` both pass (the lone advisory is the expected 'non-geo table has no geometry column').

The shared `predicts` LULC crosswalk + `predicts2` biodiversity multipliers land with the item-4 (per-alternative biodiversity) PR, where they're consumed and validated together.