### PR TITLE
feat(#301): fractional-coverage hex for ca-30x30 app categorical layers

### DIFF
--- a/catalog/ca30x30/k8s/climate-zones-kling/ca-climate-zones-hex-fractions.yaml
+++ b/catalog/ca30x30/k8s/climate-zones-kling/ca-climate-zones-hex-fractions.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ca-climate-zones-hex-fractions
+  labels:
+    k8s-app: ca-climate-zones-hex-fractions
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ca-climate-zones-hex-fractions
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-ca30x30
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-ca30x30/ca-climate-zones-cog.tif" --output-parquet s3://public-ca30x30/ca-climate-zones/hex-fractions/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column zone --hex-resampling fractions --resampling near --nodata "-9999"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex-fractions-rechunk-50.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex-fractions-rechunk-50.yaml
@@ -1,0 +1,91 @@
+# Rechunk of the single OOMKilled h0 index (50 = dense California cell
+# 577199624117288959) from climate-migration-routes-hex-fractions. The res-9
+# fractions reducer on this cell's 13-class mixing exceeded 32Gi; re-run alone
+# at 128Gi. Other 121/122 indices succeeded. Output to the same hex-fractions/.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-hex-fractions-rechunk-50
+  labels:
+    k8s-app: climate-migration-routes-hex-fractions-rechunk-50
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 1
+  completionMode: Indexed
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: climate-migration-routes-hex-fractions-rechunk-50
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/climate-migration-routes-cog.tif" --output-parquet s3://public-connectivity/climate-migration-routes/hex-fractions/ --h0-index 50 --resolution 9 --parent-resolutions 0 --value-column connectivity_class --hex-resampling fractions --resampling near --nodata "65535"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 128Gi
+            ephemeral-storage: 40Gi
+          limits:
+            cpu: '8'
+            memory: 128Gi
+            ephemeral-storage: 40Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex-fractions.yaml
+++ b/catalog/connectivity/k8s/climate-migration-routes/climate-migration-routes-hex-fractions.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: climate-migration-routes-hex-fractions
+  labels:
+    k8s-app: climate-migration-routes-hex-fractions
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: climate-migration-routes-hex-fractions
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/climate-migration-routes-cog.tif" --output-parquet s3://public-connectivity/climate-migration-routes/hex-fractions/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column connectivity_class --hex-resampling fractions --resampling near --nodata "65535"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/connectivity/k8s/present-day-connectivity/categories/present-day-connectivity-categories-hex-fractions.yaml
+++ b/catalog/connectivity/k8s/present-day-connectivity/categories/present-day-connectivity-categories-hex-fractions.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: present-day-connectivity-categories-hex-fractions
+  labels:
+    k8s-app: present-day-connectivity-categories-hex-fractions
+spec:
+  completions: 122
+  parallelism: 61
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: present-day-connectivity-categories-hex-fractions
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-connectivity
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-connectivity/present-day-connectivity-categories-cog.tif" --output-parquet s3://public-connectivity/present-day-connectivity-categories/hex-fractions/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 0 --value-column connectivity_category --hex-resampling fractions --resampling near --nodata "255"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'


### PR DESCRIPTION
Part of #301. Prioritises the categorical layers **used in the ca-30x30 app** (per its `layers-input.json`), following the validated cwhr13 + cwhr (#393) pilots.

## Layers (additive `hex-fractions`, mode retained for styling)
| layer | value col | res | nodata | bucket |
|---|---|---|---|---|
| ca-climate-zones | `zone` | 8 | -9999 | public-ca30x30 |
| present-day-connectivity-categories | `connectivity_category` | 9 | 255 | public-connectivity |
| climate-migration-routes | `connectivity_class` | 9 | 65535 | public-connectivity |

`cgls-lc100`, `nlcd-2024`, `glwd` are **not** referenced by the app, so deferred.

## Per layer, after each cluster build
- Validate: `frac ∈ [0,1]`, per-cell `SUM(frac) ≤ 1`, fractions cell-count == mode cell-count, class set ⊆ COG classes.
- Add additive `*-hex-fractions` STAC asset (long schema; area guidance deferred to h3-guide; documents excluding the explicit nodata class), and add the nodata value to the COG `classification:classes`.
- `verify-stac --bucket … --dataset …` → 0 hard.

Applied one at a time for the pod quota. STAC gate expected RED until each build publishes; will re-fire after.