### PR TITLE
Add community health files: citation, code of conduct, contributing

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+title: "Agentic Data Workflows"
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - family-names: Boettiger
+    given-names: Carl
+    orcid: "https://orcid.org/0000-0002-1642-628X"
+    affiliation: University of California, Berkeley
+  - family-names: Buhler
+    given-names: Cassie
+    affiliation: University of California, Berkeley
+repository-code: "https://github.com/boettiger-lab/data-workflows"
+url: "https://boettiger-lab.github.io/data-workflows/"
+abstract: >-
+  Dataset processing workflows that turn disparate legacy and proprietary data
+  into AI-ready, cloud-native data with rich STAC metadata — through an
+  AI-driven pipeline powered by cng-datasets and autoscaled on NRP Kubernetes.
+  One of three open-source components that make the cloud-native data stack
+  reachable by the AI tools researchers already use.
+keywords:
+  - cloud-native
+  - AI-ready data
+  - STAC
+  - Kubernetes
+  - agentic workflows
+  - data engineering
+  - geospatial
+license:
+  - BSD-3-Clause
+  - CC-BY-4.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+cboettig@berkeley.edu.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Agentic Data Workflows
+
+Thanks for your interest in contributing! This repository holds the dataset
+processing workflows that turn disparate legacy and proprietary data into
+AI-ready, cloud-native data with rich STAC metadata, autoscaled on NRP
+Kubernetes. Contributions of all kinds are welcome — new datasets, workflow and
+STAC improvements, and documentation.
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Request a dataset** — the lowest-friction way to contribute. See
+  [`dataset-requests/`](dataset-requests/) for how requests are filed and
+  processed.
+- **Add or improve a dataset workflow** — the per-dataset pipelines under
+  [`catalog/`](catalog/).
+- **Improve STAC metadata** — schema, categorical encodings, and asset fields.
+- **Documentation** — the site under [`docs/`](docs/) and the top-level guides.
+
+Browse [open issues](https://github.com/boettiger-lab/data-workflows/issues) for
+concrete tasks, or open a
+[Discussion](https://github.com/boettiger-lab/data-workflows/discussions) to
+propose an idea or ask a question first.
+
+## Development setup
+
+Workflows are generated with [`cng-datasets`](https://github.com/boettiger-lab/cng-datasets),
+which requires the Python GDAL binding matched to the system `libgdal`. A
+bootstrap script sets up a local [`uv`](https://docs.astral.sh/uv/) venv:
+
+```bash
+scripts/setup-venv.sh
+source .venv/bin/activate
+```
+
+This installs the `gdal` binding pinned to your system `gdal-config --version`.
+The pure-templating `workflow` subcommands generate Kubernetes YAML locally; no
+geospatial compute runs on your machine — that all happens on the cluster.
+
+## Making changes
+
+1. Fork the repo and create a topic branch off `main`.
+2. Keep changes focused; follow the patterns of the surrounding datasets and
+   scripts.
+3. For dataset changes, verify STAC output — CI runs STAC validation on every
+   pull request (`.github/workflows/verify-stac.yml`), and the linters under
+   [`scripts/`](scripts/) (`lint-stac-*.py`, `check-hex-*.sh`) catch common
+   encoding and coverage issues.
+4. Update documentation as appropriate.
+5. Open a pull request with a clear description and link any related issue.
+
+Maintainers will review and may request changes before merging.
+
+## Reporting bugs and asking questions
+
+- **Bugs / feature requests:** open a
+  [GitHub Issue](https://github.com/boettiger-lab/data-workflows/issues).
+- **Questions / ideas:** start a
+  [GitHub Discussion](https://github.com/boettiger-lab/data-workflows/discussions).
+
+## License
+
+This project is dual-licensed: **content** (data, documentation, STAC metadata)
+under [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) and **code**
+under the [BSD 3-Clause License](LICENSE). By contributing, you agree that your
+contributions will be licensed under the same terms.


### PR DESCRIPTION
Adds three standard community-health files:

- **CITATION.cff** — canonical citation metadata (Carl Boettiger + Cassie Buhler; dual BSD-3 / CC-BY-4.0 to match myst.yml). GitHub renders a *Cite this repository* button.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, enforcement contact cboettig@berkeley.edu.
- **CONTRIBUTING.md** — dataset-request path, `scripts/setup-venv.sh` dev setup, STAC verification/linters, and PR process.

GitHub Discussions is being enabled separately.