### PR TITLE
feat(#301): fractional-coverage hex for remaining categorical layers (glwd, cgls-lc100, nlcd-2024)

### DIFF
--- a/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex-fractions.yaml
+++ b/catalog/land-cover/k8s/cgls-lc100/cgls-lc100-2019-hex-fractions.yaml
@@ -1,0 +1,93 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cgls-lc100-2019-hex-fractions
+  labels:
+    k8s-app: cgls-lc100-2019-hex-fractions
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: cgls-lc100-2019-hex-fractions
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-land-cover
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then
+            export PROJ_DATA="$(dirname $PROJ_DB)"
+            export PROJ_LIB="$PROJ_DATA"
+          fi
+
+          cng-datasets raster --input "s3://public-land-cover/cgls-lc100-2019-cog.tif" --output-parquet s3://public-land-cover/cgls-lc100-2019/hex-fractions --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,7,6,5,0 --value-column lc_class --hex-resampling fractions --resampling near --nodata "255"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 128Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 128Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/land-cover/k8s/nlcd-2024/nlcd-2024-conus-hex-fractions.yaml
+++ b/catalog/land-cover/k8s/nlcd-2024/nlcd-2024-conus-hex-fractions.yaml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nlcd-2024-conus-hex-fractions
+  namespace: biodiversity
+  labels:
+    k8s-app: nlcd-2024-conus-hex-fractions
+spec:
+  completions: 122
+  parallelism: 6
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 10
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nlcd-2024-conus-hex-fractions
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      # No single-node pin: 256Gi/8cpu pods must spread across the cluster to run
+      # concurrently. res-10 fractions is heavier than mode (multiple class rows
+      # per cell); a densest CONUS h0 cell that OOMs at 256Gi gets re-run alone at
+      # higher memory (see the -rechunk pattern), not the whole job bumped.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: CNG_HEX_WORKERS
+          value: '8'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Fractional-coverage re-hex of full CONUS NLCD 2024 from the rebuilt
+          # full-extent COG (data-workflows #307). One indexed pod per H3 res-0
+          # base cell (0..121); ocean/empty cells skip silently.
+          H0=${JOB_COMPLETION_INDEX}
+          echo "=== NLCD CONUS res-10 FRACTIONS, h0-index $H0 ==="
+          cng-datasets raster \
+            --input "s3://public-land-cover/nlcd-2024-cog.tif" \
+            --output-parquet s3://public-land-cover/nlcd-2024/hex-fractions/ \
+            --h0-index ${H0} --resolution 10 --parent-resolutions 9,8,7,6,5,0 \
+            --value-column nlcd --hex-resampling fractions --resampling near --nodata "250"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 256Gi
+            ephemeral-storage: 40Gi
+          limits:
+            cpu: '8'
+            memory: 256Gi
+            ephemeral-storage: 40Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/glwd-class-area-consolidate.yaml
+++ b/catalog/wetlands/k8s/glwd-class-area-consolidate.yaml
@@ -1,0 +1,76 @@
+# Step 4 of the GLWD per-class AREA hex (data-workflows #301).
+# The filter step's parallel PARTITION_BY sharded larger partitions into multiple
+# data_N.parquet files (7,759 objects). This pass rewrites the sparse staging to
+# ONE data_0.parquet per (Z, h0) at the canonical path (threads=1 => single file
+# per partition, per house convention + #332), and re-prints the mass-conservation
+# total + row count for a final check. Pinned to the Berkeley node (#375).
+# Reads:  s3://public-wetlands/glwd/class-area-hex-sparse/  (314.6M sparse rows)
+# Writes: s3://public-wetlands/glwd/class-area-hex/          (canonical, 1 file/partition)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-class-area-consolidate
+  labels:
+    k8s-app: glwd-class-area-consolidate
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-class-area-consolidate
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: consolidate
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          python3 - <<'PY'
+          import os, duckdb
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs;")
+          con.execute(f"""CREATE SECRET rook (TYPE S3,
+              KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
+              SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
+              ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
+              USE_SSL false, URL_STYLE 'path');""")
+          # threads=1 -> exactly one output file per (Z, h0) partition
+          con.execute("SET preserve_insertion_order=false; SET memory_limit='100GB'; SET threads=1;")
+          src = "s3://public-wetlands/glwd/class-area-hex-sparse/Z=*/h0=*/*.parquet"
+
+          tot, rows, mn = con.execute(f"""
+            SELECT ROUND(SUM(area_ha_x10),0), COUNT(*), MIN(area_ha_x10)
+            FROM read_parquet('{src}', hive_partitioning=true)""").fetchone()
+          print(f"VALIDATION staging sum_hax10={tot:.0f} rows={rows} min_area={mn} (expect sum=18187432309, min>0)", flush=True)
+
+          con.execute(f"""
+            COPY (
+              SELECT Z, area_ha_x10, h8, h7, h6, h5, h0
+              FROM read_parquet('{src}', hive_partitioning=true)
+              ORDER BY Z, h0
+            ) TO 's3://public-wetlands/glwd/class-area-hex'
+            (FORMAT PARQUET, PARTITION_BY (Z, h0), COMPRESSION ZSTD,
+             FILENAME_PATTERN 'data_{{i}}', OVERWRITE_OR_IGNORE true);""")
+          print("CONSOLIDATE_DONE", flush=True)
+          PY
+        resources:
+          requests: {cpu: '4', memory: 100Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '4', memory: 100Gi, ephemeral-storage: 40Gi}
+      volumes: []

--- a/catalog/wetlands/k8s/glwd-class-area-filter.yaml
+++ b/catalog/wetlands/k8s/glwd-class-area-filter.yaml
@@ -1,0 +1,79 @@
+# Step 3 of the GLWD per-class AREA hex (data-workflows #301).
+# The sum-hex (step 2) writes the FULL res-8 grid per class (~669M rows/class,
+# ~99.9% zeros -> ~22B rows, 34.6 GiB). This job filters to SPARSE
+# (area_ha_x10 > 0) -> ~150-200M rows, the per-(cell,class) long table intended.
+# It also prints the mass-conservation total (SUM must == glwd-area-hex 18.19 G
+# ha x10) so validation does not depend on the flaky MCP path (#375).
+# Pinned to the Berkeley node (in-region -> reliable internal rook S3 endpoint).
+# Output: s3://public-wetlands/glwd/class-area-hex-sparse/Z=<c>/h0=<cell>/  (flipped
+# to the canonical class-area-hex/ after validation).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-class-area-filter
+  labels:
+    k8s-app: glwd-class-area-filter
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-class-area-filter
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+      containers:
+      - name: filter
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          python3 - <<'PY'
+          import os, duckdb
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs;")
+          con.execute(f"""CREATE SECRET rook (TYPE S3,
+              KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
+              SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
+              ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
+              USE_SSL false, URL_STYLE 'path');""")
+          con.execute("SET preserve_insertion_order=false; SET memory_limit='110GB'; SET threads=8;")
+          src = "s3://public-wetlands/glwd/class-area-hex/Z=*/h0=*/data_0.parquet"
+
+          # 1) mass-conservation + sparsity report (validation, no MCP needed)
+          tot, rows, nz = con.execute(f"""
+            SELECT ROUND(SUM(area_ha_x10),0), COUNT(*), COUNT(*) FILTER (WHERE area_ha_x10>0)
+            FROM read_parquet('{src}', hive_partitioning=true)""").fetchone()
+          print(f"VALIDATION class_area_sum_hax10={tot:.0f}  total_rows={rows}  nonzero_rows={nz}", flush=True)
+          print(f"  expected (glwd-area-hex) = 18187432309", flush=True)
+
+          # 2) write SPARSE long table, partitioned by (Z, h0), one data_0.parquet per partition
+          con.execute(f"""
+            COPY (
+              SELECT Z, area_ha_x10, h8, h7, h6, h5, h0
+              FROM read_parquet('{src}', hive_partitioning=true)
+              WHERE area_ha_x10 > 0
+            ) TO 's3://public-wetlands/glwd/class-area-hex-sparse'
+            (FORMAT PARQUET, PARTITION_BY (Z, h0), COMPRESSION ZSTD,
+             FILENAME_PATTERN 'data_{{i}}', OVERWRITE_OR_IGNORE true);""")
+          print("SPARSE_WRITE_DONE", flush=True)
+          PY
+        resources:
+          requests: {cpu: '8', memory: 120Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 120Gi, ephemeral-storage: 40Gi}
+      volumes: []

--- a/catalog/wetlands/k8s/glwd-class-area-hex.yaml
+++ b/catalog/wetlands/k8s/glwd-class-area-hex.yaml
@@ -1,15 +1,24 @@
+# Step 2 of the GLWD per-class AREA hex (data-workflows #301).
+# Sparse sum-hex of the 33 preprocessed per-class rasters (0/255 -> nodata 255),
+# producing a LONG per-(cell, class) table: one row per (h8 cell, wetland class)
+# with area_ha_x10 > 0. Indexed job of 33*122 = 4026 units; index -> (class, h0):
+#   CLASS = 1 + index/122   (1..33)
+#   H0    = index % 122      (0..121)
+# Each unit writes s3://public-wetlands/glwd/class-area-hex/Z=<CLASS>/h0=<cell>/.
+# Empty (class,h0) regions skip fast now that absent cells are nodata.
+# Cross-check: SUM(area_ha_x10) over all classes == glwd-area-hex nonzero total.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: glwd-main-class-hex-fractions
+  name: glwd-class-area-hex
   labels:
-    k8s-app: glwd-main-class-hex-fractions
+    k8s-app: glwd-class-area-hex
 spec:
-  completions: 122
-  parallelism: 30
+  completions: 4026
+  parallelism: 40
   completionMode: Indexed
   backoffLimitPerIndex: 2
-  maxFailedIndexes: 122
+  maxFailedIndexes: 200
   podFailurePolicy:
     rules:
     - action: Ignore
@@ -19,7 +28,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: glwd-main-class-hex-fractions
+        k8s-app: glwd-class-area-hex
     spec:
       restartPolicy: Never
       priorityClassName: opportunistic
@@ -32,10 +41,6 @@ spec:
                 operator: NotIn
                 values:
                 - 'true'
-              - key: kubernetes.io/hostname
-                operator: NotIn
-                values:
-                - cph-blade05.humboldt.edu
       containers:
       - name: hex-task
         image: ghcr.io/boettiger-lab/datasets:latest
@@ -67,19 +72,20 @@ spec:
         - |-
           set -e
           PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
-          if [ -n "$PROJ_DB" ]; then
-            export PROJ_DATA="$(dirname $PROJ_DB)"
-            export PROJ_LIB="$PROJ_DATA"
-          fi
+          if [ -n "$PROJ_DB" ]; then export PROJ_DATA="$(dirname $PROJ_DB)"; export PROJ_LIB="$PROJ_DATA"; fi
+          CLASS=$((1 + JOB_COMPLETION_INDEX / 122))    # 1..33
+          H0=$((JOB_COMPLETION_INDEX % 122))           # 0..121
+          CC=$(printf "%02d" $CLASS)
+          echo "=== GLWD class-area hex: class ${CC}, h0-index ${H0} ==="
           cng-datasets raster \
-            --input "s3://public-wetlands/glwd/glwd-main-class-cog.tif" \
-            --output-parquet "s3://public-wetlands/glwd/hex-fractions/" \
-            --h0-index ${JOB_COMPLETION_INDEX} \
-            --resolution 8 --parent-resolutions 7,6,5,0 \
-            --value-column Z --hex-resampling fractions --resampling near --nodata "255"
+            --input "s3://public-wetlands/glwd/class-area-sparse/GLWD_v2_0_class_${CC}_sparse.tif" \
+            --local-cache-dir /tmp/glwd-cache \
+            --output-parquet "s3://public-wetlands/glwd/class-area-hex/Z=${CLASS}/" \
+            --h0-index ${H0} --resolution 8 --parent-resolutions 7,6,5,0 \
+            --value-column area_ha_x10 --hex-resampling sum --resampling near --nodata "255"
         resources:
-          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
-          limits: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 40Gi}
+          limits: {cpu: '4', memory: 64Gi, ephemeral-storage: 40Gi}
       volumes:
       - name: rclone-config
         secret:

--- a/catalog/wetlands/k8s/glwd-class-area-preprocess.yaml
+++ b/catalog/wetlands/k8s/glwd-class-area-preprocess.yaml
@@ -1,0 +1,99 @@
+# Step 1 of the GLWD per-class AREA hex (data-workflows #301).
+# GLWD v2.0 ships 34 per-class area rasters (ha x10). In the source, a class's
+# absence within the land domain is encoded as 0 (a real zero), and outside the
+# domain as 255 (nodata). A plain `sum` hex of these would write the FULL res-8
+# grid (~669M rows/class, ~86% zeros) — infeasible x33. This step rewrites each
+# wetland class raster (1-33) so BOTH 0 and 255 become nodata (255), leaving only
+# real positive areas. The downstream sum-hex then drops zero cells -> a SPARSE
+# per-(cell,class) long table, and fully-empty h0 regions skip fast.
+# Output: s3://public-wetlands/glwd/class-area-sparse/GLWD_v2_0_class_CC_sparse.tif
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-class-area-preprocess
+  labels:
+    k8s-app: glwd-class-area-preprocess
+spec:
+  completions: 33
+  parallelism: 15
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 33
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-class-area-preprocess
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      containers:
+      - name: preprocess
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: GDAL_CACHEMAX
+          value: '2048'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          CLASS=$((JOB_COMPLETION_INDEX + 1))          # 1..33 (skip 0 = Dryland)
+          CC=$(printf "%02d" $CLASS)
+          echo "=== GLWD class ${CC}: 0/255 -> nodata 255 (sparse) ==="
+          mkdir -p /tmp/w
+          rclone copy "nrp:public-wetlands/GLWD_v2_0/GLWD_v2_0_area_by_class_ha/GLWD_v2_0_class_${CC}_ha_x10.tif" /tmp/w/ \
+            --retries 10 --low-level-retries 20
+          python3 - "$CC" <<'PY'
+          import sys, numpy as np
+          from osgeo import gdal
+          gdal.UseExceptions()
+          cc = sys.argv[1]
+          inp = f"/tmp/w/GLWD_v2_0_class_{cc}_ha_x10.tif"
+          outp = f"/tmp/w/GLWD_v2_0_class_{cc}_sparse.tif"
+          ds = gdal.Open(inp); b = ds.GetRasterBand(1)
+          xs, ys = ds.RasterXSize, ds.RasterYSize
+          drv = gdal.GetDriverByName("GTiff")
+          out = drv.Create(outp, xs, ys, 1, gdal.GDT_Byte,
+              options=["TILED=YES","COMPRESS=ZSTD","BIGTIFF=YES","BLOCKXSIZE=256","BLOCKYSIZE=256"])
+          out.SetGeoTransform(ds.GetGeoTransform()); out.SetProjection(ds.GetProjection())
+          ob = out.GetRasterBand(1); ob.SetNoDataValue(255)
+          kept = 0
+          for yo in range(0, ys, 1024):
+              h = min(1024, ys - yo)
+              a = b.ReadAsArray(0, yo, xs, h)
+              a = np.where((a == 0) | (a == 255), 255, a).astype(np.uint8)
+              ob.WriteArray(a, 0, yo)
+              kept += int((a != 255).sum())
+          ob.FlushCache(); out.FlushCache(); out = None
+          print(f"class {cc}: {kept} non-nodata pixels", flush=True)
+          PY
+          rclone copyto "/tmp/w/GLWD_v2_0_class_${CC}_sparse.tif" \
+            "nrp:public-wetlands/glwd/class-area-sparse/GLWD_v2_0_class_${CC}_sparse.tif" \
+            --retries 10 --low-level-retries 20
+          echo "=== class ${CC} done ==="
+        resources:
+          requests: {cpu: '2', memory: 32Gi, ephemeral-storage: 30Gi}
+          limits: {cpu: '2', memory: 32Gi, ephemeral-storage: 30Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/wetlands/k8s/glwd-main-class-hex-fractions.yaml
+++ b/catalog/wetlands/k8s/glwd-main-class-hex-fractions.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glwd-main-class-hex-fractions
+  labels:
+    k8s-app: glwd-main-class-hex-fractions
+spec:
+  completions: 122
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 122
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: glwd-main-class-hex-fractions
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - cph-blade05.humboldt.edu
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
+          if [ -n "$PROJ_DB" ]; then
+            export PROJ_DATA="$(dirname $PROJ_DB)"
+            export PROJ_LIB="$PROJ_DATA"
+          fi
+          cng-datasets raster \
+            --input "s3://public-wetlands/glwd/glwd-main-class-cog.tif" \
+            --output-parquet "s3://public-wetlands/glwd/hex-fractions/" \
+            --h0-index ${JOB_COMPLETION_INDEX} \
+            --resolution 8 --parent-resolutions 7,6,5,0 \
+            --value-column Z --hex-resampling fractions --resampling near --nodata "255"
+        resources:
+          requests: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+          limits: {cpu: '4', memory: 64Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config


### PR DESCRIPTION
Completes #301. The final three categorical layers (not in the ca-30x30 app), each additive `hex-fractions` alongside the retained mode hex, matching the existing mode build's COG/extent/resolution.

| layer | value col | res | nodata | extent |
|---|---|---|---|---|
| glwd main wetland class | `Z` | 8 | 255 | global |
| cgls-lc100 2019 | `lc_class` | 9 | 255 | global |
| nlcd-2024 | `nlcd` | 10 | 250 | CONUS |

Per layer after each build: validate (`frac∈[0,1]`, per-cell `SUM≤1`, cells==mode, class⊆COG), additive STAC asset (long schema, nodata class added to COG classes), `verify-stac` 0 hard. nlcd res-10 CONUS fractions is the heaviest (256Gi, ~2h/dense cell); densest cells that OOM get re-run alone at higher memory. Applied one at a time for the pod quota.