### PR TITLE
fix(#345): rebuild plant-richness & endemic-plant p80-hex hotspots from area-weighted mean (not MAX)

### DIFF
--- a/catalog/plant-richness/gen-jobs.sh
+++ b/catalog/plant-richness/gen-jobs.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 # Generate the cluster job YAMLs for the CBN plant-richness family (issue #229).
 #
-# Two Kling et al. (2018) CBN rasters, each processed 3 ways from ONE WGS84
+# Two Kling et al. (2018) CBN rasters, each processed from ONE WGS84
 # reprojection of the EPSG:3310 source:
 #   1. full continuous COG  + hex-max  (reducer=max  — peak richness per cell)
 #   2. (same COG)           + hex-mean (reducer=mean — area-weighted mean per cell)
-#   3. 80th-percentile hotspot COG (pixels >= P80) + p80-hex (reducer=max)
+#   3. 80th-percentile hotspot: p80-cog (raster pixel mask, pixels >= P80) AND
+#      p80-hex = the cells whose area-weighted MEAN (hex-mean) is >= the
+#      reproducible P80-by-area threshold (quantile_cont(value, 0.8) over the
+#      hex-mean cell distribution), derived by a DuckDB threshold of hex-mean.
+#
+# NOTE (issue #345): p80-hex was ORIGINALLY built by hexing p80-cog with
+# reducer=max, which flagged any cell touching a single >=P80 pixel and
+# overstated the top-20%-by-area footprint ~30% (26.6M vs ~19.3M ac), dragging
+# down the ca-30x30 "% protected" answer (validated vs the TNC 2025 Biodiversity
+# Assessment). It is now derived from hex-mean (Option 1); p80-cog is retained
+# as the standalone raster hotspot artifact but is no longer p80-hex's input.
 #
 # Per dataset the build order is: cog -> hex-max -> hex-mean -> p80-cog -> p80-hex.
 # Hex jobs read the WGS84 COG (so hex MAX validates exactly against the COG).
@@ -137,13 +147,91 @@ ${VOL_AFFINITY}
 EOF
 }
 
+# ---- single-pod DuckDB job: corrected p80-hex derived from hex-mean (#345) --
+# The true top-20%-by-area hotspot = cells whose area-weighted MEAN (hex-mean)
+# is >= the reproducible P80-by-area threshold (quantile_cont(value,0.8) over the
+# hex-mean cell distribution). Builds to a p80-hex-staging/ prefix, asserts the
+# staged count is ~20% of the covered cells (guards a partial write from ever
+# triggering the destructive flip), then swaps staging -> p80-hex.
+# args: $1 dataset-segment  $2 value-column -> stdout
+duckdb_p80_job() {
+  local ds=$1 val=$2
+  cat <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${ds}-p80-hex
+  labels: {k8s-app: ${ds}-p80-hex}
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: ${ds}-p80-hex}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: p80-hex
+        image: ${IMAGE}
+        imagePullPolicy: Always
+${ENV_BLOCK}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "=== #345 corrected p80-hex for ${ds}: threshold hex-mean at P80-by-area ==="
+          python3 - <<'PYEOF'
+          import duckdb, os
+          SRC = 's3://${BUCKET}/${ds}/hex-mean/h0=*/data_0.parquet'
+          STAGING = 's3://${BUCKET}/${ds}/p80-hex-staging/'
+          VAL = '${val}'
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', "
+              "ENDPOINT '{}', URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ.get('AWS_S3_ENDPOINT', 'rook-ceph-rgw-nautiluss3.rook')))
+          total = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}', hive_partitioning=false)".format(SRC)
+          ).fetchone()[0]
+          # reproducible P80-by-area threshold on the area-weighted mean surface (#345)
+          p80 = con.execute(
+              "SELECT quantile_cont({}, 0.8) FROM read_parquet('{}', hive_partitioning=false)".format(VAL, SRC)
+          ).fetchone()[0]
+          print('TOTAL_CELLS={}  P80_THRESHOLD({})={!r}'.format(total, VAL, p80))
+          con.execute(
+              "COPY (SELECT {v}, h8, h0 FROM read_parquet('{s}', hive_partitioning=false) "
+              "WHERE {v} >= {p}) TO '{o}' "
+              "(FORMAT PARQUET, COMPRESSION ZSTD, PARTITION_BY (h0), OVERWRITE_OR_IGNORE)".format(v=VAL, s=SRC, p=p80, o=STAGING))
+          hot = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}**/*.parquet', hive_partitioning=false)".format(STAGING)
+          ).fetchone()[0]
+          exp = round(0.2 * total)
+          print('HOTSPOT_CELLS={}  EXPECTED_TOP20%~={}'.format(hot, exp))
+          assert abs(hot - exp) <= 0.01 * total, 'staged count off from expected top-20%'
+          open('/tmp/ok', 'w').write('ok')
+          PYEOF
+          test -f /tmp/ok || { echo 'staging validation failed; NOT flipping'; exit 1; }
+          echo 'staging validated; flipping p80-hex-staging -> p80-hex'
+          rclone delete nrp:${BUCKET}/${ds}/p80-hex/
+          rclone move  nrp:${BUCKET}/${ds}/p80-hex-staging/ nrp:${BUCKET}/${ds}/p80-hex/
+          echo '=== #345 p80-hex rebuild complete ==='
+        resources:
+          requests: {cpu: '2', memory: 16Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '2', memory: 16Gi, ephemeral-storage: 10Gi}
+${VOL_AFFINITY}
+EOF
+}
+
 for entry in "${DATASETS[@]}"; do
   IFS='|' read -r DS SRC VAL <<<"$entry"
   DIR="$DS"; mkdir -p "$DIR"
   PFX="s3://${BUCKET}/${DS}"
   RAW="${PFX}/raw/${SRC}"
   COG="${PFX}/${DS}-cog.tif"
-  P80COG="${PFX}/${DS}-p80-cog.tif"
 
   # 1. full continuous WGS84 COG (reproject) + fill normalization.
   #    The 3310->4326 warp emits a SECOND near-nodata value (~-3.3999997e38)
@@ -223,12 +311,10 @@ rclone copyto /tmp/p80-value.txt nrp:${BUCKET}/${DS}/p80-value.txt
 echo 'P80 build done'" \
     > "${DIR}/${DS}-p80-cog.yaml"
 
-  # 5. p80-hex (peak richness per cell, hotspot footprint only)
-  hex_job "${DS}-p80-hex" \
-"set -e
-cng-datasets raster --input \"${P80COG}\" --output-parquet ${PFX}/p80-hex/ \\
-  --h0-index \${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \\
-  --value-column ${VAL} --hex-resampling max --nodata -3.4e38" \
+  # 5. p80-hex (#345): the true top-20%-by-area hotspot = cells whose
+  #    area-weighted MEAN (hex-mean) >= the reproducible P80-by-area threshold.
+  #    Derived from hex-mean via DuckDB (NOT hexing p80-cog with max).
+  duckdb_p80_job "${DS}" "${VAL}" \
     > "${DIR}/${DS}-p80-hex.yaml"
 
   echo "generated ${DIR}/ ($(ls "${DIR}"/*.yaml | wc -l) job yamls)"

--- a/catalog/plant-richness/k8s/plant-richness/plant-richness-p80-hex.yaml
+++ b/catalog/plant-richness/k8s/plant-richness/plant-richness-p80-hex.yaml
@@ -4,16 +4,7 @@ metadata:
   name: plant-richness-p80-hex
   labels: {k8s-app: plant-richness-p80-hex}
 spec:
-  completions: 122
-  parallelism: 61
-  completionMode: Indexed
-  backoffLimitPerIndex: 2
-  maxFailedIndexes: 0
-  podFailurePolicy:
-    rules:
-    - action: Ignore
-      onPodConditions:
-      - {type: DisruptionTarget}
+  backoffLimit: 1
   ttlSecondsAfterFinished: 10800
   template:
     metadata:
@@ -21,7 +12,7 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: hex-task
+      - name: p80-hex
         image: ghcr.io/boettiger-lab/datasets:latest
         imagePullPolicy: Always
         env:
@@ -39,13 +30,49 @@ spec:
         - bash
         - -c
         - |
-            set -e
-            cng-datasets raster --input "s3://public-ca30x30/plant-richness/plant-richness-p80-cog.tif" --output-parquet s3://public-ca30x30/plant-richness/p80-hex/ \
-              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
-              --value-column richness --hex-resampling max --nodata -3.4e38
+          set -e
+          echo "=== #345 corrected p80-hex for plant-richness: threshold hex-mean at P80-by-area ==="
+          python3 - <<'PYEOF'
+          import duckdb, os
+          SRC = 's3://public-ca30x30/plant-richness/hex-mean/h0=*/data_0.parquet'
+          STAGING = 's3://public-ca30x30/plant-richness/p80-hex-staging/'
+          VAL = 'richness'
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', "
+              "ENDPOINT '{}', URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ.get('AWS_S3_ENDPOINT', 'rook-ceph-rgw-nautiluss3.rook')))
+          total = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}', hive_partitioning=false)".format(SRC)
+          ).fetchone()[0]
+          # reproducible P80-by-area threshold on the area-weighted mean surface (#345)
+          p80 = con.execute(
+              "SELECT quantile_cont({}, 0.8) FROM read_parquet('{}', hive_partitioning=false)".format(VAL, SRC)
+          ).fetchone()[0]
+          print('TOTAL_CELLS={}  P80_THRESHOLD({})={!r}'.format(total, VAL, p80))
+          con.execute(
+              "COPY (SELECT {v}, h8, h0 FROM read_parquet('{s}', hive_partitioning=false) "
+              "WHERE {v} >= {p}) TO '{o}' "
+              "(FORMAT PARQUET, COMPRESSION ZSTD, PARTITION_BY (h0), OVERWRITE_OR_IGNORE)".format(v=VAL, s=SRC, p=p80, o=STAGING))
+          hot = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}**/*.parquet', hive_partitioning=false)".format(STAGING)
+          ).fetchone()[0]
+          exp = round(0.2 * total)
+          print('HOTSPOT_CELLS={}  EXPECTED_TOP20%~={}'.format(hot, exp))
+          assert abs(hot - exp) <= 0.01 * total, 'staged count off from expected top-20%'
+          open('/tmp/ok', 'w').write('ok')
+          PYEOF
+          test -f /tmp/ok || { echo 'staging validation failed; NOT flipping'; exit 1; }
+          echo 'staging validated; flipping p80-hex-staging -> p80-hex'
+          rclone delete nrp:public-ca30x30/plant-richness/p80-hex/
+          rclone move  nrp:public-ca30x30/plant-richness/p80-hex-staging/ nrp:public-ca30x30/plant-richness/p80-hex/
+          echo '=== #345 p80-hex rebuild complete ==='
         resources:
-          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
-          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          requests: {cpu: '2', memory: 16Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '2', memory: 16Gi, ephemeral-storage: 10Gi}
         volumeMounts:
         - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
       volumes:

--- a/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-hex.yaml
+++ b/catalog/plant-richness/k8s/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-hex.yaml
@@ -4,16 +4,7 @@ metadata:
   name: rarity-weighted-endemic-plant-richness-p80-hex
   labels: {k8s-app: rarity-weighted-endemic-plant-richness-p80-hex}
 spec:
-  completions: 122
-  parallelism: 61
-  completionMode: Indexed
-  backoffLimitPerIndex: 2
-  maxFailedIndexes: 0
-  podFailurePolicy:
-    rules:
-    - action: Ignore
-      onPodConditions:
-      - {type: DisruptionTarget}
+  backoffLimit: 1
   ttlSecondsAfterFinished: 10800
   template:
     metadata:
@@ -21,7 +12,7 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: hex-task
+      - name: p80-hex
         image: ghcr.io/boettiger-lab/datasets:latest
         imagePullPolicy: Always
         env:
@@ -39,13 +30,49 @@ spec:
         - bash
         - -c
         - |
-            set -e
-            cng-datasets raster --input "s3://public-ca30x30/rarity-weighted-endemic-plant-richness/rarity-weighted-endemic-plant-richness-p80-cog.tif" --output-parquet s3://public-ca30x30/rarity-weighted-endemic-plant-richness/p80-hex/ \
-              --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 \
-              --value-column rwe --hex-resampling max --nodata -3.4e38
+          set -e
+          echo "=== #345 corrected p80-hex for rarity-weighted-endemic-plant-richness: threshold hex-mean at P80-by-area ==="
+          python3 - <<'PYEOF'
+          import duckdb, os
+          SRC = 's3://public-ca30x30/rarity-weighted-endemic-plant-richness/hex-mean/h0=*/data_0.parquet'
+          STAGING = 's3://public-ca30x30/rarity-weighted-endemic-plant-richness/p80-hex-staging/'
+          VAL = 'rwe'
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', "
+              "ENDPOINT '{}', URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ.get('AWS_S3_ENDPOINT', 'rook-ceph-rgw-nautiluss3.rook')))
+          total = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}', hive_partitioning=false)".format(SRC)
+          ).fetchone()[0]
+          # reproducible P80-by-area threshold on the area-weighted mean surface (#345)
+          p80 = con.execute(
+              "SELECT quantile_cont({}, 0.8) FROM read_parquet('{}', hive_partitioning=false)".format(VAL, SRC)
+          ).fetchone()[0]
+          print('TOTAL_CELLS={}  P80_THRESHOLD({})={!r}'.format(total, VAL, p80))
+          con.execute(
+              "COPY (SELECT {v}, h8, h0 FROM read_parquet('{s}', hive_partitioning=false) "
+              "WHERE {v} >= {p}) TO '{o}' "
+              "(FORMAT PARQUET, COMPRESSION ZSTD, PARTITION_BY (h0), OVERWRITE_OR_IGNORE)".format(v=VAL, s=SRC, p=p80, o=STAGING))
+          hot = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}**/*.parquet', hive_partitioning=false)".format(STAGING)
+          ).fetchone()[0]
+          exp = round(0.2 * total)
+          print('HOTSPOT_CELLS={}  EXPECTED_TOP20%~={}'.format(hot, exp))
+          assert abs(hot - exp) <= 0.01 * total, 'staged count off from expected top-20%'
+          open('/tmp/ok', 'w').write('ok')
+          PYEOF
+          test -f /tmp/ok || { echo 'staging validation failed; NOT flipping'; exit 1; }
+          echo 'staging validated; flipping p80-hex-staging -> p80-hex'
+          rclone delete nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/p80-hex/
+          rclone move  nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/p80-hex-staging/ nrp:public-ca30x30/rarity-weighted-endemic-plant-richness/p80-hex/
+          echo '=== #345 p80-hex rebuild complete ==='
         resources:
-          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
-          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          requests: {cpu: '2', memory: 16Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '2', memory: 16Gi, ephemeral-storage: 10Gi}
         volumeMounts:
         - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
       volumes:

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -337,11 +337,13 @@ def check_hex_assets(doc: dict) -> list[Finding]:
         if not (is_parquet(asset) and is_hex_asset(key, asset)):
             continue
         href = asset.get("href", "")
-        # hive glob, not a bare directory
-        if not re.search(r"/hex/h0=\*/[^/]+\.parquet$", href):
+        # hive glob, not a bare directory. Any partition-dir name is valid
+        # (hex, hex-max, hex-mean, p80-hex, …) — the requirement is the
+        # h0=* partition glob + a filename, which is what rejects a bare dir.
+        if not re.search(r"/h0=\*/[^/]+\.parquet$", href):
             out.append(Finding(HARD, "hex-href-not-glob",
                                 f"asset '{key}' hex href must be the hive glob "
-                                f"…/hex/h0=*/data_0.parquet, got {href!r}."))
+                                f"…/h0=*/data_0.parquet (not a bare directory), got {href!r}."))
         # h3 resolutions declared
         native = asset.get("h3:native_resolution")
         parents = asset.get("h3:parent_resolutions")


### PR DESCRIPTION
Closes #345.

## Problem
The `p80-hex` "top-20% hotspot" asset (both `plant-richness` and `rarity-weighted-endemic-plant-richness`) was built by hexing a P80 pixel-mask COG with **reducer `max`**, so a res-8 cell was flagged if its *single peak pixel* ≥ P80. This overstated the top-20%-by-area footprint ~30% and dragged the ca-30x30 "% protected" answer below the TNC 2025 Biodiversity Assessment ground truth.

## Fix (issue Option 1)
Derive `p80-hex` as the cells whose **area-weighted mean** (`hex-mean`) ≥ the **reproducible P80-by-area threshold** (`quantile_cont(value, 0.8)` over the res-8 cell distribution). `gen-jobs.sh` step 5 now emits a single-pod DuckDB job that builds to a `p80-hex-staging/` prefix, asserts the staged count is ~20% of covered cells (guards a partial write from triggering the destructive flip), then swaps staging → `p80-hex`.

## Result — verified on live S3 (MCP)
| | plant-richness | endp |
|---|---|---|
| threshold (`quantile_cont(·,0.8)`) | 315.039 | 0.003869 |
| hotspot cells | 145,903 → **105,738** | ~135,900 → **105,738** |
| hotspot area | 26.58M → **19.26M ac** | 24.76M → **19.26M ac** |
| overlay Disc% (GAP1+2, identical method old vs new) | 34.35% → **40.49%** | 30.2% → **32.7%** |

plant-richness matches the assessment target (area ≈20.47M ac GT; Disc ≈40.6%) to method precision. Old-hotspot reconstruction (`hex-max ≥ 317.72` → 145,905 cells) reproduces the issue's ~145,903 exactly, confirming the overlay method is faithful.

## STAC
`p80-hex` asset re-documented on both collections (already published to S3): new definition, the documented threshold (`cng:hotspot_threshold`), and a note that its value column is now the **area-weighted mean** (not the peak). Full data-backed `scripts/verify-stac.py --bucket public-ca30x30 --dataset …` passes (0 hard) for both.

## Verifier fix (bundled)
`verify-stac.py`'s `hex-href-not-glob` required a literal `/hex/` path segment, HARD-flagging valid variant globs (`/p80-hex/…`) while inconsistently skipping `/hex-max/`, `/hex-mean/`. Relaxed to accept any `…/h0=*/<file>.parquet` hive glob, preserving the anti-bare-dir intent (bare dirs still rejected).

## Note
The `-cog`, `-p80-cog`, `hex-max`, `hex-mean` assets are unchanged; `p80-cog` is retained as the standalone raster hotspot artifact but is no longer `p80-hex`'s input.