### PR TITLE
hygiene(#325): rfb hex uses backoffLimitPerIndex, not backoffLimit:0

### DIFF
--- a/catalog/high-seas/k8s/rfmo/rfmo-rfb-hex.yaml
+++ b/catalog/high-seas/k8s/rfmo/rfmo-rfb-hex.yaml
@@ -8,7 +8,10 @@ spec:
   completions: 105
   parallelism: 50
   completionMode: Indexed
-  backoffLimit: 0
+  # #325: CCAMLR (index for a valid, mid-size polygon) dropped because backoffLimit:0
+  # never retried its transient chunk failure. Per-index retry fixes that.
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 10
   podFailurePolicy:
     rules:
     - action: Ignore


### PR DESCRIPTION
## Root cause
`rfmo/rfb` hex was missing **CCAMLR** (53 of 54 RFBs present). Diagnosed against live data: CCAMLR's polygon is **valid** and **smaller** than IWC/ACAP (49,773 deg², pole-to-pole) which hexed fine — so it wasn't size, geometry, or OOM. The job ran with **`backoffLimit: 0`**, so CCAMLR's transient per-index chunk failure was **never retried → permanently dropped**.

## Fix
`backoffLimit: 0` → **`backoffLimitPerIndex: 3` + `maxFailedIndexes: 10`** on the rfb hex job, so a transient index failure retries instead of dropping the feature.

## Reprocessing (in flight)
Re-ran the full 105-chunk hex → repartitioned to **`rfb/hex-staging`** (staging, per the AGENTS reprocessing pattern) → validating **54 distinct RFBs incl CCAMLR** → then flip to `rfb/hex`. (The staging redirect is a one-off operational step, not committed — the repo's repartition keeps targeting `rfb/hex`.)

Closes #325 (the CCAMLR half; the Overture dotted-path re-layout item in #325 is separate).