### PR TITLE
feat(#404): Track B reprocess hydrobasins-v1c (_cng_fid + full per-asset schema)

### DIFF
--- a/catalog/hydrobasins/k8s/hydrobasins-l3-hex-attrs.yaml
+++ b/catalog/hydrobasins/k8s/hydrobasins-l3-hex-attrs.yaml
@@ -1,0 +1,90 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hydrobasins-l3-hex-attrs
+  labels:
+    k8s-app: hydrobasins-l3-hex-attrs
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: hydrobasins-l3-hex-attrs
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+      - name: l3-hex-attrs
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Track B (#404): attach the universal _cng_fid + FULL HydroBASINS attributes to the
+          # existing (spatially-correct) L3 hex by joining on HYBAS_ID to the reconverted L3
+          # flat — NO re-hex (large L3 basins are costly to polyfill at res 8, and the geometry
+          # -> cell mapping is already correct). Written PER-h0 to a staging dir, then swapped
+          # into the bucket-root L3/ path (preserved) so we never read+write the same key.
+          python3 - <<'PYEOF'
+          import duckdb, os
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET threads=8"); con.execute("SET memory_limit='52GB'")
+          con.execute("SET preserve_insertion_order=false")
+          key=os.environ["AWS_ACCESS_KEY_ID"]; secret=os.environ["AWS_SECRET_ACCESS_KEY"]
+          ep=os.environ.get("AWS_S3_ENDPOINT","rook-ceph-rgw-nautiluss3.rook")
+          con.execute(f"""CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}',
+                          ENDPOINT '{ep}', URL_STYLE 'path', USE_SSL false)""")
+          HEX="s3://public-hydrobasins/L3"
+          STG="s3://public-hydrobasins/L3-staging"
+          FLAT="s3://public-hydrobasins/level_03.parquet"
+          # full flat attrs (incl _cng_fid), geometry excluded
+          con.execute(f"CREATE TEMP TABLE cf AS SELECT * EXCLUDE (geometry) FROM read_parquet('{FLAT}')")
+          h0_vals=[r[0] for r in con.execute(
+              f"SELECT DISTINCT h0 FROM read_parquet('{HEX}/h0=*/data_0.parquet') ORDER BY h0").fetchall()]
+          print(f"{len(h0_vals)} h0 partitions", flush=True)
+          for i,h0 in enumerate(h0_vals):
+              con.execute(f"""
+                  COPY (
+                      WITH h AS (SELECT DISTINCT HYBAS_ID, h8, h0
+                                 FROM read_parquet('{HEX}/h0={h0}/data_0.parquet'))
+                      SELECT cf.*, h.h8, h.h0 FROM h JOIN cf ON h.HYBAS_ID = cf.HYBAS_ID
+                  ) TO '{STG}/h0={h0}/data_0.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
+              """)
+              print(f"  [{i+1}/{len(h0_vals)}] h0={h0}", flush=True)
+          print("Join done.", flush=True)
+          PYEOF
+          echo "=== Swapping L3-staging -> L3 ==="
+          rclone purge nrp:public-hydrobasins/L3/
+          rclone move nrp:public-hydrobasins/L3-staging/ nrp:public-hydrobasins/L3/ --transfers 16
+          N=$(rclone lsf nrp:public-hydrobasins/L3/ | wc -l)
+          echo "L3/ now has ${N} h0 partitions"
+          [ "$N" -lt 1 ] && { echo "ERROR: empty"; exit 1; } || true
+          echo "=== Complete ==="
+        resources:
+          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 20Gi}
+          limits: {cpu: '8', memory: 64Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}

--- a/catalog/hydrobasins/k8s/hydrobasins-reconvert-flats.yaml
+++ b/catalog/hydrobasins/k8s/hydrobasins-reconvert-flats.yaml
@@ -1,0 +1,66 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hydrobasins-reconvert-flats
+  labels:
+    k8s-app: hydrobasins-reconvert-flats
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: hydrobasins-reconvert-flats
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+      - name: reconvert
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Track B (#404): add the universal _cng_fid to the documented HydroBASINS flats
+          # (L1/L3/L4) + L5/L6 (so their pmtiles have documented sibling flats). Stage each
+          # to raw/ once (never re-stage a reconverted file) so we never read+write one key.
+          for L in 01 03 04 05 06; do
+            SRC="nrp:public-hydrobasins/raw/level_${L}-src.parquet"
+            if ! rclone lsf "$SRC" >/dev/null 2>&1 || [ -z "$(rclone lsf "$SRC" 2>/dev/null)" ]; then
+              echo "Staging level_${L} -> raw/"
+              rclone copyto "nrp:public-hydrobasins/level_${L}.parquet" "$SRC"
+            else
+              echo "raw/level_${L}-src.parquet already staged"
+            fi
+            echo "Reconverting level_${L} (adds _cng_fid)..."
+            cng-convert-to-parquet \
+              "s3://public-hydrobasins/raw/level_${L}-src.parquet" \
+              "s3://public-hydrobasins/level_${L}.parquet" \
+              --row-group-size 2000
+          done
+          echo "=== All flats reconverted ==="
+        resources:
+          requests: {cpu: '4', memory: 16Gi}
+          limits: {cpu: '4', memory: 16Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}


### PR DESCRIPTION
## Track B: `hydrobasins-v1c`

Continues #404 Track B. Data-backed `verify-stac.py` → **0 hard** (9 advisories = shared-superset `values-extra`; see below).

### Data
- **Reconvert flats** L1/L3/L4 (documented) **+ added L5/L6** flat assets (their PMTiles were orphaned with no sibling flat) → each gains the universal `_cng_fid` (staged via `raw/`).
- **L3 hex — no rehex.** The res-8 polyfill of large L3 basins is costly and the existing 180M-row hex is spatially correct, so I attached `_cng_fid` + full attrs by **joining the existing hex to the reconverted L3 flat on `HYBAS_ID`** (per-h0, staging→swap to preserve the bucket-root `L3/` path). Validated: **180,375,500 rows, 291 distinct `_cng_fid`, 0 mismatches**.

### STAC
Full self-describing per-asset `table:columns` (flat + hex identical, #303) on L1/L3/L4/L5/L6 flats + L3 hex; collection-level block removed; `h3:native_resolution=8`/`parent_resolutions=[0]`; **L3 hex href fixed** from bare-dir `L3/` → `L3/h0=*/data_0.parquet`; hex asset-level per-feature-dup note (`SUB_AREA`/`UP_AREA` repeated per cell — never SUM on hex); PMTiles re-mirrored with `values`.

### Coded columns — authored from the HydroSHEDS `HydroBASINS_TechDoc_v1c` attribute table (not guessed)
- **`ENDO`** {0=not part, 1=part, 2=sink of an endorheic basin} — **corrects a previously-swapped 1/2 reading**.
- **`COAST`** {0=no, 1=yes}.
- **`ORDER`** = classical river order {0=coastal conglomerate, 1=main stem, 2–5=nth-order tributaries}.

Shared superset `values` across levels → coarse levels (e.g. L1 has only ENDO=0/ORDER=0) emit harmless `values-extra` advisories.

### Notes
- License unchanged (`proprietary` + HydroSHEDS link; Class-2 public-bucket/MinIO-only, excluded from source.coop).
- **Out of #404 scope** (recorded on the issue): the bucket also holds level_02 + level_07–12 flats and L4/L5/L6 hex dirs the STAC never exposed — documenting those is a separate STAC-completeness task.
- Jobs ran in `geo-workflows`. New recipes: `hydrobasins-reconvert-flats.yaml`, `hydrobasins-l3-hex-attrs.yaml`.