### PR TITLE
chore: venv bootstrap with system-matched GDAL binding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,8 +131,22 @@ SELECT ST_GeometryType(geom), COUNT(*) FROM read_parquet('s3://...') GROUP BY 1
 **ALWAYS use the k8s workflow. Local env lacks tools and permissions.**
 
 ### Local env (YAML generation only)
+
+`cng-datasets` does `from osgeo import gdal` at **import time**, so even the pure-templating
+`workflow`/`raster-workflow` subcommands won't load without the Python GDAL binding — you get
+`ModuleNotFoundError: No module named 'osgeo'`. libgdal is already installed on the standard
+image (`gdal-config --version` works); you only need the matching Python binding. Use the
+committed bootstrap, which pins the binding to the system libgdal so it works on any clone:
+
+```bash
+scripts/setup-venv.sh          # creates .venv with gdal==$(gdal-config --version) + cng-datasets
+source .venv/bin/activate
+```
+
+Or by hand:
 ```bash
 uv venv && source .venv/bin/activate
+uv pip install "gdal==$(gdal-config --version)"   # match system libgdal (auto-detected via gdal-config)
 uv pip install git+https://github.com/boettiger-lab/datasets.git
 ```
 

--- a/scripts/setup-venv.sh
+++ b/scripts/setup-venv.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bootstrap the local YAML-generation venv for cng-datasets.
+#
+# Why this exists: cng-datasets does `from osgeo import gdal` at import time, so the CLI
+# won't load without the Python GDAL binding — even for the pure-templating `workflow`
+# subcommands that generate k8s YAML (no geospatial compute runs locally; that's all on
+# the cluster). libgdal ships on the standard image; we just install the *matching*
+# Python binding, pinned dynamically to `gdal-config --version` so it works on any clone.
+#
+# Usage:
+#   scripts/setup-venv.sh          # create/refresh ./.venv
+#   source .venv/bin/activate
+set -euo pipefail
+
+if ! command -v gdal-config >/dev/null 2>&1; then
+  echo "ERROR: gdal-config not found. Install system GDAL (libgdal-dev) first." >&2
+  echo "       The Python 'gdal' package builds against the system libgdal via gdal-config." >&2
+  exit 1
+fi
+GDAL_VERSION="$(gdal-config --version)"
+echo "System libgdal: ${GDAL_VERSION}"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: uv not found. Install from https://docs.astral.sh/uv/ ." >&2
+  exit 1
+fi
+
+uv venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+# GDAL binding must match the system libgdal exactly; setup.py auto-detects headers via gdal-config.
+uv pip install "gdal==${GDAL_VERSION}"
+uv pip install git+https://github.com/boettiger-lab/datasets.git
+
+python -c 'from osgeo import gdal; print("osgeo GDAL OK:", gdal.__version__)'
+echo "Done. Activate with:  source .venv/bin/activate"


### PR DESCRIPTION
The local YAML-generation CLI (`cng-datasets`) does `from osgeo import gdal` at import time, so a fresh clone hits `ModuleNotFoundError: No module named 'osgeo'` even though libgdal is on the image — the Python binding just isn't in the venv. The AGENTS.md recipe (`uv pip install git+…/datasets.git`) alone doesn't fix it.

Adds:
- **`scripts/setup-venv.sh`** — one-command bootstrap. Pins `gdal==$(gdal-config --version)` so the binding matches the system libgdal on any machine (the gdal sdist auto-detects headers via `gdal-config`), then installs cng-datasets and verifies `osgeo` loads.
- **AGENTS.md** — updates the *Local env (YAML generation only)* block to explain the osgeo-at-import gotcha and point at the script (plus the by-hand equivalent).

No behavior change to any pipeline — purely developer-setup ergonomics. Verified the script runs clean end-to-end (osgeo GDAL 3.10.3 loads).