### PR TITLE
AGENTS.md: HARD BOUNDARY 3 — jobs run in geo-workflows (not biodiversity)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,56 @@ print(c.execute(\"SELECT ST_AsText(ST_Envelope(geom)) FROM read_parquet('/tmp/ou
 # → wrong: xmin=38.32 (lat) instead of -120.07 (lon)
 ```
 
+## ⛔ HARD BOUNDARY 3: Jobs run in `geo-workflows`, not `biodiversity`
+
+**Status (2026-07-05): MIGRATION IN PROGRESS** (geo-agent-ops#21). `geo-workflows`
+is provisioned as the least-privilege job-submission namespace; `biodiversity` keeps
+the fleet apps + MCP + LLM proxy (and its 26 app/LLM/private secrets). Existing
+`biodiversity` job manifests are **legacy artifacts** — reshape them by regenerating
+with `--namespace geo-workflows` (below). The hardcoded `-n biodiversity` and the
+"Namespace Pod Quota (`biodiversity`)" references elsewhere in this file are legacy;
+prefer `geo-workflows` for all new and re-run work.
+
+**Why.** `geo-workflows` holds ONLY NRP-canonical credentials (`aws` + `rclone-config`).
+A confused or compromised job there can damage only *recoverable* NRP-canonical data —
+it cannot reach the app / LLM / oauth / private-data secrets that live in
+`biodiversity`. That confinement is the whole point; **never reintroduce other
+credentials into `geo-workflows`.**
+
+**How to target it — the CLI already supports it, just pass the flag:**
+```bash
+cng-datasets workflow        --namespace geo-workflows  ...   # all other args unchanged
+cng-datasets raster-workflow --namespace geo-workflows  ...
+```
+It stamps the namespace on every generated manifest (and, for armada, the queue).
+Apply and monitor with `-n geo-workflows`:
+```bash
+kubectl apply -n geo-workflows -f catalog/<dataset>/k8s/<name>/workflow-rbac.yaml   # once
+kubectl apply -n geo-workflows -f .../configmap.yaml -f .../workflow.yaml
+kubectl -n geo-workflows get jobs | grep <name>
+```
+
+**What's already provisioned there** (manifest: geo-agent-ops `k8s/geo-workflows-provisioning.yaml`):
+- Secrets `aws` (NRP S3) + `rclone-config` (nrp-only). **Nothing else.**
+- Orchestrator SAs `cng-datasets-workflow` / `workflow-runner` (create/watch/delete child Jobs).
+- Child job pods run as the `default` SA, **hardened to mount no k8s token** (they need only S3).
+- `rechunk-scratch` PVC (2Ti RWX) for >50Gi scratch (binds once Ceph is healthy).
+- **No enforced ResourceQuota** — but keep the good-practice targets anyway:
+  **≤200 simultaneous pods** and **≤50Gi ephemeral per job** (`limits.ephemeral-storage`),
+  especially on large-completion fan-out jobs. Oversubscribing is antisocial on shared nodes.
+
+**Credential rule — three data classes (the redistribution axis is NOT the credential axis):**
+- **Classes 1 & 2 — public-bucket data.** Includes the *non-redistributable* sets
+  (WDPA / WD-OECM, IUCN, ICCA, HydroBASINS): those are ordinary `public-*` buckets on
+  NRP + MinIO backup, merely **excluded from the source.coop mirror** (a mirror-scope
+  policy, not a credential boundary). Their build jobs **read/write NRP only.** Stage raw
+  under `s3://<bucket>/raw/` (Step 1b); **never** write intermediates to MinIO with a
+  personal key; reading public data needs **no** credential. No MinIO cred in `geo-workflows`.
+- **Class 3 — strictly private data** (`private-wyoming`, `private-tpl`): single-homed on
+  MinIO, **not on any NRP bucket**. Mount a **scoped, single-bucket, on-demand EXPIRING
+  MinIO mint** for that one bucket (`mc admin user svcacct add <parent> --policy <one-bucket>
+  --expiry …`; the `wyoming-publish` model) — **never** a standing broad MinIO key.
+
 ## What You Produce
 
 **Vector datasets (GDB, Shapefile, GeoPackage, GeoParquet):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,49 @@ kubectl -n geo-workflows get jobs | grep <name>
   MinIO mint** for that one bucket (`mc admin user svcacct add <parent> --policy <one-bucket>
   --expiry …`; the `wyoming-publish` model) — **never** a standing broad MinIO key.
 
+### Backups & recovery live in a SEPARATE namespace (why workflow `rclone-config` is nrp-only)
+
+The namespace split is a two-sided security boundary: **workflow/build jobs** run in
+`geo-workflows` (NRP-canonical creds only); **backup/mirror jobs** run in a *different*
+namespace the workflow agent has no membership in, so a confused or compromised build job
+**cannot reach the backup credentials** and therefore cannot propagate a delete/corruption
+into the backups (recovery, not just prevention). Concretely (geo-agent-ops
+`DATA_WORKFLOWS_HARDENING.md`, plan step 3):
+
+- **Secret split.** The `nrp:` remote (internal Ceph RGW) lives in `rclone-config` inside the
+  workflow namespaces (`geo-workflows`, `biodiversity`). The MinIO + source.coop remotes live
+  in a **separate `rclone-backup` secret** that exists **only in `boettiger-lab`** (the
+  Carl-only namespace serving as the interim `backup` ns; a dedicated `backup` ns is planned).
+  **So a workflow-namespace `rclone-config` that contains only `[nrp]` is CORRECT and
+  intentional — not a missing-remote bug.** (Verified 2026-07-12 during #392: `rclone-config`
+  in both `geo-workflows` and `biodiversity` holds `[nrp]` only, internal endpoint
+  `http://rook-ceph-rgw-nautiluss3.rook`, `upload_concurrency=16`, `chunk_size=64Mi`.)
+- **Backup jobs run in `boettiger-lab`.** All ~81 `sync-*` / `source-sync-*` Jobs & CronJobs
+  (`catalog/sync/k8s/**`, Steps 7/7b) declare `namespace: boettiger-lab` and mount
+  `rclone-backup`. **Do not** move a backup job into `geo-workflows`/`biodiversity`, and
+  **never** add a MinIO/source.coop remote or the `rclone-backup` secret to a workflow
+  namespace — that would re-open the boundary this split exists to close.
+- **Data-workflow agents never hold backup creds.** You submit *builds* (NRP) and, for
+  class-3 private inputs, a scoped **expiring** per-bucket MinIO mint (above). You do **not**
+  run the mirror jobs by hand from a build namespace; the backup CronJobs in `boettiger-lab`
+  own that.
+
+**MinIO is NOT "just a backup" — it plays three roles**, and treating it as only-a-backup is a
+recurring, dangerous mistake:
+1. **Canonical / SOLE home for PRIVATE, non-redistributable data** (`private-wyoming`,
+   `private-tpl`, …) — this data lives **nowhere else** (not on NRP, not on source.coop).
+   Losing MinIO loses it. Reading such inputs from MinIO with a *scoped* key is normal.
+2. **Immutable vault / system-of-record backup** for the *public* buckets.
+3. **The fine-grained-IAM tier** (users, per-bucket policies, service-accounts, STS/expiry) —
+   **NRP has none of this** (one omnipotent key, no self-service scoping). This is *why* private
+   data is homed on MinIO and *why* every credential-scoping move targets MinIO.
+
+**Two failure domains.** NRP canonical Ceph S3 and the on-cluster `rustfs` copy share the **same
+rook Ceph cluster** — only **office MinIO** is an independent domain. So MinIO is the true
+off-domain wall (immutable/object-lock); rustfs is a fast hot-restore + cross-domain 2nd copy,
+not an immutability guarantee. Treat **NRP canonical as corruptible** and recoverable from the
+MinIO vault — which is the whole reason the agent is confined to the NRP-only namespace.
+
 ## What You Produce
 
 **Vector datasets (GDB, Shapefile, GeoPackage, GeoParquet):**


### PR DESCRIPTION
**READY — gate met (2026-07-12).** All merge preconditions are now green:
- ☑ RBAC/SA/secret provisioning applied (geo-agent-ops `k8s/geo-workflows-provisioning.yaml`, 2026-07-05).
- ☑ `rechunk-scratch` PVC auto-bound + `geo-workflows` plumbing proof GREEN (2026-07-06, Ceph restored): a real pipeline-image Job ran on the token-less SA and exercised both NRP creds.
- ☑ **One REAL dataset verifies end-to-end in `geo-workflows`** — CDFW Fish Passage Assessment DB (PR #398, `catalog/cdfw/k8s/fish-passage-pad/workflow.yaml` → `namespace: geo-workflows`). Full orchestrator→child DAG produced `public-cdfw/fish-passage-pad{.parquet,.pmtiles,/hex/,/stac-collection.json}`; `scripts/verify-stac.py --bucket public-cdfw --dataset fish-passage-pad` → **0 hard findings**.

The guide no longer points agents at an unverified namespace. Merges cleanly onto `main` (verified: no textual conflicts).

## What this adds
A durable "HARD BOUNDARY 3" section to `AGENTS.md` for the biodiversity → `geo-workflows` job-migration (geo-agent-ops#21):

- **Target `geo-workflows`, not `biodiversity`**, for all new/re-run work — generate with `cng-datasets ... --namespace geo-workflows` (the CLI already exposes the flag; no tool change). Legacy `biodiversity` manifests are reshaped by regenerating with the flag.
- **Why:** `geo-workflows` holds only NRP-canonical creds (`aws` + `rclone-config`), so a rogue/dumb job there can only damage recoverable NRP-canonical data — never the app/LLM/oauth/private-data secrets in `biodiversity`.
- **What's provisioned:** orchestrator SAs, token-less child pods (`default` SA automount off), `rechunk-scratch` PVC; **no enforced quota** but keep the ≤200-pod / ≤50Gi-ephemeral good-practice targets.
- **3-class credential rule** (the source.coop-redistribution axis is *not* the credential axis): classes 1 & 2 (public buckets, incl. non-redistributable WDPA/IUCN excluded only from source.coop) read/write NRP only — no MinIO cred; class 3 (`private-*`, single-homed on MinIO) uses a scoped, single-bucket, on-demand **expiring** MinIO mint.

Plan + rationale: geo-agent-ops `DATA_WORKFLOWS_HARDENING.md` (§ "Step-5 job-migration plan") and geo-agent-ops#43.
