### PR TITLE
feat(#379): import CDFW SWAP 2015 companion spatial layers

### DIFF
--- a/catalog/cdfw/k8s/swap-2015/BUILD-NOTES.md
+++ b/catalog/cdfw/k8s/swap-2015/BUILD-NOTES.md
@@ -1,0 +1,29 @@
+# SWAP 2015 build notes (#379)
+
+Three CDFW State Wildlife Action Plan 2015 companion layers → `public-cdfw/swap-2015/`.
+
+## Result
+| Layer | ds# | Features | Notes |
+|---|---|---|---|
+| provinces | ds1900 | 7 | one multipolygon per province (FeatureServer explodes to 14 single-part) |
+| terrestrial-targets | ds1966 | 31 | Conservation Units + potential targets |
+| aquatic-targets | ds2733 | 16 | HUC hydrologic units + aquatic targets |
+
+Res 8, `parent-resolutions 0`, GeoParquet + PMTiles + hex. Validated: feature
+counts and `_cng_fid` round-trip flat→hex; CA bbox; verify-stac + pmtiles-fields
+lint pass (0 hard).
+
+## Decisions that differ from the vanilla `cng-datasets workflow` output
+1. **Download GeoJSON, not shapefile.** The ArcGIS Hub `format=shp` export
+   truncates DBF field names to 10 chars (`Conservation_Unit`→`Conservati`,
+   `Potential_Target`→`Potential_`, `SWAP_Province`→`SWAP_Provi`). `format=geojson`
+   (spatialRefId 4326) preserves full names. Convert curls the GeoJSON, stages it
+   to `raw/`, and converts the local file.
+2. **Quote the source URL.** The generated convert command left the `&`-bearing
+   Hub URL unquoted, so bash backgrounded curl and mis-parsed the rest. (Tool
+   YAML-gen bug — filed upstream, worked around here.)
+3. **Hex `completions: 1`.** `--chunk-size 1000` puts all ≤31 features in chunk 0,
+   so the other 199 indexed pods are empty no-ops that only serve to land on and
+   hang the flaky `hpc-nrp-g1` node. One completion is sufficient.
+
+Sibling reference build: `catalog/cdfw/k8s/ace/terrestrial-biodiversity-summary/`.

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+                "https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
                 s3://public-cdfw/swap-2015/aquatic-targets.parquet \
                 --row-group-size 100000
             resources:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
@@ -65,17 +65,13 @@ data:
             - -c
             - |
               set -euo pipefail
-              URL="https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
-              echo "Downloading SWAP aquatic-targets shapefile zip..."
-              curl -L --retry 5 -o /tmp/aquatic-targets.zip "$URL"
-              unzip -t /tmp/aquatic-targets.zip > /dev/null && echo "zip OK"
-              rclone copyto /tmp/aquatic-targets.zip nrp:public-cdfw/raw/swap-2015-aquatic-targets.zip -v
-              mkdir -p /tmp/aquatic-targets
-              unzip -q -o /tmp/aquatic-targets.zip -d /tmp/aquatic-targets
-              SHP=$(find /tmp/aquatic-targets -name "*.shp" | head -1)
-              echo "Converting shapefile: $SHP"
+              URL="https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
+              echo "Downloading SWAP aquatic-targets GeoJSON (full field names; shp truncates to 10 chars)..."
+              curl -L --retry 5 -o /tmp/aquatic-targets.geojson "$URL"
+              python3 -c "import json; json.load(open('/tmp/aquatic-targets.geojson')); print('json OK')"
+              rclone copyto /tmp/aquatic-targets.geojson nrp:public-cdfw/raw/swap-2015-aquatic-targets.geojson -v
               cng-convert-to-parquet \
-                "$SHP" \
+                /tmp/aquatic-targets.geojson \
                 s3://public-cdfw/swap-2015/aquatic-targets.parquet \
                 --row-group-size 100000
             resources:
@@ -107,8 +103,8 @@ data:
       labels:
         k8s-app: swap-2015-aquatic-targets-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 1
+      parallelism: 1
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
@@ -64,9 +64,18 @@ data:
             - bash
             - -c
             - |
-              set -e
+              set -euo pipefail
+              URL="https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+              echo "Downloading SWAP aquatic-targets shapefile zip..."
+              curl -L --retry 5 -o /tmp/aquatic-targets.zip "$URL"
+              unzip -t /tmp/aquatic-targets.zip > /dev/null && echo "zip OK"
+              rclone copyto /tmp/aquatic-targets.zip nrp:public-cdfw/raw/swap-2015-aquatic-targets.zip -v
+              mkdir -p /tmp/aquatic-targets
+              unzip -q -o /tmp/aquatic-targets.zip -d /tmp/aquatic-targets
+              SHP=$(find /tmp/aquatic-targets -name "*.shp" | head -1)
+              echo "Converting shapefile: $SHP"
               cng-convert-to-parquet \
-                "https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
+                "$SHP" \
                 s3://public-cdfw/swap-2015/aquatic-targets.parquet \
                 --row-group-size 100000
             resources:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: swap-2015-aquatic-targets-setup-bucket.yaml, swap-2015-aquatic-targets-convert.yaml, swap-2015-aquatic-targets-pmtiles.yaml, swap-2015-aquatic-targets-hex.yaml, swap-2015-aquatic-targets-repartition.yaml
+# Generation command: cng-datasets workflow --dataset swap-2015/aquatic-targets --source-url https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 --bucket public-cdfw --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap swap-2015-aquatic-targets-yamls \
+#     --from-file=swap-2015-aquatic-targets-setup-bucket.yaml \
+#     --from-file=swap-2015-aquatic-targets-convert.yaml \
+#     --from-file=swap-2015-aquatic-targets-pmtiles.yaml \
+#     --from-file=swap-2015-aquatic-targets-hex.yaml \
+#     --from-file=swap-2015-aquatic-targets-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  swap-2015-aquatic-targets-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-aquatic-targets-convert
+      labels:
+        k8s-app: swap-2015-aquatic-targets-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-aquatic-targets-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+                s3://public-cdfw/swap-2015/aquatic-targets.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-aquatic-targets-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-aquatic-targets-hex
+      labels:
+        k8s-app: swap-2015-aquatic-targets-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-aquatic-targets-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: swap-2015-aquatic-targets
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-cdfw/swap-2015/aquatic-targets.parquet --output s3://public-cdfw/swap-2015/aquatic-targets/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-aquatic-targets-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-aquatic-targets-pmtiles
+      labels:
+        k8s-app: swap-2015-aquatic-targets-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-aquatic-targets-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: aquatic-targets
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/aquatic-targets.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/swap-2015/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-aquatic-targets-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-aquatic-targets-repartition
+      labels:
+        k8s-app: swap-2015-aquatic-targets-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-aquatic-targets-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-cdfw/swap-2015/aquatic-targets/chunks --output-dir s3://public-cdfw/swap-2015/aquatic-targets/hex --source-parquet s3://public-cdfw/swap-2015/aquatic-targets.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-aquatic-targets-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-aquatic-targets-setup-bucket
+      labels:
+        k8s-app: swap-2015-aquatic-targets-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-aquatic-targets-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: swap-2015-aquatic-targets-yamls
+  namespace: biodiversity

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/configmap.yaml
@@ -235,6 +235,7 @@ data:
               set -e
               # Use optimized GeoParquet (has ID column) from convert job
               # GDAL can read parquet via vsicurl
+              ulimit -n 65536 || true
               ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/aquatic-targets.parquet -progress
 
               # Generate PMTiles from GeoJSONSeq

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
@@ -49,17 +49,13 @@ spec:
         - -c
         - |
           set -euo pipefail
-          URL="https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
-          echo "Downloading SWAP aquatic-targets shapefile zip..."
-          curl -L --retry 5 -o /tmp/aquatic-targets.zip "$URL"
-          unzip -t /tmp/aquatic-targets.zip > /dev/null && echo "zip OK"
-          rclone copyto /tmp/aquatic-targets.zip nrp:public-cdfw/raw/swap-2015-aquatic-targets.zip -v
-          mkdir -p /tmp/aquatic-targets
-          unzip -q -o /tmp/aquatic-targets.zip -d /tmp/aquatic-targets
-          SHP=$(find /tmp/aquatic-targets -name "*.shp" | head -1)
-          echo "Converting shapefile: $SHP"
+          URL="https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
+          echo "Downloading SWAP aquatic-targets GeoJSON (full field names; shp truncates to 10 chars)..."
+          curl -L --retry 5 -o /tmp/aquatic-targets.geojson "$URL"
+          python3 -c "import json; json.load(open('/tmp/aquatic-targets.geojson')); print('json OK')"
+          rclone copyto /tmp/aquatic-targets.geojson nrp:public-cdfw/raw/swap-2015-aquatic-targets.geojson -v
           cng-convert-to-parquet \
-            "$SHP" \
+            /tmp/aquatic-targets.geojson \
             s3://public-cdfw/swap-2015/aquatic-targets.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
@@ -48,9 +48,18 @@ spec:
         - bash
         - -c
         - |
-          set -e
+          set -euo pipefail
+          URL="https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+          echo "Downloading SWAP aquatic-targets shapefile zip..."
+          curl -L --retry 5 -o /tmp/aquatic-targets.zip "$URL"
+          unzip -t /tmp/aquatic-targets.zip > /dev/null && echo "zip OK"
+          rclone copyto /tmp/aquatic-targets.zip nrp:public-cdfw/raw/swap-2015-aquatic-targets.zip -v
+          mkdir -p /tmp/aquatic-targets
+          unzip -q -o /tmp/aquatic-targets.zip -d /tmp/aquatic-targets
+          SHP=$(find /tmp/aquatic-targets -name "*.shp" | head -1)
+          echo "Converting shapefile: $SHP"
           cng-convert-to-parquet \
-            "https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
+            "$SHP" \
             s3://public-cdfw/swap-2015/aquatic-targets.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-aquatic-targets-convert
+  labels:
+    k8s-app: swap-2015-aquatic-targets-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-aquatic-targets-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+            s3://public-cdfw/swap-2015/aquatic-targets.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+            "https://hub.arcgis.com/api/v3/datasets/a2f3f5ddf7f140d9b948fdc1a9a86c44_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
             s3://public-cdfw/swap-2015/aquatic-targets.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-hex.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: swap-2015-aquatic-targets-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 1
+  parallelism: 1
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-hex.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-aquatic-targets-hex
+  labels:
+    k8s-app: swap-2015-aquatic-targets-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-aquatic-targets-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: swap-2015-aquatic-targets
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-cdfw/swap-2015/aquatic-targets.parquet --output s3://public-cdfw/swap-2015/aquatic-targets/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-pmtiles.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-aquatic-targets-pmtiles
+  labels:
+    k8s-app: swap-2015-aquatic-targets-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-aquatic-targets-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: aquatic-targets
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/aquatic-targets.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/swap-2015/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-pmtiles.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-pmtiles.yaml
@@ -55,6 +55,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
+          ulimit -n 65536 || true
           ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/aquatic-targets.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-repartition.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-aquatic-targets-repartition
+  labels:
+    k8s-app: swap-2015-aquatic-targets-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-aquatic-targets-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-cdfw/swap-2015/aquatic-targets/chunks --output-dir s3://public-cdfw/swap-2015/aquatic-targets/hex --source-parquet s3://public-cdfw/swap-2015/aquatic-targets.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-setup-bucket.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/swap-2015-aquatic-targets-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-aquatic-targets-setup-bucket
+  labels:
+    k8s-app: swap-2015-aquatic-targets-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-aquatic-targets-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/workflow-rbac.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/cdfw/k8s/swap-2015/aquatic-targets/workflow.yaml
+++ b/catalog/cdfw/k8s/swap-2015/aquatic-targets/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-aquatic-targets-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting swap-2015-aquatic-targets workflow...\"\n\n\
+          # Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/swap-2015-aquatic-targets-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/swap-2015-aquatic-targets-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/swap-2015-aquatic-targets-convert.yaml -n biodiversity\n\
+          \necho \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait\
+          \ --for=condition=complete --timeout=3600s job/swap-2015-aquatic-targets-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/swap-2015-aquatic-targets-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/swap-2015-aquatic-targets-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/swap-2015-aquatic-targets-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/swap-2015-aquatic-targets-repartition.yaml -n biodiversity\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/swap-2015-aquatic-targets-repartition -n biodiversity\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs swap-2015-aquatic-targets-setup-bucket swap-2015-aquatic-targets-convert\
+          \ swap-2015-aquatic-targets-pmtiles swap-2015-aquatic-targets-hex swap-2015-aquatic-targets-repartition\
+          \ swap-2015-aquatic-targets-workflow -n biodiversity\"\necho \"  kubectl\
+          \ delete configmap swap-2015-aquatic-targets-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: swap-2015-aquatic-targets-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+                "https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
                 s3://public-cdfw/swap-2015/provinces.parquet \
                 --row-group-size 100000
             resources:

--- a/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
@@ -64,9 +64,18 @@ data:
             - bash
             - -c
             - |
-              set -e
+              set -euo pipefail
+              URL="https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+              echo "Downloading SWAP provinces shapefile zip..."
+              curl -L --retry 5 -o /tmp/provinces.zip "$URL"
+              unzip -t /tmp/provinces.zip > /dev/null && echo "zip OK"
+              rclone copyto /tmp/provinces.zip nrp:public-cdfw/raw/swap-2015-provinces.zip -v
+              mkdir -p /tmp/provinces
+              unzip -q -o /tmp/provinces.zip -d /tmp/provinces
+              SHP=$(find /tmp/provinces -name "*.shp" | head -1)
+              echo "Converting shapefile: $SHP"
               cng-convert-to-parquet \
-                "https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
+                "$SHP" \
                 s3://public-cdfw/swap-2015/provinces.parquet \
                 --row-group-size 100000
             resources:

--- a/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: swap-2015-provinces-setup-bucket.yaml, swap-2015-provinces-convert.yaml, swap-2015-provinces-pmtiles.yaml, swap-2015-provinces-hex.yaml, swap-2015-provinces-repartition.yaml
+# Generation command: cng-datasets workflow --dataset swap-2015/provinces --source-url https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 --bucket public-cdfw --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap swap-2015-provinces-yamls \
+#     --from-file=swap-2015-provinces-setup-bucket.yaml \
+#     --from-file=swap-2015-provinces-convert.yaml \
+#     --from-file=swap-2015-provinces-pmtiles.yaml \
+#     --from-file=swap-2015-provinces-hex.yaml \
+#     --from-file=swap-2015-provinces-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  swap-2015-provinces-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-provinces-convert
+      labels:
+        k8s-app: swap-2015-provinces-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-provinces-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+                s3://public-cdfw/swap-2015/provinces.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-provinces-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-provinces-hex
+      labels:
+        k8s-app: swap-2015-provinces-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-provinces-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: swap-2015-provinces
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-cdfw/swap-2015/provinces.parquet --output s3://public-cdfw/swap-2015/provinces/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-provinces-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-provinces-pmtiles
+      labels:
+        k8s-app: swap-2015-provinces-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-provinces-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: provinces
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/provinces.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/swap-2015/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-provinces-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-provinces-repartition
+      labels:
+        k8s-app: swap-2015-provinces-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-provinces-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-cdfw/swap-2015/provinces/chunks --output-dir s3://public-cdfw/swap-2015/provinces/hex --source-parquet s3://public-cdfw/swap-2015/provinces.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-provinces-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-provinces-setup-bucket
+      labels:
+        k8s-app: swap-2015-provinces-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-provinces-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: swap-2015-provinces-yamls
+  namespace: biodiversity

--- a/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
@@ -65,17 +65,13 @@ data:
             - -c
             - |
               set -euo pipefail
-              URL="https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
-              echo "Downloading SWAP provinces shapefile zip..."
-              curl -L --retry 5 -o /tmp/provinces.zip "$URL"
-              unzip -t /tmp/provinces.zip > /dev/null && echo "zip OK"
-              rclone copyto /tmp/provinces.zip nrp:public-cdfw/raw/swap-2015-provinces.zip -v
-              mkdir -p /tmp/provinces
-              unzip -q -o /tmp/provinces.zip -d /tmp/provinces
-              SHP=$(find /tmp/provinces -name "*.shp" | head -1)
-              echo "Converting shapefile: $SHP"
+              URL="https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
+              echo "Downloading SWAP provinces GeoJSON (full field names; shp truncates to 10 chars)..."
+              curl -L --retry 5 -o /tmp/provinces.geojson "$URL"
+              python3 -c "import json; json.load(open('/tmp/provinces.geojson')); print('json OK')"
+              rclone copyto /tmp/provinces.geojson nrp:public-cdfw/raw/swap-2015-provinces.geojson -v
               cng-convert-to-parquet \
-                "$SHP" \
+                /tmp/provinces.geojson \
                 s3://public-cdfw/swap-2015/provinces.parquet \
                 --row-group-size 100000
             resources:
@@ -107,8 +103,8 @@ data:
       labels:
         k8s-app: swap-2015-provinces-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 1
+      parallelism: 1
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:

--- a/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/configmap.yaml
@@ -235,6 +235,7 @@ data:
               set -e
               # Use optimized GeoParquet (has ID column) from convert job
               # GDAL can read parquet via vsicurl
+              ulimit -n 65536 || true
               ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/provinces.parquet -progress
 
               # Generate PMTiles from GeoJSONSeq

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+            "https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
             s3://public-cdfw/swap-2015/provinces.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-provinces-convert
+  labels:
+    k8s-app: swap-2015-provinces-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-provinces-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+            s3://public-cdfw/swap-2015/provinces.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
@@ -48,9 +48,18 @@ spec:
         - bash
         - -c
         - |
-          set -e
+          set -euo pipefail
+          URL="https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+          echo "Downloading SWAP provinces shapefile zip..."
+          curl -L --retry 5 -o /tmp/provinces.zip "$URL"
+          unzip -t /tmp/provinces.zip > /dev/null && echo "zip OK"
+          rclone copyto /tmp/provinces.zip nrp:public-cdfw/raw/swap-2015-provinces.zip -v
+          mkdir -p /tmp/provinces
+          unzip -q -o /tmp/provinces.zip -d /tmp/provinces
+          SHP=$(find /tmp/provinces -name "*.shp" | head -1)
+          echo "Converting shapefile: $SHP"
           cng-convert-to-parquet \
-            "https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
+            "$SHP" \
             s3://public-cdfw/swap-2015/provinces.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-convert.yaml
@@ -49,17 +49,13 @@ spec:
         - -c
         - |
           set -euo pipefail
-          URL="https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
-          echo "Downloading SWAP provinces shapefile zip..."
-          curl -L --retry 5 -o /tmp/provinces.zip "$URL"
-          unzip -t /tmp/provinces.zip > /dev/null && echo "zip OK"
-          rclone copyto /tmp/provinces.zip nrp:public-cdfw/raw/swap-2015-provinces.zip -v
-          mkdir -p /tmp/provinces
-          unzip -q -o /tmp/provinces.zip -d /tmp/provinces
-          SHP=$(find /tmp/provinces -name "*.shp" | head -1)
-          echo "Converting shapefile: $SHP"
+          URL="https://hub.arcgis.com/api/v3/datasets/076ccc71fc1143a69cd90df79802b9a0_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
+          echo "Downloading SWAP provinces GeoJSON (full field names; shp truncates to 10 chars)..."
+          curl -L --retry 5 -o /tmp/provinces.geojson "$URL"
+          python3 -c "import json; json.load(open('/tmp/provinces.geojson')); print('json OK')"
+          rclone copyto /tmp/provinces.geojson nrp:public-cdfw/raw/swap-2015-provinces.geojson -v
           cng-convert-to-parquet \
-            "$SHP" \
+            /tmp/provinces.geojson \
             s3://public-cdfw/swap-2015/provinces.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-hex.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: swap-2015-provinces-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 1
+  parallelism: 1
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-hex.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-provinces-hex
+  labels:
+    k8s-app: swap-2015-provinces-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-provinces-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: swap-2015-provinces
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-cdfw/swap-2015/provinces.parquet --output s3://public-cdfw/swap-2015/provinces/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-pmtiles.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-provinces-pmtiles
+  labels:
+    k8s-app: swap-2015-provinces-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-provinces-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: provinces
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/provinces.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/swap-2015/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-pmtiles.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-pmtiles.yaml
@@ -55,6 +55,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
+          ulimit -n 65536 || true
           ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/provinces.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-repartition.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-provinces-repartition
+  labels:
+    k8s-app: swap-2015-provinces-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-provinces-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-cdfw/swap-2015/provinces/chunks --output-dir s3://public-cdfw/swap-2015/provinces/hex --source-parquet s3://public-cdfw/swap-2015/provinces.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-setup-bucket.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/swap-2015-provinces-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-provinces-setup-bucket
+  labels:
+    k8s-app: swap-2015-provinces-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-provinces-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/provinces/workflow-rbac.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/cdfw/k8s/swap-2015/provinces/workflow.yaml
+++ b/catalog/cdfw/k8s/swap-2015/provinces/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-provinces-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting swap-2015-provinces workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/swap-2015-provinces-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/swap-2015-provinces-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/swap-2015-provinces-convert.yaml -n biodiversity\n\
+          \necho \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait\
+          \ --for=condition=complete --timeout=3600s job/swap-2015-provinces-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/swap-2015-provinces-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/swap-2015-provinces-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/swap-2015-provinces-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/swap-2015-provinces-repartition.yaml -n biodiversity\n\necho\
+          \ \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/swap-2015-provinces-repartition -n biodiversity\n\n\
+          echo \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still be\
+          \ running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs swap-2015-provinces-setup-bucket swap-2015-provinces-convert\
+          \ swap-2015-provinces-pmtiles swap-2015-provinces-hex swap-2015-provinces-repartition\
+          \ swap-2015-provinces-workflow -n biodiversity\"\necho \"  kubectl delete\
+          \ configmap swap-2015-provinces-yamls -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: swap-2015-provinces-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: swap-2015-terrestrial-targets-setup-bucket.yaml, swap-2015-terrestrial-targets-convert.yaml, swap-2015-terrestrial-targets-pmtiles.yaml, swap-2015-terrestrial-targets-hex.yaml, swap-2015-terrestrial-targets-repartition.yaml
+# Generation command: cng-datasets workflow --dataset swap-2015/terrestrial-targets --source-url https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 --bucket public-cdfw --h3-resolution 8 --parent-resolutions "0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap swap-2015-terrestrial-targets-yamls \
+#     --from-file=swap-2015-terrestrial-targets-setup-bucket.yaml \
+#     --from-file=swap-2015-terrestrial-targets-convert.yaml \
+#     --from-file=swap-2015-terrestrial-targets-pmtiles.yaml \
+#     --from-file=swap-2015-terrestrial-targets-hex.yaml \
+#     --from-file=swap-2015-terrestrial-targets-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  swap-2015-terrestrial-targets-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-terrestrial-targets-convert
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-terrestrial-targets-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+                s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-terrestrial-targets-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-terrestrial-targets-hex
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-terrestrial-targets-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: swap-2015-terrestrial-targets
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-cdfw/swap-2015/terrestrial-targets.parquet --output s3://public-cdfw/swap-2015/terrestrial-targets/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-terrestrial-targets-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-terrestrial-targets-pmtiles
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-terrestrial-targets-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            - name: DATASET
+              value: terrestrial-targets
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/terrestrial-targets.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/swap-2015/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-terrestrial-targets-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-terrestrial-targets-repartition
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-terrestrial-targets-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-cdfw/swap-2015/terrestrial-targets/chunks --output-dir s3://public-cdfw/swap-2015/terrestrial-targets/hex --source-parquet s3://public-cdfw/swap-2015/terrestrial-targets.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  swap-2015-terrestrial-targets-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: swap-2015-terrestrial-targets-setup-bucket
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: swap-2015-terrestrial-targets-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-cdfw
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: swap-2015-terrestrial-targets-yamls
+  namespace: biodiversity

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
@@ -65,17 +65,13 @@ data:
             - -c
             - |
               set -euo pipefail
-              URL="https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
-              echo "Downloading SWAP terrestrial-targets shapefile zip..."
-              curl -L --retry 5 -o /tmp/terrestrial-targets.zip "$URL"
-              unzip -t /tmp/terrestrial-targets.zip > /dev/null && echo "zip OK"
-              rclone copyto /tmp/terrestrial-targets.zip nrp:public-cdfw/raw/swap-2015-terrestrial-targets.zip -v
-              mkdir -p /tmp/terrestrial-targets
-              unzip -q -o /tmp/terrestrial-targets.zip -d /tmp/terrestrial-targets
-              SHP=$(find /tmp/terrestrial-targets -name "*.shp" | head -1)
-              echo "Converting shapefile: $SHP"
+              URL="https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
+              echo "Downloading SWAP terrestrial-targets GeoJSON (full field names; shp truncates to 10 chars)..."
+              curl -L --retry 5 -o /tmp/terrestrial-targets.geojson "$URL"
+              python3 -c "import json; json.load(open('/tmp/terrestrial-targets.geojson')); print('json OK')"
+              rclone copyto /tmp/terrestrial-targets.geojson nrp:public-cdfw/raw/swap-2015-terrestrial-targets.geojson -v
               cng-convert-to-parquet \
-                "$SHP" \
+                /tmp/terrestrial-targets.geojson \
                 s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
                 --row-group-size 100000
             resources:
@@ -107,8 +103,8 @@ data:
       labels:
         k8s-app: swap-2015-terrestrial-targets-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 1
+      parallelism: 1
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
@@ -64,9 +64,18 @@ data:
             - bash
             - -c
             - |
-              set -e
+              set -euo pipefail
+              URL="https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+              echo "Downloading SWAP terrestrial-targets shapefile zip..."
+              curl -L --retry 5 -o /tmp/terrestrial-targets.zip "$URL"
+              unzip -t /tmp/terrestrial-targets.zip > /dev/null && echo "zip OK"
+              rclone copyto /tmp/terrestrial-targets.zip nrp:public-cdfw/raw/swap-2015-terrestrial-targets.zip -v
+              mkdir -p /tmp/terrestrial-targets
+              unzip -q -o /tmp/terrestrial-targets.zip -d /tmp/terrestrial-targets
+              SHP=$(find /tmp/terrestrial-targets -name "*.shp" | head -1)
+              echo "Converting shapefile: $SHP"
               cng-convert-to-parquet \
-                "https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
+                "$SHP" \
                 s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
                 --row-group-size 100000
             resources:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
@@ -235,6 +235,7 @@ data:
               set -e
               # Use optimized GeoParquet (has ID column) from convert job
               # GDAL can read parquet via vsicurl
+              ulimit -n 65536 || true
               ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/terrestrial-targets.parquet -progress
 
               # Generate PMTiles from GeoJSONSeq

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/configmap.yaml
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+                "https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
                 s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
                 --row-group-size 100000
             resources:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+            "https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
             s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-terrestrial-targets-convert
+  labels:
+    k8s-app: swap-2015-terrestrial-targets-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1 \
+            s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
@@ -48,9 +48,18 @@ spec:
         - bash
         - -c
         - |
-          set -e
+          set -euo pipefail
+          URL="https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
+          echo "Downloading SWAP terrestrial-targets shapefile zip..."
+          curl -L --retry 5 -o /tmp/terrestrial-targets.zip "$URL"
+          unzip -t /tmp/terrestrial-targets.zip > /dev/null && echo "zip OK"
+          rclone copyto /tmp/terrestrial-targets.zip nrp:public-cdfw/raw/swap-2015-terrestrial-targets.zip -v
+          mkdir -p /tmp/terrestrial-targets
+          unzip -q -o /tmp/terrestrial-targets.zip -d /tmp/terrestrial-targets
+          SHP=$(find /tmp/terrestrial-targets -name "*.shp" | head -1)
+          echo "Converting shapefile: $SHP"
           cng-convert-to-parquet \
-            "https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1" \
+            "$SHP" \
             s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-convert.yaml
@@ -49,17 +49,13 @@ spec:
         - -c
         - |
           set -euo pipefail
-          URL="https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=shp&spatialRefId=3857&where=1%3D1"
-          echo "Downloading SWAP terrestrial-targets shapefile zip..."
-          curl -L --retry 5 -o /tmp/terrestrial-targets.zip "$URL"
-          unzip -t /tmp/terrestrial-targets.zip > /dev/null && echo "zip OK"
-          rclone copyto /tmp/terrestrial-targets.zip nrp:public-cdfw/raw/swap-2015-terrestrial-targets.zip -v
-          mkdir -p /tmp/terrestrial-targets
-          unzip -q -o /tmp/terrestrial-targets.zip -d /tmp/terrestrial-targets
-          SHP=$(find /tmp/terrestrial-targets -name "*.shp" | head -1)
-          echo "Converting shapefile: $SHP"
+          URL="https://hub.arcgis.com/api/v3/datasets/b6cb72056e9c49efa1a42dd2e9e4b2cc_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
+          echo "Downloading SWAP terrestrial-targets GeoJSON (full field names; shp truncates to 10 chars)..."
+          curl -L --retry 5 -o /tmp/terrestrial-targets.geojson "$URL"
+          python3 -c "import json; json.load(open('/tmp/terrestrial-targets.geojson')); print('json OK')"
+          rclone copyto /tmp/terrestrial-targets.geojson nrp:public-cdfw/raw/swap-2015-terrestrial-targets.geojson -v
           cng-convert-to-parquet \
-            "$SHP" \
+            /tmp/terrestrial-targets.geojson \
             s3://public-cdfw/swap-2015/terrestrial-targets.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-hex.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: swap-2015-terrestrial-targets-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 1
+  parallelism: 1
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-hex.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-terrestrial-targets-hex
+  labels:
+    k8s-app: swap-2015-terrestrial-targets-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: swap-2015-terrestrial-targets
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-cdfw/swap-2015/terrestrial-targets.parquet --output s3://public-cdfw/swap-2015/terrestrial-targets/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-pmtiles.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-pmtiles.yaml
@@ -55,6 +55,7 @@ spec:
           set -e
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
+          ulimit -n 65536 || true
           ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/terrestrial-targets.parquet -progress
 
           # Generate PMTiles from GeoJSONSeq

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-pmtiles.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-terrestrial-targets-pmtiles
+  labels:
+    k8s-app: swap-2015-terrestrial-targets-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        - name: DATASET
+          value: terrestrial-targets
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/swap-2015/terrestrial-targets.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-cdfw/swap-2015/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-repartition.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-terrestrial-targets-repartition
+  labels:
+    k8s-app: swap-2015-terrestrial-targets-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-cdfw/swap-2015/terrestrial-targets/chunks --output-dir s3://public-cdfw/swap-2015/terrestrial-targets/hex --source-parquet s3://public-cdfw/swap-2015/terrestrial-targets.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-setup-bucket.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/swap-2015-terrestrial-targets-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-terrestrial-targets-setup-bucket
+  labels:
+    k8s-app: swap-2015-terrestrial-targets-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: swap-2015-terrestrial-targets-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-cdfw
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/workflow-rbac.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: biodiversity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/cdfw/k8s/swap-2015/terrestrial-targets/workflow.yaml
+++ b/catalog/cdfw/k8s/swap-2015/terrestrial-targets/workflow.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: swap-2015-terrestrial-targets-workflow
+  namespace: biodiversity
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting swap-2015-terrestrial-targets workflow...\"\
+          \n\n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/swap-2015-terrestrial-targets-setup-bucket.yaml\
+          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/swap-2015-terrestrial-targets-setup-bucket\
+          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
+          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
+          \nkubectl apply -f /yamls/swap-2015-terrestrial-targets-convert.yaml -n\
+          \ biodiversity\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/swap-2015-terrestrial-targets-convert\
+          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/swap-2015-terrestrial-targets-pmtiles.yaml\
+          \ -n biodiversity\nkubectl apply -f /yamls/swap-2015-terrestrial-targets-hex.yaml\
+          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/swap-2015-terrestrial-targets-hex\
+          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
+          \ -f /yamls/swap-2015-terrestrial-targets-repartition.yaml -n biodiversity\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/swap-2015-terrestrial-targets-repartition -n biodiversity\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs swap-2015-terrestrial-targets-setup-bucket swap-2015-terrestrial-targets-convert\
+          \ swap-2015-terrestrial-targets-pmtiles swap-2015-terrestrial-targets-hex\
+          \ swap-2015-terrestrial-targets-repartition swap-2015-terrestrial-targets-workflow\
+          \ -n biodiversity\"\necho \"  kubectl delete configmap swap-2015-terrestrial-targets-yamls\
+          \ -n biodiversity\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: swap-2015-terrestrial-targets-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #379.

Imports the three California State Wildlife Action Plan (SWAP) 2015 companion spatial layers into `public-cdfw`:

| Dataset | ds# | Features | Geom |
|---|---|---|---|
| `swap-2015/provinces` | ds1900 | 14 | Polygon |
| `swap-2015/terrestrial-targets` | ds1966 | 31 | Polygon |
| `swap-2015/aquatic-targets` | ds2733 | 16 | Polygon |

- **Source:** CDFW BIOS / ArcGIS Hub (org `Uq9r85Potqm3MfRV`), downloaded via the Hub `downloads/data?format=shp` endpoint (same pattern as the sibling ACE build).
- **Scope:** statewide CA, no clip. H3 res 8, `parent-resolutions 0`. GeoParquet + PMTiles + hex per layer.
- **License:** CC-BY-4.0 (matches the ACE sibling in `public-cdfw`; CDFW BIOS attribution terms), to be confirmed per-layer at STAC time.

Cluster jobs launched; STAC + parent registration land after the runs finish, at which point the verify-stac check will be re-fired. RED at PR-open is expected (STAC not published yet).