### PR TITLE
feat(#301): cwhr 60-class fractional-coverage hex

### DIFF
--- a/catalog/cwhr/k8s/cwhr/cwhr-hex-fractions.yaml
+++ b/catalog/cwhr/k8s/cwhr/cwhr-hex-fractions.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cwhr-hex-fractions
+  namespace: biodiversity
+  labels: {k8s-app: cwhr-hex-fractions}
+spec:
+  completions: 2
+  parallelism: 2
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: cwhr-hex-fractions}}
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,  valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,    value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,          value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,          value: /usr/share/gdal}
+        - {name: PYTHONPATH,         value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS,    value: '8'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CHUNK_MAP=(50 71)   # res-0 ordinals covering California
+          H0=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "=== CWHR (60+ class) res-10 FRACTIONS hex, h0-index $H0 ==="
+          cng-datasets raster \
+            --input "s3://public-ca30x30/cwhr-cog.tif" \
+            --output-parquet s3://public-ca30x30/cwhr/hex-fractions/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,7,6,5,0 \
+            --value-column whrnum --hex-resampling fractions --resampling near --nodata "0"
+        resources:
+          requests: {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 256Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}


### PR DESCRIPTION
Part of #301 (categorical mode → fractional-coverage hex). Priority #2, following the validated cwhr13 pilot.

## What
Adds `cwhr-hex-fractions.yaml` — an **additive** hex build for CWHR (`whrnum`, 60+ classes) using `--hex-resampling fractions` (datasets#143). The existing `mode` hex is retained for dominant-class map styling.

- Output: `s3://public-ca30x30/cwhr/hex-fractions/h0=*/data_0.parquet` (long schema `(whrnum, frac, h5..h10, h0)`, one row per class present per cell).
- Area recipe: `SUM(frac * cell_area) GROUP BY whrnum`, excluding the explicit nodata class `whrnum=0`.
- Same COG (`cwhr-cog.tif`), h0 cells (CA ordinals 50, 71), resolution 10, parents 9,8,7,6,5,0 as the proven mode build.

## Follow-up (this PR, after cluster run)
- Add additive `cwhr-hex-fractions` STAC asset (long schema + nodata class + area recipe) and add `whrnum=0` to the COG `classification:classes` so verify-stac's hex⊆COG check passes.
- Validate per-class areas / statewide total.

STAC gate is expected RED until the cluster run publishes the asset; will re-fire after.