### PR TITLE
fix(#356): categorical-linter folds for companion-lookup + cartographic-label columns

### DIFF
--- a/scripts/lint-stac-categorical.py
+++ b/scripts/lint-stac-categorical.py
@@ -212,6 +212,20 @@ def lint(source: str) -> list[str]:
                 if is_heterogeneous_source:
                     continue
 
+                # Skip cartographic / display-label columns — free-text label strings
+                # rendered on a printed/rendered map, not a controlled vocabulary. The
+                # value is display text (often a typeset variant of a code column), so
+                # neither an inline CODE=Definition map nor a `values` enumeration applies
+                # — enumerating label strings documents typography, not a domain. e.g.
+                # sierra-nevada map-unit-polys `Label` "Cartographic label text displayed
+                # on the printed map (often a Unicode-typeset variant of MapUnit)". Signal:
+                # a deliberate cartographic/display-label phrase in the description.
+                is_display_label = bool(re.search(
+                    r"\bcartographic label\b|\blabel text\b|\bdisplay(ed)? (text|label)\b|"
+                    r"\btext (displayed|shown) on\b|displayed on the .*\bmap\b", desc_l))
+                if is_display_label:
+                    continue
+
                 # Skip FIPS / fixed-width geographic identifier codes — GEOID-component
                 # keys (STATEFP/COUNTYFP/TRACTCE/SLDLST/SLDUST…) and FIPS/STCNTY/iso3.
                 # These are identifier components, not enumerable classes (#303). The
@@ -363,6 +377,19 @@ def lint(source: str) -> list[str]:
                 r"\b(count(y|ies)|state|province|country|territor\w+|ecoregion|"
                 r"region|place|borough|parish|municipalit\w+|island)\s+names?\b", desc_l))
 
+            # Companion / lookup-asset definitions — a coded column whose code→definition
+            # map lives in a NORMALIZED companion asset (a separate lookup/descriptions
+            # parquet the geo-agent joins on), not inline. Duplicating a large map inline is
+            # redundant and often infeasible — e.g. sierra-nevada map-unit-polys `MapUnit`
+            # is 268 geologic codes defined in the `map-unit-polys-descriptions` join asset.
+            # The `values` array still enumerates the domain; the definitions are one join
+            # away. Signal: the description points at a companion / lookup / descriptions
+            # asset (a deliberate author signal). Only folds the inline-map requirement;
+            # the `values` array is still required below.
+            is_companion_defined = bool(re.search(
+                r"\bcompanion\b|\blookup asset\b|\bdescriptions? asset\b|"
+                r"\bin the [`'\"][\w-]+[`'\"]\s+(lookup|descriptions?)\b", desc_l))
+
             # COG-classification-defined numeric codes — for a raster→hex dataset, the
             # authoritative code→name legend lives in the COG asset's
             # classification:classes, which the geo-agent reads directly. When every
@@ -383,7 +410,7 @@ def lint(source: str) -> list[str]:
             # redundant. Skip the inline requirement for them — but still require the
             # `values` array below (a documented value set is always useful). #303.
             if (not has_inline_codes and not values_self_describing(values_arr)
-                    and not is_geo_name and not cog_defined):
+                    and not is_geo_name and not cog_defined and not is_companion_defined):
                 errors.append(
                     f"[{collection_id}] asset '{asset_key}', column '{col_name}': "
                     f"coded categorical column missing inline CODE=Definition list in description. "


### PR DESCRIPTION
Closes the coded-column dimension of #356.

## Context
A catalog-wide sweep for #356 Part 2 linted **all 171 leaf collections** with `lint-stac-categorical.py`: **170 pass** — the #303/#294 campaigns already retrofitted `description`+`values` onto coded/boolean columns everywhere. The single remaining finding (`sierra-nevada-atlas-map-unit-polys`) was **two linter false positives**, not data defects:

- **`MapUnit`** — 268 geologic codes that already carry a `values` array; their full definitions live by design in the companion `map-unit-polys-descriptions` join asset, so an inline 268-entry CODE=Definition map is redundant.
- **`Label`** — free-text cartographic label (display text), not a controlled vocabulary.

## Change
Two principled folds in `scripts/lint-stac-categorical.py`, matching the linter's existing author-signal design (`is_source`, `is_heterogeneous_source`, taxonomic, geo-name):
- `is_companion_defined` — description points at a companion/lookup/descriptions asset → exempt the **inline-map** requirement (still requires `values`).
- `is_display_label` — cartographic/display-label phrasing → skip both requirements.

## Verification
- `sierra-nevada-atlas-map-unit-polys` → **0 findings** (was 4); catalog now **171/171 clean**.
- `ramsar`, `padus/fee`, `landvote` unaffected (still 0).
- **Negative test:** a synthetic under-documented `status_code` (no companion/label signal) still flags *both* the inline-map and `values`-array requirements → folds are narrow, don't mask genuine defects.

The larger gap this sweep surfaced — **90 parquet deliverables with entirely-missing `table:columns`** — is tracked separately in #404 (out of scope here; that's schema authoring, not coded-value lists).