### PR TITLE
feat(#404): Track B reprocess 4 american-rivers line datasets (_cng_fid + full per-asset schemas)

### DIFF
--- a/catalog/american-rivers/k8s/nri-2016/american-rivers-nri-2016-convert.yaml
+++ b/catalog/american-rivers/k8s/nri-2016/american-rivers-nri-2016-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            s3://public-rivers/american-rivers/nri-2016.parquet \
+            s3://public-rivers/american-rivers/raw/nri-2016-src.parquet \
             s3://public-rivers/american-rivers/nri-2016.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/american-rivers/k8s/nri-2016/american-rivers-nri-2016-hex.yaml
+++ b/catalog/american-rivers/k8s/nri-2016/american-rivers-nri-2016-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: american-rivers-nri-2016-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 8
+  parallelism: 8
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:
@@ -60,9 +60,11 @@ spec:
           requests:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
           limits:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:

--- a/catalog/american-rivers/k8s/nri-2016/american-rivers-nri-2016-repartition.yaml
+++ b/catalog/american-rivers/k8s/nri-2016/american-rivers-nri-2016-repartition.yaml
@@ -56,11 +56,11 @@ spec:
           requests:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
           limits:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
       volumes:
       - name: rclone-config
         secret:

--- a/catalog/american-rivers/k8s/nri-2016/configmap.yaml
+++ b/catalog/american-rivers/k8s/nri-2016/configmap.yaml
@@ -1,6 +1,6 @@
 # Auto-generated ConfigMap containing job definitions
 # Generated from: american-rivers-nri-2016-setup-bucket.yaml, american-rivers-nri-2016-convert.yaml, american-rivers-nri-2016-pmtiles.yaml, american-rivers-nri-2016-hex.yaml, american-rivers-nri-2016-repartition.yaml
-# Generation command: cng-datasets workflow --dataset american-rivers/nri-2016 --source-url s3://public-rivers/american-rivers/nri-2016.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
+# Generation command: cng-datasets workflow --dataset american-rivers/nri-2016 --source-url s3://public-rivers/american-rivers/raw/nri-2016-src.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
 #
 # This ConfigMap is equivalent to running:
 #   kubectl create configmap american-rivers-nri-2016-yamls \
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                s3://public-rivers/american-rivers/nri-2016.parquet \
+                s3://public-rivers/american-rivers/raw/nri-2016-src.parquet \
                 s3://public-rivers/american-rivers/nri-2016.parquet \
                 --row-group-size 100000
             resources:
@@ -98,8 +98,8 @@ data:
       labels:
         k8s-app: american-rivers-nri-2016-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 8
+      parallelism: 8
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:
@@ -153,9 +153,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
               limits:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:
@@ -317,11 +319,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
               limits:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
           volumes:
           - name: rclone-config
             secret:
@@ -419,4 +421,4 @@ data:
 kind: ConfigMap
 metadata:
   name: american-rivers-nri-2016-yamls
-  namespace: biodiversity
+  namespace: geo-workflows

--- a/catalog/american-rivers/k8s/nri-2016/workflow-rbac.yaml
+++ b/catalog/american-rivers/k8s/nri-2016/workflow-rbac.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 rules:
 - apiGroups:
   - batch
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/catalog/american-rivers/k8s/nri-2016/workflow.yaml
+++ b/catalog/american-rivers/k8s/nri-2016/workflow.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: american-rivers-nri-2016-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 spec:
   template:
     spec:
@@ -11,30 +11,30 @@ spec:
         - "\nset -e\n\necho \"Starting american-rivers-nri-2016 workflow...\"\n\n\
           # Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
           \ up bucket...\"\nkubectl apply -f /yamls/american-rivers-nri-2016-setup-bucket.yaml\
-          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
           kubectl wait --for=condition=complete --timeout=600s job/american-rivers-nri-2016-setup-bucket\
-          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
-          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
-          \nkubectl apply -f /yamls/american-rivers-nri-2016-convert.yaml -n biodiversity\n\
-          \necho \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait\
-          \ --for=condition=complete --timeout=3600s job/american-rivers-nri-2016-convert\
-          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/american-rivers-nri-2016-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/american-rivers-nri-2016-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
           \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
           \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/american-rivers-nri-2016-pmtiles.yaml\
-          \ -n biodiversity\nkubectl apply -f /yamls/american-rivers-nri-2016-hex.yaml\
-          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ -n geo-workflows\nkubectl apply -f /yamls/american-rivers-nri-2016-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
           \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
           \nkubectl wait --for=condition=complete --timeout=172800s job/american-rivers-nri-2016-hex\
-          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
-          \ -f /yamls/american-rivers-nri-2016-repartition.yaml -n biodiversity\n\n\
-          echo \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
-          \ --timeout=3600s job/american-rivers-nri-2016-repartition -n biodiversity\n\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/american-rivers-nri-2016-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/american-rivers-nri-2016-repartition -n geo-workflows\n\
           \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
           \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
           \ \"  kubectl delete jobs american-rivers-nri-2016-setup-bucket american-rivers-nri-2016-convert\
           \ american-rivers-nri-2016-pmtiles american-rivers-nri-2016-hex american-rivers-nri-2016-repartition\
-          \ american-rivers-nri-2016-workflow -n biodiversity\"\necho \"  kubectl\
-          \ delete configmap american-rivers-nri-2016-yamls -n biodiversity\"\n"
+          \ american-rivers-nri-2016-workflow -n geo-workflows\"\necho \"  kubectl\
+          \ delete configmap american-rivers-nri-2016-yamls -n geo-workflows\"\n"
         command:
         - bash
         - -c

--- a/catalog/american-rivers/k8s/nri-2024/american-rivers-nri-2024-convert.yaml
+++ b/catalog/american-rivers/k8s/nri-2024/american-rivers-nri-2024-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            s3://public-rivers/american-rivers/nri-2024.parquet \
+            s3://public-rivers/american-rivers/raw/nri-2024-src.parquet \
             s3://public-rivers/american-rivers/nri-2024.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/american-rivers/k8s/nri-2024/american-rivers-nri-2024-hex.yaml
+++ b/catalog/american-rivers/k8s/nri-2024/american-rivers-nri-2024-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: american-rivers-nri-2024-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 8
+  parallelism: 8
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:
@@ -60,9 +60,11 @@ spec:
           requests:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
           limits:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:

--- a/catalog/american-rivers/k8s/nri-2024/american-rivers-nri-2024-repartition.yaml
+++ b/catalog/american-rivers/k8s/nri-2024/american-rivers-nri-2024-repartition.yaml
@@ -56,11 +56,11 @@ spec:
           requests:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
           limits:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
       volumes:
       - name: rclone-config
         secret:

--- a/catalog/american-rivers/k8s/nri-2024/configmap.yaml
+++ b/catalog/american-rivers/k8s/nri-2024/configmap.yaml
@@ -1,6 +1,6 @@
 # Auto-generated ConfigMap containing job definitions
 # Generated from: american-rivers-nri-2024-setup-bucket.yaml, american-rivers-nri-2024-convert.yaml, american-rivers-nri-2024-pmtiles.yaml, american-rivers-nri-2024-hex.yaml, american-rivers-nri-2024-repartition.yaml
-# Generation command: cng-datasets workflow --dataset american-rivers/nri-2024 --source-url s3://public-rivers/american-rivers/nri-2024.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
+# Generation command: cng-datasets workflow --dataset american-rivers/nri-2024 --source-url s3://public-rivers/american-rivers/raw/nri-2024-src.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
 #
 # This ConfigMap is equivalent to running:
 #   kubectl create configmap american-rivers-nri-2024-yamls \
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                s3://public-rivers/american-rivers/nri-2024.parquet \
+                s3://public-rivers/american-rivers/raw/nri-2024-src.parquet \
                 s3://public-rivers/american-rivers/nri-2024.parquet \
                 --row-group-size 100000
             resources:
@@ -98,8 +98,8 @@ data:
       labels:
         k8s-app: american-rivers-nri-2024-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 8
+      parallelism: 8
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:
@@ -153,9 +153,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
               limits:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:
@@ -317,11 +319,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
               limits:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
           volumes:
           - name: rclone-config
             secret:
@@ -419,4 +421,4 @@ data:
 kind: ConfigMap
 metadata:
   name: american-rivers-nri-2024-yamls
-  namespace: biodiversity
+  namespace: geo-workflows

--- a/catalog/american-rivers/k8s/nri-2024/workflow-rbac.yaml
+++ b/catalog/american-rivers/k8s/nri-2024/workflow-rbac.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 rules:
 - apiGroups:
   - batch
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/catalog/american-rivers/k8s/nri-2024/workflow.yaml
+++ b/catalog/american-rivers/k8s/nri-2024/workflow.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: american-rivers-nri-2024-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 spec:
   template:
     spec:
@@ -11,30 +11,30 @@ spec:
         - "\nset -e\n\necho \"Starting american-rivers-nri-2024 workflow...\"\n\n\
           # Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
           \ up bucket...\"\nkubectl apply -f /yamls/american-rivers-nri-2024-setup-bucket.yaml\
-          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
           kubectl wait --for=condition=complete --timeout=600s job/american-rivers-nri-2024-setup-bucket\
-          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
-          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
-          \nkubectl apply -f /yamls/american-rivers-nri-2024-convert.yaml -n biodiversity\n\
-          \necho \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait\
-          \ --for=condition=complete --timeout=3600s job/american-rivers-nri-2024-convert\
-          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/american-rivers-nri-2024-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/american-rivers-nri-2024-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
           \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
           \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/american-rivers-nri-2024-pmtiles.yaml\
-          \ -n biodiversity\nkubectl apply -f /yamls/american-rivers-nri-2024-hex.yaml\
-          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ -n geo-workflows\nkubectl apply -f /yamls/american-rivers-nri-2024-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
           \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
           \nkubectl wait --for=condition=complete --timeout=172800s job/american-rivers-nri-2024-hex\
-          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
-          \ -f /yamls/american-rivers-nri-2024-repartition.yaml -n biodiversity\n\n\
-          echo \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
-          \ --timeout=3600s job/american-rivers-nri-2024-repartition -n biodiversity\n\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/american-rivers-nri-2024-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/american-rivers-nri-2024-repartition -n geo-workflows\n\
           \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
           \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
           \ \"  kubectl delete jobs american-rivers-nri-2024-setup-bucket american-rivers-nri-2024-convert\
           \ american-rivers-nri-2024-pmtiles american-rivers-nri-2024-hex american-rivers-nri-2024-repartition\
-          \ american-rivers-nri-2024-workflow -n biodiversity\"\necho \"  kubectl\
-          \ delete configmap american-rivers-nri-2024-yamls -n biodiversity\"\n"
+          \ american-rivers-nri-2024-workflow -n geo-workflows\"\necho \"  kubectl\
+          \ delete configmap american-rivers-nri-2024-yamls -n geo-workflows\"\n"
         command:
         - bash
         - -c

--- a/catalog/american-rivers/k8s/wild-scenic-designated/american-rivers-wild-scenic-designated-convert.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-designated/american-rivers-wild-scenic-designated-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            s3://public-rivers/american-rivers/wild-scenic-designated.parquet \
+            s3://public-rivers/american-rivers/raw/wild-scenic-designated-src.parquet \
             s3://public-rivers/american-rivers/wild-scenic-designated.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/american-rivers/k8s/wild-scenic-designated/american-rivers-wild-scenic-designated-hex.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-designated/american-rivers-wild-scenic-designated-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: american-rivers-wild-scenic-designated-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 4
+  parallelism: 4
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:
@@ -60,9 +60,11 @@ spec:
           requests:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
           limits:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:

--- a/catalog/american-rivers/k8s/wild-scenic-designated/american-rivers-wild-scenic-designated-repartition.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-designated/american-rivers-wild-scenic-designated-repartition.yaml
@@ -56,11 +56,11 @@ spec:
           requests:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
           limits:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
       volumes:
       - name: rclone-config
         secret:

--- a/catalog/american-rivers/k8s/wild-scenic-designated/configmap.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-designated/configmap.yaml
@@ -1,6 +1,6 @@
 # Auto-generated ConfigMap containing job definitions
 # Generated from: american-rivers-wild-scenic-designated-setup-bucket.yaml, american-rivers-wild-scenic-designated-convert.yaml, american-rivers-wild-scenic-designated-pmtiles.yaml, american-rivers-wild-scenic-designated-hex.yaml, american-rivers-wild-scenic-designated-repartition.yaml
-# Generation command: cng-datasets workflow --dataset american-rivers/wild-scenic-designated --source-url s3://public-rivers/american-rivers/wild-scenic-designated.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
+# Generation command: cng-datasets workflow --dataset american-rivers/wild-scenic-designated --source-url s3://public-rivers/american-rivers/raw/wild-scenic-designated-src.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
 #
 # This ConfigMap is equivalent to running:
 #   kubectl create configmap american-rivers-wild-scenic-designated-yamls \
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                s3://public-rivers/american-rivers/wild-scenic-designated.parquet \
+                s3://public-rivers/american-rivers/raw/wild-scenic-designated-src.parquet \
                 s3://public-rivers/american-rivers/wild-scenic-designated.parquet \
                 --row-group-size 100000
             resources:
@@ -98,8 +98,8 @@ data:
       labels:
         k8s-app: american-rivers-wild-scenic-designated-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 4
+      parallelism: 4
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:
@@ -153,9 +153,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
               limits:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:
@@ -317,11 +319,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
               limits:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
           volumes:
           - name: rclone-config
             secret:
@@ -419,4 +421,4 @@ data:
 kind: ConfigMap
 metadata:
   name: american-rivers-wild-scenic-designated-yamls
-  namespace: biodiversity
+  namespace: geo-workflows

--- a/catalog/american-rivers/k8s/wild-scenic-designated/workflow-rbac.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-designated/workflow-rbac.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 rules:
 - apiGroups:
   - batch
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/catalog/american-rivers/k8s/wild-scenic-designated/workflow.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-designated/workflow.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: american-rivers-wild-scenic-designated-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 spec:
   template:
     spec:
@@ -11,32 +11,32 @@ spec:
         - "\nset -e\n\necho \"Starting american-rivers-wild-scenic-designated workflow...\"\
           \n\n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
           \ up bucket...\"\nkubectl apply -f /yamls/american-rivers-wild-scenic-designated-setup-bucket.yaml\
-          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
           kubectl wait --for=condition=complete --timeout=600s job/american-rivers-wild-scenic-designated-setup-bucket\
-          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
-          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
-          \nkubectl apply -f /yamls/american-rivers-wild-scenic-designated-convert.yaml\
-          \ -n biodiversity\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/american-rivers-wild-scenic-designated-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
           \nkubectl wait --for=condition=complete --timeout=3600s job/american-rivers-wild-scenic-designated-convert\
-          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
           \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
           \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/american-rivers-wild-scenic-designated-pmtiles.yaml\
-          \ -n biodiversity\nkubectl apply -f /yamls/american-rivers-wild-scenic-designated-hex.yaml\
-          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ -n geo-workflows\nkubectl apply -f /yamls/american-rivers-wild-scenic-designated-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
           \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
           \nkubectl wait --for=condition=complete --timeout=172800s job/american-rivers-wild-scenic-designated-hex\
-          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
-          \ -f /yamls/american-rivers-wild-scenic-designated-repartition.yaml -n biodiversity\n\
-          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
-          \ --timeout=3600s job/american-rivers-wild-scenic-designated-repartition\
-          \ -n biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/american-rivers-wild-scenic-designated-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/american-rivers-wild-scenic-designated-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
           \ job may still be running in the background\"\necho \"\"\necho \"Clean\
           \ up with:\"\necho \"  kubectl delete jobs american-rivers-wild-scenic-designated-setup-bucket\
           \ american-rivers-wild-scenic-designated-convert american-rivers-wild-scenic-designated-pmtiles\
           \ american-rivers-wild-scenic-designated-hex american-rivers-wild-scenic-designated-repartition\
-          \ american-rivers-wild-scenic-designated-workflow -n biodiversity\"\necho\
+          \ american-rivers-wild-scenic-designated-workflow -n geo-workflows\"\necho\
           \ \"  kubectl delete configmap american-rivers-wild-scenic-designated-yamls\
-          \ -n biodiversity\"\n"
+          \ -n geo-workflows\"\n"
         command:
         - bash
         - -c

--- a/catalog/american-rivers/k8s/wild-scenic-eligible/american-rivers-wild-scenic-eligible-convert.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-eligible/american-rivers-wild-scenic-eligible-convert.yaml
@@ -50,7 +50,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            s3://public-rivers/american-rivers/wild-scenic-eligible.parquet \
+            s3://public-rivers/american-rivers/raw/wild-scenic-eligible-src.parquet \
             s3://public-rivers/american-rivers/wild-scenic-eligible.parquet \
             --row-group-size 100000
         resources:

--- a/catalog/american-rivers/k8s/wild-scenic-eligible/american-rivers-wild-scenic-eligible-hex.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-eligible/american-rivers-wild-scenic-eligible-hex.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     k8s-app: american-rivers-wild-scenic-eligible-hex
 spec:
-  completions: 200
-  parallelism: 50
+  completions: 8
+  parallelism: 8
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:
@@ -60,9 +60,11 @@ spec:
           requests:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
           limits:
             cpu: '4'
             memory: 8Gi
+            ephemeral-storage: 10Gi
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:

--- a/catalog/american-rivers/k8s/wild-scenic-eligible/american-rivers-wild-scenic-eligible-repartition.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-eligible/american-rivers-wild-scenic-eligible-repartition.yaml
@@ -56,11 +56,11 @@ spec:
           requests:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
           limits:
             cpu: '4'
             memory: 32Gi
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 50Gi
       volumes:
       - name: rclone-config
         secret:

--- a/catalog/american-rivers/k8s/wild-scenic-eligible/configmap.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-eligible/configmap.yaml
@@ -1,6 +1,6 @@
 # Auto-generated ConfigMap containing job definitions
 # Generated from: american-rivers-wild-scenic-eligible-setup-bucket.yaml, american-rivers-wild-scenic-eligible-convert.yaml, american-rivers-wild-scenic-eligible-pmtiles.yaml, american-rivers-wild-scenic-eligible-hex.yaml, american-rivers-wild-scenic-eligible-repartition.yaml
-# Generation command: cng-datasets workflow --dataset american-rivers/wild-scenic-eligible --source-url s3://public-rivers/american-rivers/wild-scenic-eligible.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
+# Generation command: cng-datasets workflow --dataset american-rivers/wild-scenic-eligible --source-url s3://public-rivers/american-rivers/raw/wild-scenic-eligible-src.parquet --bucket public-rivers --h3-resolution 8 --parent-resolutions "0"
 #
 # This ConfigMap is equivalent to running:
 #   kubectl create configmap american-rivers-wild-scenic-eligible-yamls \
@@ -66,7 +66,7 @@ data:
             - |
               set -e
               cng-convert-to-parquet \
-                s3://public-rivers/american-rivers/wild-scenic-eligible.parquet \
+                s3://public-rivers/american-rivers/raw/wild-scenic-eligible-src.parquet \
                 s3://public-rivers/american-rivers/wild-scenic-eligible.parquet \
                 --row-group-size 100000
             resources:
@@ -98,8 +98,8 @@ data:
       labels:
         k8s-app: american-rivers-wild-scenic-eligible-hex
     spec:
-      completions: 200
-      parallelism: 50
+      completions: 8
+      parallelism: 8
       completionMode: Indexed
       backoffLimit: 0
       podFailurePolicy:
@@ -153,9 +153,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
               limits:
                 cpu: '4'
                 memory: 8Gi
+                ephemeral-storage: 10Gi
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:
@@ -317,11 +319,11 @@ data:
               requests:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
               limits:
                 cpu: '4'
                 memory: 32Gi
-                ephemeral-storage: 200Gi
+                ephemeral-storage: 50Gi
           volumes:
           - name: rclone-config
             secret:
@@ -419,4 +421,4 @@ data:
 kind: ConfigMap
 metadata:
   name: american-rivers-wild-scenic-eligible-yamls
-  namespace: biodiversity
+  namespace: geo-workflows

--- a/catalog/american-rivers/k8s/wild-scenic-eligible/workflow-rbac.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-eligible/workflow-rbac.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 rules:
 - apiGroups:
   - batch
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cng-datasets-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/catalog/american-rivers/k8s/wild-scenic-eligible/workflow.yaml
+++ b/catalog/american-rivers/k8s/wild-scenic-eligible/workflow.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: american-rivers-wild-scenic-eligible-workflow
-  namespace: biodiversity
+  namespace: geo-workflows
 spec:
   template:
     spec:
@@ -11,32 +11,32 @@ spec:
         - "\nset -e\n\necho \"Starting american-rivers-wild-scenic-eligible workflow...\"\
           \n\n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
           \ up bucket...\"\nkubectl apply -f /yamls/american-rivers-wild-scenic-eligible-setup-bucket.yaml\
-          \ -n biodiversity\n\necho \"Waiting for bucket setup to complete...\"\n\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
           kubectl wait --for=condition=complete --timeout=600s job/american-rivers-wild-scenic-eligible-setup-bucket\
-          \ -n biodiversity\n\n# Step 1: Convert to optimized GeoParquet (needed by\
-          \ both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\
-          \nkubectl apply -f /yamls/american-rivers-wild-scenic-eligible-convert.yaml\
-          \ -n biodiversity\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/american-rivers-wild-scenic-eligible-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
           \nkubectl wait --for=condition=complete --timeout=3600s job/american-rivers-wild-scenic-eligible-convert\
-          \ -n biodiversity\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
           \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
           \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/american-rivers-wild-scenic-eligible-pmtiles.yaml\
-          \ -n biodiversity\nkubectl apply -f /yamls/american-rivers-wild-scenic-eligible-hex.yaml\
-          \ -n biodiversity\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ -n geo-workflows\nkubectl apply -f /yamls/american-rivers-wild-scenic-eligible-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
           \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
           \nkubectl wait --for=condition=complete --timeout=172800s job/american-rivers-wild-scenic-eligible-hex\
-          \ -n biodiversity\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl apply\
-          \ -f /yamls/american-rivers-wild-scenic-eligible-repartition.yaml -n biodiversity\n\
-          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
-          \ --timeout=3600s job/american-rivers-wild-scenic-eligible-repartition -n\
-          \ biodiversity\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/american-rivers-wild-scenic-eligible-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/american-rivers-wild-scenic-eligible-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
           \ job may still be running in the background\"\necho \"\"\necho \"Clean\
           \ up with:\"\necho \"  kubectl delete jobs american-rivers-wild-scenic-eligible-setup-bucket\
           \ american-rivers-wild-scenic-eligible-convert american-rivers-wild-scenic-eligible-pmtiles\
           \ american-rivers-wild-scenic-eligible-hex american-rivers-wild-scenic-eligible-repartition\
-          \ american-rivers-wild-scenic-eligible-workflow -n biodiversity\"\necho\
+          \ american-rivers-wild-scenic-eligible-workflow -n geo-workflows\"\necho\
           \ \"  kubectl delete configmap american-rivers-wild-scenic-eligible-yamls\
-          \ -n biodiversity\"\n"
+          \ -n geo-workflows\"\n"
         command:
         - bash
         - -c

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -126,7 +126,12 @@ def targets_from_yaml(text: str) -> set[tuple[str, str]]:
         if bucket in INFRA_BUCKETS:
             continue
         rest = rest.strip("/")
-        if not rest or rest == "raw" or rest.startswith("raw/"):
+        # Skip raw/staging inputs — never a dataset collection. `raw` may be a
+        # top-level prefix (public-census/raw/…) OR nested under a domain prefix
+        # (public-rivers/american-rivers/raw/<ds>-src.parquet, the staging layout
+        # used when re-converting an existing GeoParquet), so exclude `raw` as ANY
+        # path segment, not just the leading one.
+        if not rest or "raw" in rest.split("/"):
             continue  # bucket-level / raw inputs aren't a dataset collection
         if re.search(r"\.(tif|tiff)$", rest, re.I):
             continue  # a COG raster (`<name>-cog.tif`, `…-cog-4326.tif`, …) is an asset


### PR DESCRIPTION
## Track B (#404): reprocess 4 american-rivers line datasets for `_cng_fid` + full per-asset schemas

Continues the Track B loop (re-convert → re-hex → schema) validated on the `ira-watersheds`/`roo-cjest` pilots. These 4 federal Wild & Scenic / NRI **line** datasets lacked `_cng_fid` (converted pre-#369), so a schema-only edit couldn't make them green — the data was reprocessed first.

| collection | geometry | features | native res / parents |
|---|---|---|---|
| `american-rivers-nri-2016` | LINE | 3,213 | 8 / 0 |
| `american-rivers-nri-2024` | LINE | 4,496 | 8 / 0 |
| `american-rivers-wild-scenic-eligible` | LINE | 5,357 | 8 / 0 |
| `american-rivers-wild-scenic-designated` | LINE | 1,052 | 8 / 0 |

### What ran (per dataset, `geo-workflows` ns)
- Staged canonical `.parquet` → `raw/<ds>-src.parquet` (provenance; avoids in-place read/write).
- **Re-convert** → flat now carries `_cng_fid` (rows == distinct `_cng_fid`, unchanged counts).
- **Re-hex** res 8 / parents 0 (in-place same-h0 overwrite) + repartition → hex carries `_cng_fid` + `h8`/`h0`; distinct `_cng_fid` == feature count.
- **Regenerate PMTiles** (tiles now include `_cng_fid`).

### STAC (published to NRP S3 — not in this repo)
- Full self-describing per-asset `table:columns` on flat + hex (identical text, #303 render-dedups); collection-level block removed.
- `_cng_fid` + geom on flat; `_cng_fid` + `h8` + `h0` on hex; `h3:native_resolution=8` / `h3:parent_resolutions=[0]`; hex glob href.
- Hex asset-level per-feature-dup note + **line-buffering note** (each reach buffered by the H3 res-8 circumradius before polyfill).
- Categoricals data-validated: `NPS_Region` → 7-code enum (NER/PWR/IMR/…); `ORV`/`ORV_LIST` documented as comma-separated ORV combinations; HUC codes as fixed-width geo identifiers; `UnitCode` as an NPS unit join key.
- PMTiles lean-mirrored from the corrected GeoParquet (name+type+values + `_cng_fid`).
- License unchanged (`public-domain` + link) — federal NRI/WSR products.

### Verification
`scripts/verify-stac.py --bucket public-rivers --dataset american-rivers/<ds>` → **0 hard** for all 4 (nri-2016: 54 adv, nri-2024: 37 adv, ws-eligible: 57 adv, ws-designated: 20 adv — recall-candidate hints on descriptive text fields).

Closes the remaining american-rivers items of #404 Track B. Remaining Track B: hydrobasins, mappinginequality, overture ×2, svi ×3, wwf-ecoregions, and `roo-cjest`'s CEJST codebook schema (geoplatform.gov still DNS-blocked here).
