### PR TITLE
hardening(#21): point backup manifests at rclone-backup (secret split)

### DIFF
--- a/catalog/sync/k8s/source-sync-ca-dac.yaml
+++ b/catalog/sync/k8s/source-sync-ca-dac.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-calenviroscreen.yaml
+++ b/catalog/sync/k8s/source-sync-calenviroscreen.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-carbon.yaml
+++ b/catalog/sync/k8s/source-sync-carbon.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-census.yaml
+++ b/catalog/sync/k8s/source-sync-census.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-cgs.yaml
+++ b/catalog/sync/k8s/source-sync-cgs.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-cpad.yaml
+++ b/catalog/sync/k8s/source-sync-cpad.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-cron.yaml
+++ b/catalog/sync/k8s/source-sync-cron.yaml
@@ -108,7 +108,7 @@ spec:
           volumes:
             - name: rclone-config
               secret:
-                secretName: rclone-config
+                secretName: rclone-backup
             - name: scope
               configMap:
                 name: source-sync-scope

--- a/catalog/sync/k8s/source-sync-ecoregion.yaml
+++ b/catalog/sync/k8s/source-sync-ecoregion.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-epa-water.yaml
+++ b/catalog/sync/k8s/source-sync-epa-water.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-fire.yaml
+++ b/catalog/sync/k8s/source-sync-fire.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-gbif.yaml
+++ b/catalog/sync/k8s/source-sync-gbif.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-gfw.yaml
+++ b/catalog/sync/k8s/source-sync-gfw.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-high-seas.yaml
+++ b/catalog/sync/k8s/source-sync-high-seas.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-inat.yaml
+++ b/catalog/sync/k8s/source-sync-inat.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-indigenous.yaml
+++ b/catalog/sync/k8s/source-sync-indigenous.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-land-cover.yaml
+++ b/catalog/sync/k8s/source-sync-land-cover.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-mappinginequality.yaml
+++ b/catalog/sync/k8s/source-sync-mappinginequality.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-mobi.yaml
+++ b/catalog/sync/k8s/source-sync-mobi.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-ncp.yaml
+++ b/catalog/sync/k8s/source-sync-ncp.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-overturemaps.yaml
+++ b/catalog/sync/k8s/source-sync-overturemaps.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-padus.yaml
+++ b/catalog/sync/k8s/source-sync-padus.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-population.yaml
+++ b/catalog/sync/k8s/source-sync-population.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-rap.yaml
+++ b/catalog/sync/k8s/source-sync-rap.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-rivers.yaml
+++ b/catalog/sync/k8s/source-sync-rivers.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-social-vulnerability.yaml
+++ b/catalog/sync/k8s/source-sync-social-vulnerability.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-trails.yaml
+++ b/catalog/sync/k8s/source-sync-trails.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-usfws.yaml
+++ b/catalog/sync/k8s/source-sync-usfws.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-wetlands.yaml
+++ b/catalog/sync/k8s/source-sync-wetlands.yaml
@@ -54,4 +54,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-ca-wolves.yaml
+++ b/catalog/sync/k8s/sync-public-ca-wolves.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-ca30x30.yaml
+++ b/catalog/sync/k8s/sync-public-ca30x30.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-calenviroscreen.yaml
+++ b/catalog/sync/k8s/sync-public-calenviroscreen.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-carbon.yaml
+++ b/catalog/sync/k8s/sync-public-carbon.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-cdfw.yaml
+++ b/catalog/sync/k8s/sync-public-cdfw.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-census.yaml
+++ b/catalog/sync/k8s/sync-public-census.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-cgs.yaml
+++ b/catalog/sync/k8s/sync-public-cgs.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-connectivity.yaml
+++ b/catalog/sync/k8s/sync-public-connectivity.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-cpad.yaml
+++ b/catalog/sync/k8s/sync-public-cpad.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-data.yaml
+++ b/catalog/sync/k8s/sync-public-data.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-datacenters.yaml
+++ b/catalog/sync/k8s/sync-public-datacenters.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-ecoregion.yaml
+++ b/catalog/sync/k8s/sync-public-ecoregion.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-epa-water.yaml
+++ b/catalog/sync/k8s/sync-public-epa-water.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-fire.yaml
+++ b/catalog/sync/k8s/sync-public-fire.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-gbif.yaml
+++ b/catalog/sync/k8s/sync-public-gbif.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-gfw.yaml
+++ b/catalog/sync/k8s/sync-public-gfw.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-grids.yaml
+++ b/catalog/sync/k8s/sync-public-grids.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-hazard.yaml
+++ b/catalog/sync/k8s/sync-public-hazard.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-high-seas.yaml
+++ b/catalog/sync/k8s/sync-public-high-seas.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-hydrobasins.yaml
+++ b/catalog/sync/k8s/sync-public-hydrobasins.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-icca.yaml
+++ b/catalog/sync/k8s/sync-public-icca.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-im3.yaml
+++ b/catalog/sync/k8s/sync-public-im3.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-inat.yaml
+++ b/catalog/sync/k8s/sync-public-inat.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-indigenous.yaml
+++ b/catalog/sync/k8s/sync-public-indigenous.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-iucn.yaml
+++ b/catalog/sync/k8s/sync-public-iucn.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-land-cover.yaml
+++ b/catalog/sync/k8s/sync-public-land-cover.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-mappinginequality.yaml
+++ b/catalog/sync/k8s/sync-public-mappinginequality.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-mobi.yaml
+++ b/catalog/sync/k8s/sync-public-mobi.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-ncp.yaml
+++ b/catalog/sync/k8s/sync-public-ncp.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-overturemaps.yaml
+++ b/catalog/sync/k8s/sync-public-overturemaps.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-padus.yaml
+++ b/catalog/sync/k8s/sync-public-padus.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-rap.yaml
+++ b/catalog/sync/k8s/sync-public-rap.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-rivers.yaml
+++ b/catalog/sync/k8s/sync-public-rivers.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-social-vulnerability.yaml
+++ b/catalog/sync/k8s/sync-public-social-vulnerability.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-tpl.yaml
+++ b/catalog/sync/k8s/sync-public-tpl.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-trails.yaml
+++ b/catalog/sync/k8s/sync-public-trails.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-usfws.yaml
+++ b/catalog/sync/k8s/sync-public-usfws.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-usgs-nhd.yaml
+++ b/catalog/sync/k8s/sync-public-usgs-nhd.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-usgs-wbd.yaml
+++ b/catalog/sync/k8s/sync-public-usgs-wbd.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-wdpa.yaml
+++ b/catalog/sync/k8s/sync-public-wdpa.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-wetlands.yaml
+++ b/catalog/sync/k8s/sync-public-wetlands.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-public-wyoming.yaml
+++ b/catalog/sync/k8s/sync-public-wyoming.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup

--- a/catalog/sync/k8s/sync-shared-ca30x30-app.yaml
+++ b/catalog/sync/k8s/sync-shared-ca30x30-app.yaml
@@ -45,4 +45,4 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup


### PR DESCRIPTION
Companion to the cluster-side **rclone-config secret split** (geo-agent-ops#21, step 3).

**Why:** the `biodiversity` `rclone-config` secret is now stripped to `nrp:`-only, so the many data-processing jobs that mount it can no longer reach the backup/mirror remotes. The backup remotes (`nrp`+`minio`+`source`) moved to a new `rclone-backup` secret. These manifests must point at `rclone-backup` or they break on the next `kubectl apply`.

**Scope:** `catalog/sync/k8s/` only — 71 `secretName` lines flipped (29 `source-sync-*`, 42 `sync-public-*`, 1 `sync-shared-*`). `source-sync-cron-config.yaml` (a ConfigMap) is untouched. Diff is *only* secretName lines.

**Interim note:** the `sync-public-*` (MinIO) jobs are the old manual-Job model, slated to converge onto the source.coop CronJob model in step 2 — repointed here for interim correctness.

**Held out for review:** the one-off `kind: Job` manifests that also use `minio:`/`source:` (`iucn-audit`, `iucn-nrp-sync`, `iucn-rescue`, `mche-stage`, `ecoregion-convert`, `nlcd-2024-conus-cog`) — these look like one-offs that may be deletable rather than repointed.

Refs geo-agent-ops#21.