### PR TITLE
feat(#404): Track B reprocess mappinginequality (_cng_fid + full per-asset schema)

### DIFF
--- a/catalog/mappinginequality/README.md
+++ b/catalog/mappinginequality/README.md
@@ -39,8 +39,8 @@ Other datasets may use different resolutions based on their spatial scale (e.g.,
 ### Processing Workflow
 
 The H3 hexagonal tiling follows a **two-pass approach** (matching wdpa/):
-1. **Chunking** - Process data in parallel chunks, writing to `s3://public-mappinginequality/mappinginequality/chunks/`
-2. **Repartitioning** - Consolidate all chunks into h0-partitioned format in `s3://public-mappinginequality/mappinginequality/hex/`, then delete temporary chunks/
+1. **Chunking** - Process data in parallel chunks, writing to `s3://public-mappinginequality/chunks/`
+2. **Repartitioning** - Consolidate all chunks into h0-partitioned format in `s3://public-mappinginequality/hex/`, then delete temporary chunks/
 
 This approach enables efficient parallel processing of large datasets while ensuring optimal query performance with h0 partitioning.
 
@@ -114,8 +114,8 @@ The h0 partitioning enables efficient spatial queries by limiting reads to relev
 
 - `s3://public-mappinginequality/mappinginequality.parquet` - GeoParquet
 - `s3://public-mappinginequality/mappinginequality.pmtiles` - PMTiles
-- `s3://public-mappinginequality/mappinginequality/chunks/` - Temporary H3 processing chunks (deleted after repartitioning)
-- `s3://public-mappinginequality/mappinginequality/hex/` - H3-indexed parquet (partitioned by h0)
+- `s3://public-mappinginequality/chunks/` - Temporary H3 processing chunks (deleted after repartitioning)
+- `s3://public-mappinginequality/hex/` - H3-indexed parquet (partitioned by h0)
 
 ## Cleanup and Reset
 
@@ -134,8 +134,8 @@ rclone purge nrp:public-mappinginequality
 # Or delete specific outputs:
 rclone delete nrp:public-mappinginequality/mappinginequality.parquet
 rclone delete nrp:public-mappinginequality/mappinginequality.pmtiles
-rclone purge nrp:public-mappinginequality/mappinginequality/hex/
-rclone purge nrp:public-mappinginequality/mappinginequality/chunks/  # if workflow was interrupted
+rclone purge nrp:public-mappinginequality/hex/
+rclone purge nrp:public-mappinginequality/chunks/  # if workflow was interrupted
 ```
 
 ### Complete Reset

--- a/catalog/mappinginequality/k8s/mappinginequality/configmap.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: mappinginequality-setup-bucket.yaml, mappinginequality-convert.yaml, mappinginequality-pmtiles.yaml, mappinginequality-hex.yaml, mappinginequality-repartition.yaml
+# Generation command: cng-datasets workflow --dataset mappinginequality --source-url s3://public-mappinginequality/mappinginequality.parquet --bucket public-mappinginequality --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap mappinginequality-yamls \
+#     --from-file=mappinginequality-setup-bucket.yaml \
+#     --from-file=mappinginequality-convert.yaml \
+#     --from-file=mappinginequality-pmtiles.yaml \
+#     --from-file=mappinginequality-hex.yaml \
+#     --from-file=mappinginequality-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  mappinginequality-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mappinginequality-convert
+      labels:
+        k8s-app: mappinginequality-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mappinginequality-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-mappinginequality
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-mappinginequality/mappinginequality.parquet \
+                s3://public-mappinginequality/mappinginequality.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mappinginequality-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mappinginequality-hex
+      labels:
+        k8s-app: mappinginequality-hex
+    spec:
+      completions: 60
+      parallelism: 30
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mappinginequality-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-mappinginequality
+            - name: DATASET
+              value: mappinginequality
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-mappinginequality/mappinginequality.parquet --output s3://public-mappinginequality/mappinginequality/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mappinginequality-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mappinginequality-pmtiles
+      labels:
+        k8s-app: mappinginequality-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mappinginequality-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-mappinginequality
+            - name: DATASET
+              value: mappinginequality
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-mappinginequality/mappinginequality.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-mappinginequality/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mappinginequality-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mappinginequality-repartition
+      labels:
+        k8s-app: mappinginequality-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mappinginequality-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-mappinginequality
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-mappinginequality/mappinginequality/chunks --output-dir s3://public-mappinginequality/mappinginequality/hex --source-parquet s3://public-mappinginequality/mappinginequality.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mappinginequality-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mappinginequality-setup-bucket
+      labels:
+        k8s-app: mappinginequality-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mappinginequality-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-mappinginequality
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mappinginequality-yamls
+  namespace: geo-workflows

--- a/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-convert.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-convert.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mappinginequality-convert
+  labels:
+    k8s-app: mappinginequality-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mappinginequality-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-mappinginequality
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Re-convert from the staged pre-_cng_fid provenance copy (raw/) so we never
+          # read+write the same key. Adds the row-unique universal _cng_fid (#369),
+          # preserving the legacy fid + geometry. Track B (#404).
+          cng-convert-to-parquet \
+            s3://public-mappinginequality/raw/mappinginequality-src.parquet \
+            s3://public-mappinginequality/mappinginequality.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-hex.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mappinginequality-hex
+  labels:
+    k8s-app: mappinginequality-hex
+spec:
+  completions: 60
+  parallelism: 30
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mappinginequality-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-mappinginequality
+        - name: DATASET
+          value: mappinginequality
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-mappinginequality/mappinginequality.parquet --output s3://public-mappinginequality/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-pmtiles.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-pmtiles.yaml
@@ -1,0 +1,103 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mappinginequality-pmtiles
+  labels:
+    k8s-app: mappinginequality-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mappinginequality-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-mappinginequality
+        - name: DATASET
+          value: mappinginequality
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-mappinginequality/mappinginequality.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          # Preserve the published source-layer name `redlining` (NOT $DATASET) so
+          # existing MapLibre consumers keyed on source-layer:"redlining" keep working.
+          tippecanoe -o /tmp/$DATASET.pmtiles -l redlining --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-mappinginequality/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-repartition.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mappinginequality-repartition
+  labels:
+    k8s-app: mappinginequality-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mappinginequality-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-mappinginequality
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-mappinginequality/chunks --output-dir s3://public-mappinginequality/hex --source-parquet s3://public-mappinginequality/mappinginequality.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-setup-bucket.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/mappinginequality-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mappinginequality-setup-bucket
+  labels:
+    k8s-app: mappinginequality-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mappinginequality-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-mappinginequality
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/mappinginequality/k8s/mappinginequality/workflow-rbac.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/mappinginequality/k8s/mappinginequality/workflow.yaml
+++ b/catalog/mappinginequality/k8s/mappinginequality/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mappinginequality-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting mappinginequality workflow...\"\n\n# Step 0:\
+          \ Setup bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/mappinginequality-setup-bucket.yaml -n geo-workflows\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/mappinginequality-setup-bucket -n geo-workflows\n\n\
+          # Step 1: Convert to optimized GeoParquet (needed by both pmtiles and hex\
+          \ jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\nkubectl\
+          \ apply -f /yamls/mappinginequality-convert.yaml -n geo-workflows\n\necho\
+          \ \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/mappinginequality-convert -n geo-workflows\n\n# Step\
+          \ 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/mappinginequality-pmtiles.yaml -n geo-workflows\n\
+          kubectl apply -f /yamls/mappinginequality-hex.yaml -n geo-workflows\n\n\
+          echo \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/mappinginequality-hex -n geo-workflows\n\necho \"\
+          Step 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/mappinginequality-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/mappinginequality-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs mappinginequality-setup-bucket\
+          \ mappinginequality-convert mappinginequality-pmtiles mappinginequality-hex\
+          \ mappinginequality-repartition mappinginequality-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap mappinginequality-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mappinginequality-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
## Track B item: `mappinginequality` (HOLC redlining)

Continues #404 Track B (re-convert → [re-hex] → schema). Data-backed `verify-stac.py` passes **0 hard** against live S3.

### What changed
- **Data:** re-converted the flat GeoParquet from a staged `raw/` provenance copy → adds the universal `_cng_fid` (#369), preserving `fid` + geometry. Regenerated PMTiles so tiles carry `_cng_fid`.
- **No re-hex needed:** the existing hex already carried `_cng_fid` with `_cng_fid == fid` on every row, and the re-converted flat reproduces `_cng_fid == fid` identically (10,154/10,154, 0 mismatches) — so flat↔hex are already consistent and the correct hex was left untouched.
- **STAC:** full self-describing per-asset `table:columns` on flat (15) + hex (18) with identical shared text (#303 contract); collection-level block removed; hex asset-level per-feature-dup note; `h3:native_resolution=10` / `parent_resolutions=[9,8,0]`; bucket-root hex glob href; PMTiles lean-mirrored (17 fields incl `_cng_fid`; `geom_bbox` struct flattened by ogr2ogr into `geom_bbox.{xmin,ymin,xmax,ymax}`). `grade` `values` = exact ingested set incl dirty trailing-space variants (`'A '`,`'C '`) — data-backed check green.

### Correctness fixes (#294 class)
- Collection desc wrongly said `category` "duplicates grade" — it is the surveyor's **free-text** description (hundreds of distinct verbatim strings), distinct from the standardized `grade`.
- `geom_bbox` corrected from "binary (WKB)" to the actual `STRUCT(xmin,ymin,xmax,ymax)`.

### Path preservation
Hex/flat/pmtiles stay at **bucket-root** (`public-mappinginequality/hex/`, not the tool-standard `mappinginequality/hex/`) to match the layout the canonical `examples.qmd` reads and the currently published tiles. Recipe hex/repartition YAMLs and the README were corrected to bucket-root accordingly. PMTiles source-layer `redlining` preserved.

### Verify
`scripts/verify-stac.py https://s3-west.nrp-nautilus.io/public-mappinginequality/stac-collection.json` → **0 hard**. (Note: `--bucket/--dataset` derives the nested path and 404s for this bucket-root collection; CI `--yaml` mode falls back to the bucket-root STAC and passes.)

Jobs ran in `geo-workflows`.