### PR TITLE
hardening(geo-agent-ops#21): step 3b — backup jobs → boettiger-lab namespace

### DIFF
--- a/catalog/sync/k8s/source-sync-ca-dac.yaml
+++ b/catalog/sync/k8s/source-sync-ca-dac.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-ca-dac
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-calenviroscreen.yaml
+++ b/catalog/sync/k8s/source-sync-calenviroscreen.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-calenviroscreen
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-carbon.yaml
+++ b/catalog/sync/k8s/source-sync-carbon.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-carbon
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-census.yaml
+++ b/catalog/sync/k8s/source-sync-census.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-census
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-cgs.yaml
+++ b/catalog/sync/k8s/source-sync-cgs.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-cgs
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-cpad.yaml
+++ b/catalog/sync/k8s/source-sync-cpad.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-cpad
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-cron-config.yaml
+++ b/catalog/sync/k8s/source-sync-cron-config.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: source-sync-scope
-  namespace: biodiversity
+  namespace: boettiger-lab
   labels:
     app: source-sync
 data:

--- a/catalog/sync/k8s/source-sync-cron.yaml
+++ b/catalog/sync/k8s/source-sync-cron.yaml
@@ -5,13 +5,13 @@
 # source-sync-<repo>.yaml jobs. continue-on-error: one bad repo doesn't block
 # the rest, but the Job still exits non-zero so the failure is visible.
 #   Apply:      kubectl apply -f source-sync-cron-config.yaml -f source-sync-cron.yaml
-#   Manual run: kubectl -n biodiversity create job --from=cronjob/source-sync source-sync-manual
+#   Manual run: kubectl -n boettiger-lab create job --from=cronjob/source-sync source-sync-manual
 #   Dry run:    edit env DRYRUN=true on the manual Job (lists changes, writes nothing)
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: source-sync
-  namespace: biodiversity
+  namespace: boettiger-lab
   labels:
     app: source-sync
 spec:

--- a/catalog/sync/k8s/source-sync-ecoregion.yaml
+++ b/catalog/sync/k8s/source-sync-ecoregion.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-ecoregion
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-epa-water.yaml
+++ b/catalog/sync/k8s/source-sync-epa-water.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-epa-water
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-fire.yaml
+++ b/catalog/sync/k8s/source-sync-fire.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-fire
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-gbif.yaml
+++ b/catalog/sync/k8s/source-sync-gbif.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-gbif
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-gfw.yaml
+++ b/catalog/sync/k8s/source-sync-gfw.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-gfw
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-high-seas.yaml
+++ b/catalog/sync/k8s/source-sync-high-seas.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-high-seas
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-inat.yaml
+++ b/catalog/sync/k8s/source-sync-inat.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-inat
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-indigenous.yaml
+++ b/catalog/sync/k8s/source-sync-indigenous.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-indigenous
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-land-cover.yaml
+++ b/catalog/sync/k8s/source-sync-land-cover.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-land-cover
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-mappinginequality.yaml
+++ b/catalog/sync/k8s/source-sync-mappinginequality.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-mappinginequality
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-mobi.yaml
+++ b/catalog/sync/k8s/source-sync-mobi.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-mobi
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-ncp.yaml
+++ b/catalog/sync/k8s/source-sync-ncp.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-ncp
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-overturemaps.yaml
+++ b/catalog/sync/k8s/source-sync-overturemaps.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-overturemaps
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-padus.yaml
+++ b/catalog/sync/k8s/source-sync-padus.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-padus
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-population.yaml
+++ b/catalog/sync/k8s/source-sync-population.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-population
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-rap.yaml
+++ b/catalog/sync/k8s/source-sync-rap.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-rap
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-rivers.yaml
+++ b/catalog/sync/k8s/source-sync-rivers.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-rivers
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-social-vulnerability.yaml
+++ b/catalog/sync/k8s/source-sync-social-vulnerability.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-social-vulnerability
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-trails.yaml
+++ b/catalog/sync/k8s/source-sync-trails.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-trails
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-usfws.yaml
+++ b/catalog/sync/k8s/source-sync-usfws.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-usfws
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/source-sync-wetlands.yaml
+++ b/catalog/sync/k8s/source-sync-wetlands.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-wetlands
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-ca-wolves.yaml
+++ b/catalog/sync/k8s/sync-public-ca-wolves.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-ca-wolves
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-ca30x30.yaml
+++ b/catalog/sync/k8s/sync-public-ca30x30.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-ca30x30
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-calenviroscreen.yaml
+++ b/catalog/sync/k8s/sync-public-calenviroscreen.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-calenviroscreen
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-carbon.yaml
+++ b/catalog/sync/k8s/sync-public-carbon.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-carbon
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-cdfw.yaml
+++ b/catalog/sync/k8s/sync-public-cdfw.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-cdfw
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-census.yaml
+++ b/catalog/sync/k8s/sync-public-census.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-census
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-cgs.yaml
+++ b/catalog/sync/k8s/sync-public-cgs.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-cgs
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-connectivity.yaml
+++ b/catalog/sync/k8s/sync-public-connectivity.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-connectivity
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-cpad.yaml
+++ b/catalog/sync/k8s/sync-public-cpad.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-cpad
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-data.yaml
+++ b/catalog/sync/k8s/sync-public-data.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-data
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-datacenters.yaml
+++ b/catalog/sync/k8s/sync-public-datacenters.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-datacenters
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-ecoregion.yaml
+++ b/catalog/sync/k8s/sync-public-ecoregion.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-ecoregion
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-epa-water.yaml
+++ b/catalog/sync/k8s/sync-public-epa-water.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-epa-water
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-fire.yaml
+++ b/catalog/sync/k8s/sync-public-fire.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-fire
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-gbif.yaml
+++ b/catalog/sync/k8s/sync-public-gbif.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-gbif
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-gfw.yaml
+++ b/catalog/sync/k8s/sync-public-gfw.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-gfw
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-grids.yaml
+++ b/catalog/sync/k8s/sync-public-grids.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-grids
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-hazard.yaml
+++ b/catalog/sync/k8s/sync-public-hazard.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-hazard
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-high-seas.yaml
+++ b/catalog/sync/k8s/sync-public-high-seas.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-high-seas
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-hydrobasins.yaml
+++ b/catalog/sync/k8s/sync-public-hydrobasins.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-hydrobasins
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-icca.yaml
+++ b/catalog/sync/k8s/sync-public-icca.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-icca
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-im3.yaml
+++ b/catalog/sync/k8s/sync-public-im3.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-im3
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-inat.yaml
+++ b/catalog/sync/k8s/sync-public-inat.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-inat
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-indigenous.yaml
+++ b/catalog/sync/k8s/sync-public-indigenous.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-indigenous
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-iucn.yaml
+++ b/catalog/sync/k8s/sync-public-iucn.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-iucn
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-land-cover.yaml
+++ b/catalog/sync/k8s/sync-public-land-cover.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-land-cover
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-mappinginequality.yaml
+++ b/catalog/sync/k8s/sync-public-mappinginequality.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-mappinginequality
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-mobi.yaml
+++ b/catalog/sync/k8s/sync-public-mobi.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-mobi
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-ncp.yaml
+++ b/catalog/sync/k8s/sync-public-ncp.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-ncp
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-overturemaps.yaml
+++ b/catalog/sync/k8s/sync-public-overturemaps.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-overturemaps
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-padus.yaml
+++ b/catalog/sync/k8s/sync-public-padus.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-padus
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-rap.yaml
+++ b/catalog/sync/k8s/sync-public-rap.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-rap
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-rivers.yaml
+++ b/catalog/sync/k8s/sync-public-rivers.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-rivers
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-social-vulnerability.yaml
+++ b/catalog/sync/k8s/sync-public-social-vulnerability.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-social-vulnerability
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-tpl.yaml
+++ b/catalog/sync/k8s/sync-public-tpl.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-tpl
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-trails.yaml
+++ b/catalog/sync/k8s/sync-public-trails.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-trails
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-usfws.yaml
+++ b/catalog/sync/k8s/sync-public-usfws.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-usfws
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-usgs-nhd.yaml
+++ b/catalog/sync/k8s/sync-public-usgs-nhd.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-usgs-nhd
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-usgs-wbd.yaml
+++ b/catalog/sync/k8s/sync-public-usgs-wbd.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-usgs-wbd
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-wdpa.yaml
+++ b/catalog/sync/k8s/sync-public-wdpa.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-wdpa
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-wetlands.yaml
+++ b/catalog/sync/k8s/sync-public-wetlands.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-wetlands
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-public-wyoming.yaml
+++ b/catalog/sync/k8s/sync-public-wyoming.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-public-wyoming
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/k8s/sync-shared-ca30x30-app.yaml
+++ b/catalog/sync/k8s/sync-shared-ca30x30-app.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: sync-shared-ca30x30-app
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400

--- a/catalog/sync/source-coop/gen-source-sync.sh
+++ b/catalog/sync/source-coop/gen-source-sync.sh
@@ -81,7 +81,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: source-sync-${repo}
-  namespace: biodiversity
+  namespace: boettiger-lab
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 86400
@@ -162,7 +162,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: source-sync-scope
-  namespace: biodiversity
+  namespace: boettiger-lab
   labels:
     app: source-sync
 data:
@@ -184,13 +184,13 @@ cat > "${CRON}" <<'YAML'
 # source-sync-<repo>.yaml jobs. continue-on-error: one bad repo doesn't block
 # the rest, but the Job still exits non-zero so the failure is visible.
 #   Apply:      kubectl apply -f source-sync-cron-config.yaml -f source-sync-cron.yaml
-#   Manual run: kubectl -n biodiversity create job --from=cronjob/source-sync source-sync-manual
+#   Manual run: kubectl -n boettiger-lab create job --from=cronjob/source-sync source-sync-manual
 #   Dry run:    edit env DRYRUN=true on the manual Job (lists changes, writes nothing)
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: source-sync
-  namespace: biodiversity
+  namespace: boettiger-lab
   labels:
     app: source-sync
 spec:

--- a/catalog/sync/source-coop/run-source-sync.sh
+++ b/catalog/sync/source-coop/run-source-sync.sh
@@ -15,7 +15,7 @@
 # currently 501/disabled.
 set -euo pipefail
 K8S="$(cd "$(dirname "$0")/../k8s" && pwd)"
-NS=biodiversity
+NS=boettiger-lab
 
 ORDER=(
   mobi mappinginequality cgs ncp usfws calenviroscreen trails


### PR DESCRIPTION
Repo half of **step 3b** (geo-agent-ops#21, DATA_WORKFLOWS_HARDENING.md): backup credentials leave the agent-reachable `biodiversity` namespace.

## What
- All 72 backup manifests in `catalog/sync/k8s/` flip `namespace: biodiversity` → `boettiger-lab` (27 `source-sync-*` one-offs, 42 `sync-public-*`, `sync-shared-ca30x30-app`, the `source-sync` CronJob + `source-sync-scope` ConfigMap).
- `gen-source-sync.sh` + `run-source-sync.sh` updated first, generated files regenerated from it (no generator drift — same discipline as #347).
- Diff verified namespace-only: no other content changed.

## Why boettiger-lab
Per decision 2026-07-02: agent-free already (workflow-agent SA is not a member; Carl-only), no NRP portal request needed. Anything with create-pods in `biodiversity` (incl. today's OIDC-identity agent) can currently mount `rclone-backup` = the **omnipotent `nrp:` and account-wide `source:` keys**. After the move, those leave the agent's reach.

## Sequencing
1. Merge this PR.
2. Cluster side (blocked on kubectl re-auth right now, Ceph-independent): create `rclone-backup` secret in `boettiger-lab`, `kubectl apply` the CronJob + ConfigMap there, then delete CronJob/ConfigMap/secret from `biodiversity`.
3. End-to-end sync verification waits for Ceph recovery (next cron: Sunday 08:00 UTC).

Interim inconsistency is fail-safe in both orders: a manifest applied in a namespace without the secret just doesn't schedule.

⚠ `sync-shared-ca30x30-app` is flipped for consistency but remains broken by design (scoped `geo-workflow` key can't write `shared-*`) — keep-vs-drop still an open decision.

Part of the geo-agent-ops#21 hardening campaign; step 3a was #341/#347.