### PR TITLE
source-coop: add 6 license-clear repos to mirror scope (27→33)

### DIFF
--- a/catalog/sync/k8s/source-sync-connectivity.yaml
+++ b/catalog/sync/k8s/source-sync-connectivity.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-connectivity
+  namespace: boettiger-lab
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-connectivity"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/connectivity"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: connectivity"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-cron-config.yaml
+++ b/catalog/sync/k8s/source-sync-cron-config.yaml
@@ -16,18 +16,22 @@ data:
     carbon sync 
     census sync 
     cgs sync 
+    connectivity sync 
     cpad sync 
     ecoregion sync 
     epa-water sync 
+    facts sync 
     fire sync 
     gbif sync 
     gfw sync 
+    hazard sync mid-century-habitat-climate-exposure/**
     high-seas sync mpa-candidates/**
     inat sync 
     indigenous sync 
     land-cover sync 
     mappinginequality sync 
     mobi copy 
+    nci-frontiers sync 
     ncp sync 
     overturemaps sync 
     padus sync 
@@ -37,4 +41,6 @@ data:
     social-vulnerability sync 
     trails sync 
     usfws sync 
+    usgs-nhd sync 
+    usgs-wbd sync 
     wetlands sync 

--- a/catalog/sync/k8s/source-sync-facts.yaml
+++ b/catalog/sync/k8s/source-sync-facts.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-facts
+  namespace: boettiger-lab
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-facts"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/facts"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: facts"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-hazard.yaml
+++ b/catalog/sync/k8s/source-sync-hazard.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-hazard
+  namespace: boettiger-lab
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-hazard"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/hazard"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS --exclude 'mid-century-habitat-climate-exposure/**' "$SRC" "$DEST"
+              echo "Done: hazard"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-nci-frontiers.yaml
+++ b/catalog/sync/k8s/source-sync-nci-frontiers.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-nci-frontiers
+  namespace: boettiger-lab
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-nci-frontiers"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/nci-frontiers"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: nci-frontiers"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-usgs-nhd.yaml
+++ b/catalog/sync/k8s/source-sync-usgs-nhd.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-usgs-nhd
+  namespace: boettiger-lab
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-usgs-nhd"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/usgs-nhd"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: usgs-nhd"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-backup

--- a/catalog/sync/k8s/source-sync-usgs-wbd.yaml
+++ b/catalog/sync/k8s/source-sync-usgs-wbd.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: source-sync-usgs-wbd
+  namespace: boettiger-lab
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: sync
+          image: ghcr.io/boettiger-lab/datasets:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+          command: [bash, -c]
+          args:
+            - |
+              set -euo pipefail
+              SRC="nrp:public-usgs-wbd"
+              DEST="source:us-west-2.opendata.source.coop/cboettig/usgs-wbd"
+              # Safety: the source.coop remote has account-wide access to a SHARED
+              # bucket. Refuse to sync unless DEST is the intended cboettig sub-path.
+              case "$DEST" in
+                "source:us-west-2.opendata.source.coop/cboettig/"?*) : ;;
+                *) echo "REFUSING: dest '$DEST' is not a cboettig/<repo> sub-path" >&2; exit 1 ;;
+              esac
+              # --max-delete 150: circuit-breaker — abort if a run would delete
+              # more than 150 objects at the dest (stops a propagated wipe from an
+              # emptied/corrupted source). 150 covers overturemaps' ~122 H0
+              # partitions + assets; tune per hardening plan (geo-agent-ops#21).
+              RCLONE_FLAGS="--transfers 2 --checkers 4 --bwlimit 50M --tpslimit 5 --retries 5 --max-delete 150 --stats 120s -v"
+              # DRYRUN=true (env) lists changes without writing. Default: real sync.
+              if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
+              echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
+              rclone sync $RCLONE_FLAGS "$SRC" "$DEST"
+              echo "Done: usgs-wbd"
+      volumes:
+        - name: rclone-config
+          secret:
+            secretName: rclone-backup

--- a/catalog/sync/source-coop/gen-source-sync.sh
+++ b/catalog/sync/source-coop/gen-source-sync.sh
@@ -45,10 +45,10 @@ DEST_BUCKET="us-west-2.opendata.source.coop"
 
 # Catalogued, license-clear repos (== NRP public-<repo>).
 REPOS=(
-  ca-dac calenviroscreen carbon census cgs cpad ecoregion epa-water
-  fire gbif gfw high-seas inat indigenous land-cover mappinginequality mobi ncp
-  overturemaps padus population rap rivers social-vulnerability trails usfws
-  wetlands
+  ca-dac calenviroscreen carbon census cgs connectivity cpad ecoregion epa-water
+  facts fire gbif gfw hazard high-seas inat indigenous land-cover mappinginequality
+  mobi nci-frontiers ncp overturemaps padus population rap rivers
+  social-vulnerability trails usfws usgs-nhd usgs-wbd wetlands
 )
 
 # Per-repo sub-path excludes (HOLD: license unconfirmed for these collections).
@@ -56,6 +56,13 @@ REPOS=(
 declare -A EXCLUDES=(
   [rivers]="american-rivers/campaigns/** american-rivers/ira-watersheds/** american-rivers/roo-cjest/**"
   [high-seas]="mpa-candidates/**"
+  # hazard: flood-hazard (FEMA) + sea-level-rise (NOAA) are public-domain and mirror.
+  # mid-century-habitat-climate-exposure (Thorne et al. 2016, CDFW-commissioned) is NOT a
+  # Dryad/Zenodo deposit and its STAC states redistribution terms "are not explicitly
+  # published with the source and require confirmation" (license: other). BIOS-general is
+  # CC-BY, but this dataset ships no explicit license — HOLD (don't assert one) until CDFW/
+  # Thorne terms are confirmed, then set its STAC license + drop this exclude.
+  [hazard]="mid-century-habitat-climate-exposure/**"
 )
 
 # Per-repo rclone verb. Default "sync" (mirror-with-delete: dest becomes an exact

--- a/catalog/sync/source-coop/license-inventory.md
+++ b/catalog/sync/source-coop/license-inventory.md
@@ -205,4 +205,31 @@ Full recursive STAC walk (130 nodes). Verdict per collection:
 - **OK** · `WGFD open-data (other)` — public-wyoming/wgfd-pronghorn-crucial  · WGFD public ArcGIS Open Data; attribution+disclaimer (confirm)
 - **OK** · `WGFD open-data (other)` — public-wyoming/wgfd-pronghorn-seasonal  · WGFD public ArcGIS Open Data; attribution+disclaimer (confirm)
 - **OK** · `public-domain` — public-wyoming/wy-counties  
-- **OK** · `public-domain` — public-wyoming/wyoming-places  
+- **OK** · `public-domain` — public-wyoming/wyoming-places
+
+## Additions 2026-07 (batch: usgs-nhd, usgs-wbd, facts, nci-frontiers, connectivity, hazard)
+
+## public-usgs-nhd
+- **OK** · `public-domain` — public-usgs-nhd/streams-by-order  · USGS National Hydrography Dataset; US federal work (PD).
+- **OK** · `public-domain` — public-usgs-nhd/perennial-streams  · USGS NHD; US federal work (PD).
+
+## public-usgs-wbd
+- **OK** · `public-domain` — public-usgs-wbd/wbd/hu2 · hu4 · hu6 · hu8 · hu10 · hu12  · USGS Watershed Boundary Dataset (all HU levels); US federal work (PD).
+
+## public-facts
+- **OK** · `public-domain` — public-facts/common-attributes-2026-06  · USFS FACTS Common Attributes; US federal work (PD).
+
+## public-nci-frontiers
+- **OK** · `CC0-1.0` — public-nci-frontiers  · Polasky et al. (2026, Science) / Natural Capital Project; CC0 (STAC declares CC0 + CC0 link; confirm against the paper's data deposit on first mirror).
+
+## public-connectivity
+- **OK** · `CC-BY-4.0` — public-connectivity/regional-connectivity-linkages  · South Coast Missing Linkages (Beier et al. 2006) via CDFW BIOS ds419; CC-BY.
+- **OK** · `CC0-1.0` — public-connectivity/climate-migration-routes  · Schloss et al. 2022; CC0.
+- **OK** · `CC0-1.0` — public-connectivity/present-day-connectivity/flow  · Cameron/Schloss/Theobald/Morrison 2022; CC0.
+- **OK** · `CC0-1.0` — public-connectivity/present-day-connectivity/categories  · same; CC0.
+- **OK** · `CC-BY-4.0` — public-connectivity/wildlife-movement-barriers  · CDFW BIOS ds2867; CC-BY.
+
+## public-hazard
+- **OK** · `public-domain` — public-hazard/flood-hazard  · FEMA National Flood Hazard Layer; US federal work (PD).
+- **OK** · `public-domain` — public-hazard/sea-level-rise  · NOAA Office for Coastal Management; US federal work (PD).
+- **HOLD** · `other` — public-hazard/mid-century-habitat-climate-exposure  · Thorne et al. (2016), CDFW-commissioned (SWAP 2015). NOT a Dryad/Zenodo deposit; STAC states redistribution terms "are not explicitly published with the source and require confirmation." BIOS-general is CC-BY and this is not a CNDDB/spotted-owl carve-out, so likely includable — but source ships no explicit license, so do NOT assert one. **Excluded from the `hazard` mirror** until CDFW/Thorne terms are confirmed.  

--- a/catalog/sync/source-coop/new-repos.md
+++ b/catalog/sync/source-coop/new-repos.md
@@ -1,7 +1,18 @@
 # source.coop repos (account: cboettig)
 
-**Scope: 27 repos** (all created in the web UI as of 2026-06-17). Create with **visibility: public**.
+**Scope: 33 repos** (27 created 2026-06-17; **6 new below still to create**). Create with **visibility: public**.
 ⚠️ = non-commercial (label NC). See `license-inventory.md` + `README.md`.
+
+## 🆕 To create in the web UI (6 new, 2026-07)
+
+All catalogued + license-verified (see `license-inventory.md`). Create `cboettig/<repo>`, visibility public, then `kubectl apply -f catalog/sync/k8s/source-sync-cron-config.yaml` so the weekly cron picks them up (do NOT apply before the repos exist — the sync fails on a missing dest).
+
+- `usgs-nhd` (public-domain — USGS National Hydrography)
+- `usgs-wbd` (public-domain — USGS Watershed Boundary Dataset)
+- `facts` (public-domain — USFS FACTS Common Attributes)
+- `nci-frontiers` (CC0-1.0 — Polasky et al. 2026 / Natural Capital Project)
+- `connectivity` (CC-BY-4.0 + CC0 — CDFW BIOS ds419/ds2867 + Schloss/Cameron et al.)
+- `hazard` (public-domain — FEMA flood + NOAA SLR; `mid-century-habitat-climate-exposure/**` **excluded**, terms unconfirmed)
 
 > Note: `public-wyoming` is intentionally NOT mirrored — a Wyoming-clipped collection whose datasets now live in full-extent buckets; kept on NRP, migration tracked in #225.
 


### PR DESCRIPTION
Extends the source.coop mirror campaign (#158) with 6 catalogued, license-verified buckets. Prompted by the backup reconciliation — these are publicly-licensed datasets added since the last scope pass that weren't yet whitelisted.

## Added to scope (all catalogued + license-clear)
| repo | license | source |
|---|---|---|
| `usgs-nhd` | public-domain | USGS National Hydrography |
| `usgs-wbd` | public-domain | USGS Watershed Boundary Dataset (hu2–hu12) |
| `facts` | public-domain | USFS FACTS Common Attributes |
| `nci-frontiers` | CC0-1.0 | Polasky et al. 2026 (Science) / NatCap |
| `connectivity` | CC-BY-4.0 + CC0 | CDFW BIOS ds419/ds2867 + Schloss/Cameron et al. |
| `hazard` | public-domain | FEMA flood + NOAA SLR (**`mid-century-habitat-climate-exposure` excluded**) |

## Licensing notes (verified, not guessed)
- **State ≠ public-domain.** PD is a *federal* rule (17 USC §105); CA has no blanket PD. CDFW **BIOS** data is **CC-BY** (mirror-eligible with attribution), except **CNDDB / Spotted-Owl** (redistribution prohibited). Our BIOS layers (ds419/ds2867) are correctly CC-BY.
- **`hazard/mid-century-habitat-climate-exposure`** (Thorne et al. 2016, CDFW-commissioned) is **held/excluded**: not a Dryad/Zenodo deposit, and its STAC states redistribution terms "are not explicitly published with the source and require confirmation." Not asserting a license — excluded until CDFW/Thorne terms confirmed.

## Mechanics
- `gen-source-sync.sh` REPOS +6, `EXCLUDES[hazard]` set; regenerated the 6 per-repo jobs + `source-sync-scope` ConfigMap (27→33).
- Verdicts in `license-inventory.md`; create-list in `new-repos.md`.

## ⚠️ Manual step before this takes effect (API disabled)
Create the 6 repos in the source.coop web UI (`cboettig/<repo>`, visibility public), **then** `kubectl apply -f catalog/sync/k8s/source-sync-cron-config.yaml`. Do **not** apply the ConfigMap before the repos exist — the sync fails on a missing dest.

Refs #158.