### PR TITLE
hardening(#21): --max-delete 150 circuit-breaker on source.coop sync

### DIFF
--- a/catalog/sync/k8s/source-sync-ca-dac.yaml
+++ b/catalog/sync/k8s/source-sync-ca-dac.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-calenviroscreen.yaml
+++ b/catalog/sync/k8s/source-sync-calenviroscreen.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-carbon.yaml
+++ b/catalog/sync/k8s/source-sync-carbon.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-census.yaml
+++ b/catalog/sync/k8s/source-sync-census.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-cgs.yaml
+++ b/catalog/sync/k8s/source-sync-cgs.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-cpad.yaml
+++ b/catalog/sync/k8s/source-sync-cpad.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-cron.yaml
+++ b/catalog/sync/k8s/source-sync-cron.yaml
@@ -62,7 +62,10 @@ spec:
                                               # stay literal and a HOLD path can't accidentally expand away.
                   ACCOUNT="cboettig"
                   DEST_BUCKET="us-west-2.opendata.source.coop"
-                  RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 300s -v"
+                  # --max-delete 150: circuit-breaker (see per-repo job comment) —
+                  # aborts a run that would delete >150 objects at dest, so an
+                  # emptied/corrupted source can't propagate a wipe to source.coop.
+                  RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 300s -v"
                   if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
                   fail=0 ; n=0
                   while read -r repo verb excludes; do

--- a/catalog/sync/k8s/source-sync-ecoregion.yaml
+++ b/catalog/sync/k8s/source-sync-ecoregion.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-epa-water.yaml
+++ b/catalog/sync/k8s/source-sync-epa-water.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-fire.yaml
+++ b/catalog/sync/k8s/source-sync-fire.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-gbif.yaml
+++ b/catalog/sync/k8s/source-sync-gbif.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-gfw.yaml
+++ b/catalog/sync/k8s/source-sync-gfw.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-high-seas.yaml
+++ b/catalog/sync/k8s/source-sync-high-seas.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-inat.yaml
+++ b/catalog/sync/k8s/source-sync-inat.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-indigenous.yaml
+++ b/catalog/sync/k8s/source-sync-indigenous.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-land-cover.yaml
+++ b/catalog/sync/k8s/source-sync-land-cover.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-mappinginequality.yaml
+++ b/catalog/sync/k8s/source-sync-mappinginequality.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-mobi.yaml
+++ b/catalog/sync/k8s/source-sync-mobi.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Copying: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-ncp.yaml
+++ b/catalog/sync/k8s/source-sync-ncp.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-overturemaps.yaml
+++ b/catalog/sync/k8s/source-sync-overturemaps.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-padus.yaml
+++ b/catalog/sync/k8s/source-sync-padus.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-population.yaml
+++ b/catalog/sync/k8s/source-sync-population.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-rap.yaml
+++ b/catalog/sync/k8s/source-sync-rap.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-rivers.yaml
+++ b/catalog/sync/k8s/source-sync-rivers.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-social-vulnerability.yaml
+++ b/catalog/sync/k8s/source-sync-social-vulnerability.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-trails.yaml
+++ b/catalog/sync/k8s/source-sync-trails.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-usfws.yaml
+++ b/catalog/sync/k8s/source-sync-usfws.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/k8s/source-sync-wetlands.yaml
+++ b/catalog/sync/k8s/source-sync-wetlands.yaml
@@ -45,7 +45,11 @@ spec:
                 "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
                 *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"

--- a/catalog/sync/source-coop/gen-source-sync.sh
+++ b/catalog/sync/source-coop/gen-source-sync.sh
@@ -124,7 +124,11 @@ spec:
                 "source:${DEST_BUCKET}/${ACCOUNT}/"?*) : ;;
                 *) echo "REFUSING: dest '\$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
               esac
-              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 120s -v"
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "\${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="\$RCLONE_FLAGS --dry-run"; fi
               echo "${verb^}ing: \$SRC -> \$DEST  (DRYRUN=\${DRYRUN:-false})"
@@ -133,7 +137,7 @@ spec:
       volumes:
         - name: rclone-config
           secret:
-            secretName: rclone-config
+            secretName: rclone-backup
 YAML
   echo "wrote source-sync-${repo}.yaml  [${verb}]${excl:+  (excludes:${excl})}"
 done
@@ -237,7 +241,10 @@ spec:
                                               # stay literal and a HOLD path can't accidentally expand away.
                   ACCOUNT="cboettig"
                   DEST_BUCKET="us-west-2.opendata.source.coop"
-                  RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --stats 300s -v"
+                  # --max-delete 150: circuit-breaker (see per-repo job comment) —
+                  # aborts a run that would delete >150 objects at dest, so an
+                  # emptied/corrupted source can't propagate a wipe to source.coop.
+                  RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 300s -v"
                   if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
                   fail=0 ; n=0
                   while read -r repo verb excludes; do
@@ -283,7 +290,7 @@ spec:
           volumes:
             - name: rclone-config
               secret:
-                secretName: rclone-config
+                secretName: rclone-backup
             - name: scope
               configMap:
                 name: source-sync-scope


### PR DESCRIPTION
Adds a **`--max-delete 150`** circuit-breaker to the source.coop backup (via the `gen-source-sync.sh` generator → 27 per-repo jobs + the weekly cron). If a run would delete >150 objects at the destination it aborts, so an emptied/corrupted NRP source can't propagate a mass-delete wipe to the source.coop mirror. 150 comfortably covers `overturemaps`'s ~122 H0 partitions + assets (and its upstream sync is manual, not this cron).

Also **fixes a generator drift**: the generator still emitted `secretName: rclone-config`, but #341 changed the *generated* files to `rclone-backup` without updating the generator — so a regen would have silently reverted #341. The generator now emits `rclone-backup`.

No `--backup-dir` here (source.coop is a public mirror we don't own). Refs geo-agent-ops#21.