### PR TITLE
feat(#301): cwhr13 fractional-coverage hex (validated pilot)

### DIFF
--- a/catalog/cwhr/k8s/cwhr13/cwhr13-hex-fractions.yaml
+++ b/catalog/cwhr/k8s/cwhr13/cwhr13-hex-fractions.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cwhr13-hex-fractions
+  namespace: biodiversity
+  labels: {k8s-app: cwhr13-hex-fractions}
+spec:
+  completions: 2
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: cwhr13-hex-fractions}}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,  valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,    value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,          value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,          value: /usr/share/gdal}
+        - {name: PYTHONPATH,         value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS,    value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(50 71)   # res-0 ordinals covering California
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== CWHR13 (13-class) res-10 FRACTIONS hex (#301), h0-index $H0 ==="
+          cng-datasets raster \
+            --input "s3://public-ca30x30/cwhr13-cog.tif" \
+            --output-parquet s3://public-ca30x30/cwhr13/hex-fractions/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,7,6,5,0 \
+            --value-column whr13num --hex-resampling fractions --resampling near --nodata "0"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}


### PR DESCRIPTION
First dataset in the #301 batch — replaces the mode-biased per-class areas (ca-30x30#73) with the `fractions` reducer (datasets#143), **additively** (mode hex kept for map styling).

## What this adds
`catalog/cwhr/k8s/cwhr13/cwhr13-hex-fractions.yaml` — hexes the cwhr13 COG with `--hex-resampling fractions` to a new `cwhr13/hex-fractions/` path (long `(whr13num, frac, h5..h10, h0)` schema), leaving the existing `cwhr13/hex/` (mode) untouched.

## Built + validated + STAC published (verify-stac --bucket = 0 hard)
- Mass-conserving: `frac ∈ [0,1]`, per-cell `SUM(frac) ≤ 1`, 0 cells over 1.
- Per-class bias corrected vs mode in both directions (Conifer Forest 17.55→17.31 M-ac; Hardwood Forest 5.11→5.21; Wetland 0.78→0.85).
- Nodata explicit as `whr13num=0`.
- STAC (on S3, not in this PR per HARD BOUNDARY 1): added `cwhr13-hex-fractions` asset with area guidance `SUM(frac × cell_area) GROUP BY whr13num` (exclude 0); redirected the mode asset's biased `COUNT(DISTINCT h10)` guidance; added `0=Nodata` to the COG classes.

## Batch finding (see #301)
The fractions reducer surfaces `--nodata` as an explicit class (0 here) rather than excluding it — each of the remaining 7 rebuilds must document + exclude its nodata code and add it to the COG classes. This validates the reducer on the focal cwhr13 data that datasets#143 asked us to confirm before broad reprocessing.

Refs #301, ca-30x30#73, datasets#143.