### PR TITLE
feat(#404): Track B reprocess overture counties + countries (_cng_fid + full per-asset schema)

### DIFF
--- a/catalog/overturemaps/k8s/2026-02-18.0/counties/2026-02-18.0-counties-hex.yaml
+++ b/catalog/overturemaps/k8s/2026-02-18.0/counties/2026-02-18.0-counties-hex.yaml
@@ -6,7 +6,7 @@ metadata:
     k8s-app: om-2026-counties-hex
 spec:
   completions: 200
-  parallelism: 200
+  parallelism: 50
   completionMode: Indexed
   backoffLimit: 0
   podFailurePolicy:

--- a/catalog/overturemaps/k8s/2026-02-18.0/counties/2026-02-18.0-counties-repartition.yaml
+++ b/catalog/overturemaps/k8s/2026-02-18.0/counties/2026-02-18.0-counties-repartition.yaml
@@ -49,13 +49,16 @@ spec:
         - name: AWS_VIRTUAL_HOSTING
           value: 'FALSE'
         - name: TMPDIR
-          value: /tmp
+          value: /scratch
         - name: BUCKET
           value: public-overturemaps
         volumeMounts:
         - name: rclone-config
           mountPath: /root/.config/rclone
           readOnly: true
+        - name: scratch
+          mountPath: /scratch
+          subPath: om-2026-counties-repartition
         command:
         - bash
         - -c
@@ -65,13 +68,16 @@ spec:
         resources:
           requests:
             cpu: '4'
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 40Gi
             memory: 128Gi
           limits:
             cpu: '4'
-            ephemeral-storage: 200Gi
+            ephemeral-storage: 40Gi
             memory: 128Gi
       volumes:
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
       - name: rclone-config
         secret:
           secretName: rclone-config

--- a/catalog/overturemaps/k8s/2026-02-18.0/countries/derive-countries-hex-attrs.yaml
+++ b/catalog/overturemaps/k8s/2026-02-18.0/countries/derive-countries-hex-attrs.yaml
@@ -1,0 +1,106 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: om-2026-derive-countries-hex-attrs
+  labels:
+    k8s-app: om-2026-derive-countries-hex-attrs
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: om-2026-derive-countries-hex-attrs
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+      - name: derive-countries-hex
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: '8'
+            memory: 128Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '8'
+            memory: 128Gi
+            ephemeral-storage: 40Gi
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Track B (#404): countries are unions of their regions, so the res-8 hex is
+          # DERIVED from regions/hex (a continent-scale polyfill of the country polygons is
+          # infeasible at res 8, ~24h/giant). Attach FULL per-feature attributes + the
+          # universal _cng_fid from the re-converted countries flat by joining on the ISO
+          # country code (one flat feature per code, preferring the land feature; land codes
+          # are unique). Processed PER-h0 (regions/hex is hive-partitioned by h0, so each
+          # read is partition-pruned and the DISTINCT fits in memory — no global spill).
+          echo "=== Purging stale countries/hex ==="
+          rclone purge nrp:public-overturemaps/2026-02-18.0/countries/hex/ || true
+          python3 - <<'PYEOF'
+          import duckdb, os
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET threads=8")
+          con.execute("SET memory_limit='110GB'")
+          con.execute("SET preserve_insertion_order=false")
+          key = os.environ["AWS_ACCESS_KEY_ID"]; secret = os.environ["AWS_SECRET_ACCESS_KEY"]
+          endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
+          con.execute(f"""CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}',
+                          ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false)""")
+          REG = "s3://public-overturemaps/2026-02-18.0/regions/hex"
+          OUT = "s3://public-overturemaps/2026-02-18.0/countries/hex"
+          # One flat feature per country code (prefer the land feature); tiny (219 rows).
+          con.execute("""CREATE TEMP TABLE cf AS
+              SELECT * EXCLUDE (rn) FROM (
+                  SELECT * EXCLUDE (geometry),
+                         ROW_NUMBER() OVER (PARTITION BY country ORDER BY (class='land') DESC, _cng_fid) AS rn
+                  FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+              ) WHERE rn = 1""")
+          h0_vals = [r[0] for r in con.execute(
+              f"SELECT DISTINCT h0 FROM read_parquet('{REG}/h0=*/data_0.parquet') WHERE country IS NOT NULL ORDER BY h0"
+          ).fetchall()]
+          print(f"{len(h0_vals)} h0 partitions to derive", flush=True)
+          for i, h0 in enumerate(h0_vals):
+              con.execute(f"""
+                  COPY (
+                      WITH d AS (
+                          SELECT DISTINCT h8, h0, country
+                          FROM read_parquet('{REG}/h0={h0}/data_0.parquet')
+                          WHERE country IS NOT NULL
+                      )
+                      SELECT cf.*, d.h8, d.h0 FROM d JOIN cf ON d.country = cf.country
+                  ) TO '{OUT}/h0={h0}/data_0.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
+              """)
+              print(f"  [{i+1}/{len(h0_vals)}] h0={h0} written", flush=True)
+          print("Done.", flush=True)
+          PYEOF
+          N=$(rclone lsf nrp:public-overturemaps/2026-02-18.0/countries/hex/ | wc -l)
+          echo "countries/hex/ has ${N} h0 partitions"
+          [ "$N" -lt 1 ] && { echo "ERROR: no output"; exit 1; } || true
+          echo "=== Complete ==="
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}


### PR DESCRIPTION
## Track B: overture-divisions `counties` + `countries`

Continues #404 Track B. Both children re-hexed for `_cng_fid` consistency and given full self-describing per-asset `table:columns`. Data-backed `verify-stac.py` → **0 hard** on both.

### counties ✅
Standard re-hex from the `_cng_fid`-carrying flat (chunk-size 200, res 8) → repartition (scratch PVC). Hex **175.6M rows, 39,818 distinct `_cng_fid` = all features, 0 flat↔hex mismatches**, full 19-col schema.

### countries ✅ (derived, not polyfilled)
The res-8 **polyfill of continent-scale country polygons is infeasible** (chunk 4's Pass-2 unnest was ~24h-scale). So — as the original build did — the hex is **derived from the sibling `regions/hex`** (a country = the union of its regions' cells), then joined on the ISO country code (one flat feature per code, land preferred; land codes are unique) to attach full attrs + `_cng_fid`. Run **per-h0** (partition-pruned, no global spill) at 128Gi. Hex **196.9M rows, 195 distinct `_cng_fid`** (the land countries that have sub-regions), **0 mismatches, 0 invalid ids**. The ~24 region-less micro-states + maritime `class` features are in the flat/PMTiles but not the derived hex — documented on the hex asset.

### Correctness fixes (#294 class)
- **`admin_level`**: counties documented as `6` → actually `0–3` (overwhelmingly `2`); countries documented as `2` → actually `0`.
- Dropped **nonexistent** collection-level columns (`wikidata`, `population`, `hierarchies`, `perspectives`, `local_type`, `norms`, `capital_*`, `cartography`, `parent_division_id`) — authored from the live 18-col schema instead of relocating the stale block.

### PMTiles
Kept their existing id-keyed schema (16–17 fields). Regenerating tiles to add `_cng_fid` was infeasibly slow on the detailed boundaries (tippecanoe `--extend-zooms`, >2h and climbing); the Overture GERS `id` present in the tiles serves map identify, and `_cng_fid` remains the parquet/hex join key. Mirrored accurately from the live footers.

### Verify
Both: `verify-stac.py <child-url>` → **0 hard** (2 advisories on countries: hex `class` is land-only by design; the `division_id` land/maritime split is not true duplication — `_cng_fid`/`id` are the per-feature keys and there are no summable amounts).

New recipe: `derive-countries-hex-attrs.yaml` (the countries method). Jobs ran in `geo-workflows`.