### PR TITLE
fix(stac-lint): don't misclassify continuous 'frac' column as coded categorical

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -153,6 +153,20 @@ def lint(source: str) -> list[str]:
             # column that lacks one. A column that already declares `values` is an
             # explicit opt-in to categorical validation and is never skipped here.
             if values_arr is None:
+                # Skip continuous fractional-coverage columns — the `frac` output of the
+                # categorical `fractions` reducer (datasets#143) is a per-cell areal
+                # weight in [0,1], NOT a coded class, even though its description names
+                # the "class"/"category"/"code" it weights (which otherwise trips the
+                # `is_coded` heuristic below). Signal: float-typed and named `frac` (the
+                # reducer's fixed output name) or described as an areal fraction.
+                is_fraction = (
+                    col_type in ("double", "float", "float32", "float64")
+                    and (col_name == "frac"
+                         or bool(re.search(r"\bareal fraction\b|fraction \(0", desc_l)))
+                )
+                if is_fraction:
+                    continue
+
                 # Skip date columns — a date is never a categorical class, even when its
                 # description names the "code" it dates (e.g. "Date the GAP Status Code
                 # was assigned in YYYYMMDD"). Signals: name ends in dt/date, or a date-ish


### PR DESCRIPTION
## Problem
`scripts/lint-stac-categorical.py`'s `is_coded` heuristic matches `\bcategor|code\b` in a column's description. The continuous `frac` column emitted by the categorical **fractions** reducer (datasets#143) necessarily names the *class / category / code* it weights, so it was HARD-flagged as a coded categorical column "missing a values array" — a false positive that blocks every fractional-coverage STAC (hit on the ca-30x30 app layers, #301).

## Fix
Before the `is_coded` check (inside the `values_arr is None` branch), skip float-typed columns that are continuous areal fractions — named `frac` (the reducer's fixed output name) or described as an "areal fraction". Genuinely coded columns are unaffected.

## Verification
Crafted fixture with a `frac` column whose description contains "connectivity category / class code" **and** a genuinely coded `landcover_code` column:
- before: `frac` HARD-flagged (2 findings)
- after: `frac` passes; `landcover_code` still correctly flagged ✅

No dedicated test file exists for this script. Companion to #301 (the fractions rollout).