### PR TITLE
fix(#314): landvote canonical ids — dedup + hex landvote_id/_cng_fid

### DIFF
--- a/catalog/tpl/k8s/landvote/landvote-dedup.yaml
+++ b/catalog/tpl/k8s/landvote/landvote-dedup.yaml
@@ -1,0 +1,97 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: landvote-dedup
+  labels:
+    k8s-app: landvote-dedup
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: landvote-dedup
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: dedup-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          python3 - <<'PY'
+          import duckdb, os
+          con = duckdb.connect()
+          con.execute("INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;")
+          con.execute("SET s3_endpoint='rook-ceph-rgw-nautiluss3.rook';")
+          con.execute("SET s3_use_ssl=false;")
+          con.execute("SET s3_url_style='path';")
+          con.execute(f"SET s3_access_key_id='{os.environ['AWS_ACCESS_KEY_ID']}';")
+          con.execute(f"SET s3_secret_access_key='{os.environ['AWS_SECRET_ACCESS_KEY']}';")
+
+          src = "s3://public-tpl/landvote.parquet"
+          dst = "s3://public-tpl/landvote-dedup.parquet"
+
+          # Non-_cng_fid columns define a logical row; ST_AsWKB(geom) makes geometry comparable.
+          part = ("landvote_id, year, state, county, municipal, jurisdiction, status, "
+                  "percent_yes, percent_no, date, total_funds_at_stake, total_funds_approved, "
+                  "conservation_funds_at_stake, conservation_funds_approved, finance_mechanism, "
+                  "other_comment, purpose, description, notes, voted_acq_measure, election_year, "
+                  "party, ST_AsWKB(geom)")
+
+          n_in = con.execute(f"SELECT COUNT(*) FROM read_parquet('{src}')").fetchone()[0]
+          print(f"input rows: {n_in}", flush=True)
+
+          con.execute(f"""
+            COPY (
+              SELECT * EXCLUDE (rn) FROM (
+                SELECT *, ROW_NUMBER() OVER (PARTITION BY {part} ORDER BY _cng_fid) AS rn
+                FROM read_parquet('{src}')
+              ) WHERE rn = 1
+            ) TO '{dst}' (FORMAT PARQUET, ROW_GROUP_SIZE 2000, COMPRESSION ZSTD);
+          """)
+
+          n_out = con.execute(f"SELECT COUNT(*) FROM read_parquet('{dst}')").fetchone()[0]
+          n_fid = con.execute(f"SELECT COUNT(DISTINCT _cng_fid) FROM read_parquet('{dst}')").fetchone()[0]
+          n_lv  = con.execute(f"SELECT COUNT(DISTINCT landvote_id) FROM read_parquet('{dst}')").fetchone()[0]
+          gtype = con.execute(f"SELECT DISTINCT typeof(geom) FROM read_parquet('{dst}') LIMIT 1").fetchone()[0]
+          print(f"output rows: {n_out}  distinct _cng_fid: {n_fid}  distinct landvote_id: {n_lv}  geom type: {gtype}", flush=True)
+
+          assert n_out == 3866, f"expected 3866 rows, got {n_out}"
+          assert n_lv == 3072, f"expected 3072 measures, got {n_lv}"
+          assert n_fid == 3866, f"expected 3866 distinct _cng_fid, got {n_fid}"
+          print("OK dedup verified", flush=True)
+          PY
+        resources:
+          requests:
+            cpu: '2'
+            memory: 8Gi
+          limits:
+            cpu: '2'
+            memory: 8Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/landvote/landvote-hex.yaml
+++ b/catalog/tpl/k8s/landvote/landvote-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: landvote-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 4
+  parallelism: 4
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:

--- a/catalog/tpl/k8s/landvote/landvote-repartition.yaml
+++ b/catalog/tpl/k8s/landvote/landvote-repartition.yaml
@@ -56,11 +56,11 @@ spec:
           requests:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 10Gi
           limits:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 10Gi
       volumes:
       - name: rclone-config
         secret:


### PR DESCRIPTION
Closes #314.

Fixes the landvote data + STAC so both dedup keys are present everywhere.

## Data (published to NRP S3, `geo-workflows` ns)
- Dropped the **20 byte-identical rows** (a Special-District measure replicated ×21) from `landvote.parquet`: **3,886 → 3,866 rows**, 3,072 distinct `landvote_id` unchanged, multi-jurisdiction rows retained.
- **Re-hexed** from the deduped parquet (res 8, parent 0). Removes the ×21 hex-cell bloat and carries `landvote_id` + `_cng_fid`. Rebuilt hex covers **all 3,866 polygons / 3,072 measures** — the current tool assigns every feature ≥1 h8 cell, recovering the 10 sub-h8-cell municipal measures the old build dropped (old hex was 3,873 fid / 3,062 measures).

## STAC (all assets; `verify-stac.py --bucket public-tpl --dataset landvote` → exit 0)
- **parquet**: added `_cng_fid` column (per-row canonical join key); `landvote_id` reworded as the per-measure dedup key.
- **hex**: now lists its full column set (was only `_cng_fid`/`h8`/`h0`) incl. `landvote_id`, with two-axis (per-cell + per-place-row) **dedup-before-SUM** warnings on the four funds columns.
- **pmtiles**: categoricals (`jurisdiction`/`status`/`finance_mechanism`/`party`) gained `values` enumerations.
- Embedded counts refreshed (3,886→3,866; raw at-stake $438B→$437B; status Pass 3096→3076; etc.). Deduped totals unchanged ($344.2B at stake / $93.98B conservation approved).

## Recipe YAMLs
- `landvote-dedup.yaml` (new) — DuckDB dedup job.
- `landvote-hex.yaml` — completions 200→4.
- `landvote-repartition.yaml` — ephemeral 200Gi→10Gi (≤50Gi cap).

PMTiles **tiles** were not rebuilt (the 20 dropped rows are byte-identical duplicate polygons — visually inert; tiles carry `_cng_fid` for dedup).

Verified state and the moot res-8 caveat documented in the issue comments.