### PR TITLE
fix(#136): re-hex priority-areas-gye at h11 (recover Upper Green boundary parcels)

### DIFF
--- a/catalog/wyoming/k8s/priority-areas-gye/priority-areas-gye-hex.yaml
+++ b/catalog/wyoming/k8s/priority-areas-gye/priority-areas-gye-hex.yaml
@@ -1,0 +1,74 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: priority-areas-gye-hex
+  labels:
+    k8s-app: priority-areas-gye-hex
+spec:
+  completions: 3
+  parallelism: 3
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: priority-areas-gye-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # #136: re-hex at native h11 with h10 parent so the h10-parent superset
+          # recovers Upper Green boundary parcels the direct-h10 polyfill dropped.
+          # chunk-size 1 => one feature per pod (Upper Green is far larger than the others).
+          cng-datasets vector --input s3://public-wyoming/priority-areas-gye.parquet --output s3://public-wyoming/priority-areas-gye/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1 --intermediate-chunk-size 10 --resolution 11 --parent-resolutions 10,9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wyoming/k8s/priority-areas-gye/priority-areas-gye-repartition.yaml
+++ b/catalog/wyoming/k8s/priority-areas-gye/priority-areas-gye-repartition.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: priority-areas-gye-repartition
+  labels:
+    k8s-app: priority-areas-gye-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: priority-areas-gye-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wyoming/priority-areas-gye/chunks --output-dir s3://public-wyoming/priority-areas-gye/hex --source-parquet s3://public-wyoming/priority-areas-gye.parquet --cleanup --memory-limit 50GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 40Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 40Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'


### PR DESCRIPTION
Closes #136.

Re-hexes the 3 GYE priority areas at **native h11** (parents `10,9,8,0`; was native h10) so the h10-parent set becomes a **superset** of a direct-h10 polyfill, recovering the Upper Green boundary parcels the previous center-containment h10 build dropped.

## Mechanism (verified against the live geometry, then the rebuilt hex)
| area | direct-h10 | new h10 (via h11) | extra boundary h10 |
|---|---:|---:|---:|
| Absaroka Front | 851,433 | 852,789 | +1,356 |
| **Upper Green** | 1,557,684 | **1,559,602** | **+1,918** |
| Upper Wind River | 913,012 | 914,925 | +1,913 |

The existing **res-10 parcel join** (`priority.h10 == parcel.h10`) keeps working unchanged and now picks up the ~360 missing Upper Green edge parcels; **h11** is available for finer joins. No NULL h11/h10; all 3 features present.

## STAC (republished to NRP S3; `verify-stac.py --bucket public-wyoming --dataset priority-areas-gye` → exit 0)
- hex asset href fixed to the `hex/h0=*/data_0.parquet` glob; `h3:native_resolution: 11`, `h3:parent_resolutions: [10,9,8,0]`; full `table:columns` (h11/h10/h9/h8/h0/_cng_fid/Name/bbox).
- parquet asset gained `table:columns` incl. `_cng_fid` (was missing → would HARD-fail #369).
- Removed legacy collection-level `table:columns`.

## Remaining validation (needs private data)
The final parcel-count check (3,054 vs report 3,027, boettiger-lab/wyoming#5) requires the **private** `gye-parcels` layer + the wyoming app join, which this session can't reach (MinIO `private-wyoming` is access-denied here). The public-side recovery (+1,918 Upper Green boundary h10 cells) is the deterministic source of the missing parcels; handing the parcel-count confirmation to the wyoming app. Details in the issue comments.

Ran in the `geo-workflows` namespace.