### PR TITLE
landmark-indicative-poly: complete res-10 re-hex recipe (fix #179)

### DIFF
--- a/catalog/indigenous/k8s/indicative-poly/landmark-indicative-poly-rehex-repartition.yaml
+++ b/catalog/indigenous/k8s/indicative-poly/landmark-indicative-poly-rehex-repartition.yaml
@@ -1,0 +1,102 @@
+# Fix #179 — STEP 3 of 3 (run AFTER both landmark-indicative-poly-rehex.yaml [res-10]
+# and landmark-indicative-poly-rehex-res8.yaml [res-8 giants] have completed).
+#
+# Merges the mixed-resolution chunks in chunks-rehex (res-10 for the ~17,512 features
+# <=50 deg^2, res-8 for the ~27 continent-scale claims) into a STAGING hex dir, keyed by
+# h0. --source-parquet rejoins chunk outputs to the flat GeoParquet by _cng_fid, so the
+# original unsorted source MUST be used (do not re-sort — that reassigns _cng_fid and
+# breaks the hex<->flat join).
+#
+# Output goes to hex-staging, NOT the canonical hex/ — do not overwrite the live layer
+# until the hard gate passes.
+#
+# ⚠️ HARD GATE before flipping staging -> canonical (per issue #179, cboettig 2026-06-26):
+#   1. DESCRIBE shows columns h0, h8, h9, h10.
+#   2. COUNT(DISTINCT _cng_fid) == 17539  (the current live build is lossy: only 17,462).
+#   3. The 27 giant features (>50 deg^2) are present (at h8).
+# Only then flip:
+#   rclone purge  nrp:public-indigenous/landmark/indicative-poly/hex        # confirm empty after
+#   rclone copyto nrp:public-indigenous/landmark/indicative-poly/hex-staging \
+#                 nrp:public-indigenous/landmark/indicative-poly/hex
+# then patch the STAC (add h3:native_resolution: 10, h3:parent_resolutions: [9,8,0], drop
+# "mixed" from the title, document that ~27 giants top out at h8).
+#
+# ephemeral-storage is 50Gi (the namespace cap); the original repartition YAML requested
+# 200Gi, which the quota rejects.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: landmark-indicative-poly-rehex-repartition
+  labels:
+    k8s-app: landmark-indicative-poly-rehex-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: landmark-indicative-poly-rehex-repartition
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-indigenous
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-indigenous/landmark/indicative-poly/chunks-rehex --output-dir s3://public-indigenous/landmark/indicative-poly/hex-staging --source-parquet s3://public-indigenous/landmark/indicative-poly.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/indigenous/k8s/indicative-poly/landmark-indicative-poly-rehex-res8.yaml
+++ b/catalog/indigenous/k8s/indicative-poly/landmark-indicative-poly-rehex-res8.yaml
@@ -1,0 +1,92 @@
+# Fix #179 — STEP 2 of 3 (run AFTER landmark-indicative-poly-rehex.yaml, the res-10 build).
+#
+# The res-10 full build writes every feasible chunk to .../indicative-poly/chunks-rehex.
+# Continent-scale claims (>50 deg^2; a single 849 deg^2 polygon ~= 700M cells at res 10)
+# OOM at res 10 and produce NO output for their chunk. This job reprocesses ONLY those
+# giant-containing chunks at res 8 into the SAME chunks-rehex dir, filling the gaps.
+#
+# ⚠️ DO NOT hardcode the chunk map blindly. After the res-10 job completes, identify the
+#    chunks that produced no output empirically, e.g.:
+#      for i in $(seq 0 199); do
+#        rclone lsf nrp:public-indigenous/landmark/indicative-poly/chunks-rehex/ | grep -q "chunk-${i}\b" \
+#          || echo "empty: $i"
+#      done
+#    (or list the chunks-rehex dir and diff against 0..199). cboettig verified 2026-06-26
+#    that giants fall in chunks {0, 6, 197, 198} by (_cng_fid-1)//88 — used as the default
+#    below — but this MUST be reconciled against the actual empty-output set, and BOTH
+#    `completions` and CHUNK_MAP updated to match if it differs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: landmark-indicative-poly-rehex-res8
+  labels:
+    k8s-app: landmark-indicative-poly-rehex-res8
+spec:
+  completions: 4          # == len(CHUNK_MAP); update if the empirical empty-chunk set differs
+  parallelism: 4
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 1
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: landmark-indicative-poly-rehex-res8
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(0 6 197 198)
+          CHUNK_ID=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "Reprocessing giant chunk $CHUNK_ID at resolution 8 -> chunks-rehex"
+          cng-datasets vector --input s3://public-indigenous/landmark/indicative-poly.parquet --output s3://public-indigenous/landmark/indicative-poly/chunks-rehex --chunk-id $CHUNK_ID --chunk-size 88 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 48Gi
+          limits:
+            cpu: '4'
+            memory: 48Gi

--- a/catalog/indigenous/k8s/indicative-poly/landmark-indicative-poly-rehex.yaml
+++ b/catalog/indigenous/k8s/indicative-poly/landmark-indicative-poly-rehex.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: landmark-indicative-poly-rehex
+  labels:
+    k8s-app: landmark-indicative-poly-rehex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  # Giant continent-scale claims OOM at res 10 and produce no output (expected);
+  # tolerate those failed indices instead of failing the whole job, and retry
+  # transient preemptions per index.
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 40
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: landmark-indicative-poly-rehex
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-indigenous
+        - name: DATASET
+          value: landmark-indicative-poly
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-indigenous/landmark/indicative-poly.parquet --output s3://public-indigenous/landmark/indicative-poly/chunks-rehex --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 88 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 48Gi
+          limits:
+            cpu: '4'
+            memory: 48Gi


### PR DESCRIPTION
Completes the re-hex recipe for `landmark-indicative-poly`, whose hex is currently h8-only and lossy (17,462 of 17,539 features) while its STAC claims resolution 10 (#179).

Implements the 3-step plan from #179 (cboettig 2026-06-26):

1. **`-rehex.yaml`** (already on branch) — res-10 full build → `indicative-poly/chunks-rehex`; continent-scale claims OOM at res 10 and produce no output (tolerated via `maxFailedIndexes`).
2. **`-rehex-res8.yaml`** (new) — res-8 reprocess of the OOM'd giant chunks into the same `chunks-rehex`. Defaults to the giant-containing chunks `{0,6,197,198}` cboettig verified, with the empirical empty-chunk derivation + `completions`/`CHUNK_MAP` reconcile documented inline (per the plan's "do not hardcode blindly").
3. **`-rehex-repartition.yaml`** (new) — merges the mixed-resolution `chunks-rehex` → **`hex-staging`** (not canonical `hex/`), `--source-parquet` to keep `_cng_fid`-safe joins, ephemeral **50Gi** (the original repartition YAML's 200Gi exceeds the namespace cap).

Each new YAML carries inline run order and the **hard gate** before flipping staging → canonical: `DESCRIBE` shows h0/h8/h9/h10, `COUNT(DISTINCT _cng_fid) == 17539`, and the 27 giant features present. The flip + STAC patch (add `h3:native_resolution: 10`, `h3:parent_resolutions: [9,8,0]`, drop "mixed" from the title) are documented as the manual post-gate steps.

**Codegen only — not yet executed** (ceph/S3 currently unavailable). YAMLs lint clean.

Refs #179.