### PR TITLE
feat(#404): Track B reprocess wwf-ecoregions-2017 (_cng_fid + full per-asset schema)

### DIFF
--- a/catalog/ecoregion/k8s/ecoregion-convert.yaml
+++ b/catalog/ecoregion/k8s/ecoregion-convert.yaml
@@ -60,7 +60,7 @@ spec:
         - |
           set -e
           cng-convert-to-parquet \
-            /vsicurl/https://s3-west.nrp-nautilus.io/public-ecoregions/raw/ecoregions.gdb \
+            s3://public-ecoregion/raw/ecoregion-src.parquet \
             s3://public-ecoregion/ecoregion.parquet
         resources:
           requests:

--- a/catalog/ecoregion/k8s/ecoregion-hex.yaml
+++ b/catalog/ecoregion/k8s/ecoregion-hex.yaml
@@ -65,7 +65,7 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets vector --input s3://public-ecoregion/ecoregion.parquet --output s3://public-ecoregion/ecoregion/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 5 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 9,8,0
+          cng-datasets vector --input s3://public-ecoregion/ecoregion.parquet --output s3://public-ecoregion/ecoregion/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 5 --intermediate-chunk-size 10 --resolution 8 --parent-resolutions 0
         resources:
           requests:
             cpu: '4'

--- a/catalog/ecoregion/k8s/ecoregion-pmtiles.yaml
+++ b/catalog/ecoregion/k8s/ecoregion-pmtiles.yaml
@@ -63,6 +63,7 @@ spec:
         - -c
         - |
           set -e
+          ulimit -n 65536 || true   # tippecanoe opens many temp files on complex multipolygons (FD-limit fix)
           # Use optimized GeoParquet (has ID column) from convert job
           # GDAL can read parquet via vsicurl
           ogr2ogr -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-ecoregion/ecoregion.parquet -progress


### PR DESCRIPTION
## Track B (#404): reprocess wwf-ecoregions-2017 for `_cng_fid` + full per-asset schema

`wwf-ecoregions-2017` (public-ecoregion, CC-BY-4.0) lacked `_cng_fid` on its flat GeoParquet, and its **hex had a triple-`_cng_fid` corruption** (`_cng_fid`, `_cng_fid_1`, `_cng_fid_2`) from repeated in-place re-conversions. Track B reprocessing cleans both.

### What ran (`geo-workflows` ns)
- Stage canonical `ecoregion.parquet` → `raw/ecoregion-src.parquet`; **re-convert** → flat carries one clean `_cng_fid` (847 rows / 847 distinct, geometry `SHAPE` intact).
- **Re-hex** res 8 / parents 0 (170 completions, 64Gi) + repartition → **195,074,779 hex rows, 847 distinct `_cng_fid`** (all ecoregions), single clean `_cng_fid` + `h8` + `h0` + `bbox` (triple-fid gone).
- **Regenerate PMTiles** — added `ulimit -n 65536` to fix a tippecanoe *"Too many open files"* failure on the 847 complex multipolygons.

### STAC (published to NRP S3)
- Full self-describing per-asset `table:columns`: flat (19 cols: `_cng_fid` + 16 attrs + `bbox` + `SHAPE`) and hex (20 cols: same minus `SHAPE`, plus `h8`/`h0`), identical text per #303; collection-level block removed.
- `h3:native_resolution=8` / `parent_resolutions=[0]`; hex asset-level per-feature-dup note (SHAPE_Area/Length repeated per cell → dedup by `_cng_fid`).
- Categoricals data-validated vs DISTINCT: `BIOME_NUM` (1–14 WWF biome map), `NNH`/`NNH_NAME` (0–4 Nature Needs Half). Color/ID/combined-code columns given identifier/plain descriptions to clear false coded-categorical flags.

### Verification
`scripts/verify-stac.py https://…/public-ecoregion/stac-collection.json` → **0 hard, 6 advisory, EXIT 0**.

Part of #404 Track B. **Remaining Track B** (deferred, notes on issue): overture countries/counties (schema-vs-data mismatch + `admin_level` documented wrong + continent-scale countries need batched hex), mappinginequality (bucket-root hex path), hydrobasins (multi-level, bare-dir hex, proprietary), svi ×3 (no hex, ~120-col CDC authoring).
