### PR TITLE
nci-frontiers: complete the 13 transition-cost alternatives (item 3, #334)

### DIFF
--- a/catalog/nci-frontiers/k8s/tran-cost-extensification-bmps-irrigated/tran-cost-extensification-bmps-irrigated-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-extensification-bmps-irrigated/tran-cost-extensification-bmps-irrigated-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-extensification-bmps-irrigated-hex
+  labels:
+    k8s-app: tran-cost-extensification-bmps-irrigated-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-extensification-bmps-irrigated-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_extensification_bmps_irrigated.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-extensification-bmps-irrigated/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_ext_bmps_irrig_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-extensification-bmps-rainfed/tran-cost-extensification-bmps-rainfed-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-extensification-bmps-rainfed/tran-cost-extensification-bmps-rainfed-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-extensification-bmps-rainfed-hex
+  labels:
+    k8s-app: tran-cost-extensification-bmps-rainfed-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-extensification-bmps-rainfed-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_extensification_bmps_rainfed.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-extensification-bmps-rainfed/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_ext_bmps_rainfed_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-extensification-current-practices/tran-cost-extensification-current-practices-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-extensification-current-practices/tran-cost-extensification-current-practices-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-extensification-current-practices-hex
+  labels:
+    k8s-app: tran-cost-extensification-current-practices-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-extensification-current-practices-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_extensification_current_practices.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-extensification-current-practices/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_ext_current_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-fixedarea-bmps-irrigated/tran-cost-fixedarea-bmps-irrigated-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-fixedarea-bmps-irrigated/tran-cost-fixedarea-bmps-irrigated-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-fixedarea-bmps-irrigated-hex
+  labels:
+    k8s-app: tran-cost-fixedarea-bmps-irrigated-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-fixedarea-bmps-irrigated-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_fixedarea_bmps_irrigated.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-fixedarea-bmps-irrigated/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_fixedarea_bmps_irrig_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-fixedarea-bmps-rainfed/tran-cost-fixedarea-bmps-rainfed-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-fixedarea-bmps-rainfed/tran-cost-fixedarea-bmps-rainfed-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-fixedarea-bmps-rainfed-hex
+  labels:
+    k8s-app: tran-cost-fixedarea-bmps-rainfed-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-fixedarea-bmps-rainfed-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_fixedarea_bmps_rainfed.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-fixedarea-bmps-rainfed/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_fixedarea_bmps_rainfed_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-fixedarea-intensified-irrigated/tran-cost-fixedarea-intensified-irrigated-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-fixedarea-intensified-irrigated/tran-cost-fixedarea-intensified-irrigated-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-fixedarea-intensified-irrigated-hex
+  labels:
+    k8s-app: tran-cost-fixedarea-intensified-irrigated-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-fixedarea-intensified-irrigated-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_fixedarea_intensified_irrigated.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-fixedarea-intensified-irrigated/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_fixedarea_intens_irrig_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-fixedarea-intensified-rainfed/tran-cost-fixedarea-intensified-rainfed-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-fixedarea-intensified-rainfed/tran-cost-fixedarea-intensified-rainfed-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-fixedarea-intensified-rainfed-hex
+  labels:
+    k8s-app: tran-cost-fixedarea-intensified-rainfed-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-fixedarea-intensified-rainfed-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_fixedarea_intensified_rainfed.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-fixedarea-intensified-rainfed/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_fixedarea_intens_rainfed_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/k8s/tran-cost-forestry-expansion/tran-cost-forestry-expansion-hex.yaml
+++ b/catalog/nci-frontiers/k8s/tran-cost-forestry-expansion/tran-cost-forestry-expansion-hex.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tran-cost-forestry-expansion-hex
+  labels:
+    k8s-app: tran-cost-forestry-expansion-hex
+spec:
+  completions: 122
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: tran-cost-forestry-expansion-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-nci-frontiers
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - 'set -e
+
+
+          cng-datasets raster --input "s3://public-nci-frontiers/raw/inputs/transition_costs/tran_cost_forestry_expansion.tif"
+          --output-parquet s3://public-nci-frontiers/tran-cost-forestry-expansion/hex/ --h0-index
+          ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 7,6,5,0 --value-column
+          tcost_forestry_expansion_usd --hex-resampling sum'
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org
+      activeDeadlineSeconds: 1200

--- a/catalog/nci-frontiers/scripts/gen_stac.py
+++ b/catalog/nci-frontiers/scripts/gen_stac.py
@@ -39,15 +39,33 @@ k,a=asset("grazing-methane-hex","Potential grazing methane",5,"methane_kg_ha_yr"
 k,a=asset("forestry-return-hex","Potential forestry revenue",8,"forestry_usd_ha",dens("forestry_usd_ha","potential forestry net return",-99999)); assets[k]=a
 k,a=asset("flii-hex","Forest Landscape Integrity Index",8,"flii",
   {"name":"flii","type":"double","description":"Area-weighted MEAN Forest Landscape Integrity Index, 0–10000 (÷10000 → 0–1; higher = more intact forest). reducer=mean. **Intensity — AVG not SUM.** Source: Grantham et al. 2020 (doi:10.1038/s41467-020-19493-3), provided CC0 via "+SRC}); assets[k]=a
-# Wave 3 — transition costs (res 8, USD/cell totals, SUM-able)
-for key,title,col,scn in [
-  ("tran-cost-restoration-hex","Transition cost: restoration","tcost_restoration_usd","restoration to natural habitat"),
-  ("tran-cost-sustainable-current-hex","Transition cost: sustainable current","tcost_sustainable_current_usd","sustainable current land use"),
-  ("tran-cost-extensification-intensified-irrigated-hex","Transition cost: extensification+intensified irrigated","tcost_ext_intens_irrig_usd","cropland expansion + intensified irrigated"),
-  ("tran-cost-extensification-intensified-rainfed-hex","Transition cost: extensification+intensified rainfed","tcost_ext_intens_rainfed_usd","cropland expansion + intensified rainfed"),
-  ("tran-cost-grazing-expansion-hex","Transition cost: grazing expansion","tcost_grazing_expansion_usd","grazing expansion")]:
-    k,a=asset(key,title,8,col,
-      {"name":col,"type":"double","description":f"Total one-time land-use transition cost in USD per H3 cell for the **{scn}** alternative (reducer=sum of per-pixel USD). Safe to SUM across cells at the SAME resolution; do not sum across resolutions. "+SRC}); assets[k]=a
+# Wave 3 — transition costs: all 13 land-use alternatives (res 8, sum of per-pixel USD).
+# Units are ANNUALIZED USD 2015 per year (SI §7), NOT one-time. 4 alternatives have a genuine
+# model zero (management/sustainable-use change on existing cover — no land conversion); verified
+# against the authors' results (Brazil+USA sums, Brazil ModelResults pixels). base_lulc is the
+# baseline reference (not an alternative) and is intentionally excluded.
+for key,title,col,scn,zero in [
+  ("tran-cost-restoration-hex","Transition cost: restoration","tcost_restoration_usd","restoration to natural habitat",0),
+  ("tran-cost-extensification-intensified-irrigated-hex","Transition cost: extensification+intensified irrigated","tcost_ext_intens_irrig_usd","cropland expansion, intensified, irrigated",0),
+  ("tran-cost-extensification-intensified-rainfed-hex","Transition cost: extensification+intensified rainfed","tcost_ext_intens_rainfed_usd","cropland expansion, intensified, rainfed",0),
+  ("tran-cost-extensification-bmps-irrigated-hex","Transition cost: extensification+BMPs irrigated","tcost_ext_bmps_irrig_usd","cropland expansion, best-management-practices, irrigated",0),
+  ("tran-cost-extensification-bmps-rainfed-hex","Transition cost: extensification+BMPs rainfed","tcost_ext_bmps_rainfed_usd","cropland expansion, best-management-practices, rainfed",0),
+  ("tran-cost-extensification-current-practices-hex","Transition cost: extensification current practices","tcost_ext_current_usd","cropland expansion, current practices",0),
+  ("tran-cost-fixedarea-bmps-irrigated-hex","Transition cost: fixed-area BMPs irrigated","tcost_fixedarea_bmps_irrig_usd","fixed-area cropland, best-management-practices, irrigated",0),
+  ("tran-cost-fixedarea-bmps-rainfed-hex","Transition cost: fixed-area BMPs rainfed","tcost_fixedarea_bmps_rainfed_usd","fixed-area cropland, best-management-practices, rainfed",0),
+  ("tran-cost-fixedarea-intensified-irrigated-hex","Transition cost: fixed-area intensified irrigated","tcost_fixedarea_intens_irrig_usd","fixed-area cropland, intensified, irrigated",0),
+  ("tran-cost-sustainable-current-hex","Transition cost: sustainable current","tcost_sustainable_current_usd","sustainable current land use",1),
+  ("tran-cost-grazing-expansion-hex","Transition cost: grazing expansion","tcost_grazing_expansion_usd","sustainable grazing expansion",1),
+  ("tran-cost-forestry-expansion-hex","Transition cost: forestry expansion","tcost_forestry_expansion_usd","sustainable forestry expansion",1),
+  ("tran-cost-fixedarea-intensified-rainfed-hex","Transition cost: fixed-area intensified rainfed","tcost_fixedarea_intens_rainfed_usd","fixed-area cropland, intensified, rainfed",1)]:
+    base=(f"Annualized land-use transition cost (USD 2015 per year) for the **{scn}** alternative, "
+          "summed over source pixels in each H3 cell (reducer=sum). Safe to SUM across cells at the SAME "
+          "resolution; do not sum across resolutions. ")
+    znote=("**This alternative incurs zero transition cost in the model** (management / sustainable-use change "
+           "on existing land cover — no land conversion or new infrastructure); every cell is 0. Verified against "
+           "the authors' results (Brazil+USA country sums and Brazil ModelResults pixels). Published for a complete "
+           "13-alternative set. " if zero else "")
+    k,a=asset(key,title,8,col,{"name":col,"type":"double","description":base+znote+SRC}); assets[k]=a
 
 # ESA CCI land cover (current land-use mask for the economic overlay) — categorical, res 8
 _ESA={10:"Cropland rainfed",11:"Cropland rainfed herbaceous",12:"Cropland rainfed tree/shrub",20:"Cropland irrigated",30:"Mosaic cropland>50%/natural",40:"Mosaic natural>50%/cropland",50:"Tree broadleaved evergreen",60:"Tree broadleaved deciduous",61:"Tree broadleaved deciduous closed",62:"Tree broadleaved deciduous open",70:"Tree needleleaved evergreen",71:"Tree needleleaved evergreen closed",72:"Tree needleleaved evergreen open",80:"Tree needleleaved deciduous",81:"Tree needleleaved deciduous closed",82:"Tree needleleaved deciduous open",90:"Tree mixed",100:"Mosaic tree-shrub>50%/herbaceous",110:"Mosaic herbaceous>50%/tree-shrub",120:"Shrubland",121:"Shrubland evergreen",122:"Shrubland deciduous",130:"Grassland",140:"Lichens/mosses",150:"Sparse vegetation",151:"Sparse tree",152:"Sparse shrub",153:"Sparse herbaceous",160:"Tree flooded fresh/brackish",170:"Tree flooded saline",180:"Shrub/herbaceous flooded",190:"Urban",200:"Bare areas",201:"Bare consolidated",202:"Bare unconsolidated",210:"Water",220:"Permanent snow/ice"}


### PR DESCRIPTION
Item 3 of the Polasky 2026 frontier (#334): the remaining transition-cost layers, completing the full **13-alternative** set.

## What landed
- **6 new nonzero layers** hexed (res 8, `sum`, 64Gi hardened recipe): extensification {bmps-irrigated, bmps-rainfed, current-practices}, fixedarea {bmps-irrigated, bmps-rainfed, intensified-irrigated}. Validated via MCP — all 122 partitions, dateline seam present, global sums exceed the Brazil+USA results-deposit anchors.
- **2 genuine-zero layers** hexed (forestry-expansion, fixedarea-intensified-rainfed): confirmed `SUM=0` over the full 122-partition grid. Published for a consistent 13-alternative set.
- **STAC:** all 13 transition-cost alternatives now have assets (36 total). Units **corrected to annualized USD 2015/year** (SI §7; the prior 5 said 'one-time'). The 4 zero-cost alternatives are documented as genuine model zeros.
- **base_lulc excluded** — it's the baseline reference, not an alternative (no row in the results table).

## Rigor note (why the zeros are correct, not corrupt)
Pre-flight found 3 all-zero sources. Rather than assume a broken export, I pulled the **results deposit** (`solutions.h5`, via HTTP range-read — no full download) and confirmed `forestry_expansion`, `fixedarea_intensified_rainfed`, `grazing_expansion`, `sustainable_current` are **exactly 0** in both Brazil and USA `value_table_summary`, and 0 at the pixel level in Brazil `ModelResults`. `transition_cost` is the annualized *land-conversion* cost — management-only / sustainable-use changes on existing cover legitimately incur none. The one uint8-nonzero layer (fixedarea-bmps-rainfed) has true max 216 → not clipped. **No author contact needed.**

verify-stac.py static + data-backed both pass (the lone advisory is the expected 'non-geo reference table has no geometry column' on the carbon lookup).