### PR TITLE
fix(#411): public-usgs-nhd anonymous ListBucket policy + setup-bucket manifest

### DIFF
--- a/catalog/usgs-nhd/k8s/BUILD.md
+++ b/catalog/usgs-nhd/k8s/BUILD.md
@@ -26,16 +26,25 @@ Geometry reprojected NAD83 (EPSG:4269) → **OGC:CRS84**; hexed to **H3 resoluti
    - `streams-by-order.parquet` = `nhdflowline` LEFT JOIN `vaa` on `PERMANENT_IDENTIFIER`
      (VAA keys are unique → no fan-out).
    - `perennial-streams.parquet` = `nhdflowline` WHERE `FCODE = 46006`.
-4. Bucket made public + CORS (`cng-datasets storage setup-bucket`, equivalently a public-read
-   policy + CORS).
+4. Bucket made public + CORS — **run `setup-bucket.yaml`** (`cng-datasets storage
+   setup-bucket --bucket public-usgs-nhd --remote nrp --verify`). ⚠️ Do NOT substitute a
+   hand-rolled "public-read" policy: a bare `s3:GetObject`-only grant omits `s3:ListBucket`,
+   so anonymous object GET works but `h0=*` **globs 403** (they need a bucket LIST). The tool
+   emits the correct two-statement policy (`s3:GetBucketLocation`+`s3:ListBucket` on the
+   bucket **and** `s3:GetObject` on `/*`), matching every sibling `public-*` bucket. This was
+   the #411 bug — the original build applied a GetObject-only policy by hand. Verify anonymously:
+   `curl -so/dev/null -w '%{http_code}' 'https://s3-west.nrp-nautilus.io/public-usgs-nhd?list-type=2&max-keys=1'`
+   must be `200`.
 5. Per dataset: **`<ds>-hex.yaml`** (200 completions; chunk-size = ceil(features/200):
    151200 for streams-by-order, 34000 for perennial) → **`<ds>-repartition.yaml`**, and
    **`<ds>-pmtiles.yaml`**.
 
-The generated `<ds>-convert.yaml`, `<ds>-setup-bucket.yaml`, and `workflow.yaml` (orchestrator)
-are the standard `cng-datasets workflow` scaffolding; they are **superseded** by the custom
-`convert.yaml` + `derive.yaml` above (kept for reference only — do not run the orchestrator, it
-would skip the VAA join).
+The generated `<ds>-convert.yaml` and `workflow.yaml` (orchestrator) are the standard
+`cng-datasets workflow` scaffolding; they are **superseded** by the custom `convert.yaml` +
+`derive.yaml` above (kept for reference only — do not run the orchestrator, it would skip the
+VAA join). **`setup-bucket.yaml` is NOT superseded — it must still be run** (step 4); it is the
+one piece of the standard scaffolding this custom build still needs, and skipping it (or hand-
+rolling its policy) is exactly what caused #411.
 
 ## Notes / gotchas hit during the build
 

--- a/catalog/usgs-nhd/k8s/setup-bucket.yaml
+++ b/catalog/usgs-nhd/k8s/setup-bucket.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: usgs-nhd-setup-bucket
+  labels:
+    k8s-app: usgs-nhd-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: usgs-nhd-setup-bucket
+    spec:
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usgs-nhd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access (ListBucket + GetObject) and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config


### PR DESCRIPTION
Fixes #411.

## Problem
`public-usgs-nhd` denied anonymous `s3:ListBucket`, so any DuckDB read that **globs** the H3 hex partitions (`.../streams-by-order/hex/h0=*/data_0.parquet`) returned **403** — the exact path published in the STAC. Object GET already worked; only the bucket LIST that a glob requires was denied. This broke streams-by-order queries in the ca-30x30 app (ca-30x30#90) and headless reproduction.

## Root cause
`public-usgs-nhd` was a **custom manual build** (#235) — `streams-by-order` needs a VAA join for `STREAMORDER`, so per `BUILD.md` the standard `cng-datasets workflow` orchestrator and its generated scaffolding were superseded. The generated `setup-bucket.yaml` was **never committed or run**; instead the bucket was made public with a hand-rolled single-statement `{"Sid":"PublicRead","Action":["s3:GetObject"]}` policy that **omits `s3:ListBucket`**.

`cng-datasets storage setup-bucket` (`storage/setup_bucket.py`) emits the correct **two-statement** policy — `s3:GetBucketLocation`+`s3:ListBucket` on the bucket ARN **and** `s3:GetObject` on `/*` — which is exactly what every sibling `public-*` bucket carries. The tool was simply bypassed.

## Fix
- Applied `cng-datasets storage setup-bucket --bucket public-usgs-nhd --remote nrp --verify` via a Job in `geo-workflows` (`catalog/usgs-nhd/k8s/setup-bucket.yaml`, added here). Bucket policy now matches siblings.
- `BUILD.md` step 4: run `setup-bucket.yaml`; warn against a hand-rolled public-read policy; clarify `setup-bucket` is **not** superseded by the custom build.

## Verification (unauthenticated, public endpoint)
- anonymous `ListBucket` → **HTTP 200** (was 403).
- anonymous `h0=*` glob via DuckDB (no creds): `SELECT COUNT(*) FROM read_parquet('s3://public-usgs-nhd/streams-by-order/hex/h0=*/data_0.parquet')` → **45,915,081 rows across 17 h0 partitions**.

No data reprocessing. The bucket-policy change was already applied on the cluster; this PR commits the reproducible manifest + the BUILD.md fix that prevents recurrence.