### PR TITLE
feat(#404): Track B reprocess svi-2000/2010/2020 (_cng_fid + full CDC-dictionary schema)

### DIFF
--- a/catalog/social-vulnerability/k8s/svi-reconvert-flats.yaml
+++ b/catalog/social-vulnerability/k8s/svi-reconvert-flats.yaml
@@ -1,0 +1,66 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: svi-reconvert-flats
+  labels:
+    k8s-app: svi-reconvert-flats
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: svi-reconvert-flats
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      containers:
+      - name: reconvert
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Track B (#404): add the universal _cng_fid to the SVI 2000/2010/2020 county+tract
+          # flats. Stage each to raw/ once (never re-stage a reconverted file).
+          for YR in 2000 2010 2020; do
+            for GEO in county tract; do
+              F="SVI${YR}_US_${GEO}.parquet"
+              SRC="nrp:public-social-vulnerability/${YR}/raw/${F%.parquet}-src.parquet"
+              if ! rclone lsf "$SRC" >/dev/null 2>&1 || [ -z "$(rclone lsf "$SRC" 2>/dev/null)" ]; then
+                echo "Staging ${YR}/${F} -> raw/"
+                rclone copyto "nrp:public-social-vulnerability/${YR}/${F}" "$SRC"
+              fi
+              echo "Reconverting ${YR}/${F} (adds _cng_fid)..."
+              cng-convert-to-parquet \
+                "s3://public-social-vulnerability/${YR}/raw/${F%.parquet}-src.parquet" \
+                "s3://public-social-vulnerability/${YR}/${F}" \
+                --row-group-size 2000
+            done
+          done
+          echo "=== All 6 SVI flats reconverted ==="
+        resources:
+          requests: {cpu: '4', memory: 16Gi}
+          limits: {cpu: '4', memory: 16Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}


### PR DESCRIPTION
## Track B: `svi-2000`, `svi-2010`, `svi-2020`

Continues #404 Track B. The three older CDC/ATSDR SVI year-collections (county + tract flats, no hex) lacked `_cng_fid` and `table:columns` (collection-level documented only 8 of ~82–161 columns). Data-backed `verify-stac.py` → **0 hard** on all three.

### Data
Reconverted all 6 flats (county+tract × 2000/2010/2020) → each gains the row-unique `_cng_fid` (staged via `raw/`).

### Schema — authored per-era from the CDC/ATSDR SVI documentation (fetched + parsed, **not guessed**)
The three versions use **different** variable schemes:
- **2020** (161 cols): modern `E_`/`M_`/`EP_`/`MP_`/`EPL_`/`F_` per variable + `SPL_`/`RPL_`/`F_` per theme.
- **2010** (tract 111 / county 104): mixed **ACS** (`E_`/`M_`/`E_P_`/`M_P_`/`E_PL_`) + **decennial SF1** (bare count / `P_` proportion / `PL_` percentile); handles the county `F_PLSNGPRNT` typo column.
- **2000** (tract 83 / county 81): Group/Variable `G#V#` codes (`N`=count, `R`=proportion) + `USG#V#P` percentile / `USG#V#F` flag / `USG#T#` theme / `UST#` overall — decoded from `SVI2000Documentation`.

### Correctness details
- Full self-describing per-asset `table:columns` (county+tract identical, #303); collection-level blocks removed; PMTiles re-mirrored.
- Coded `F_` flags carry `values`: 2020/2010 include the **-999 missing sentinel** actually present in the data; 2000 flags are `0/1`. The `-999` sentinel is documented on estimate/percentile columns.
- Theme membership taken from each doc (e.g. 2020 T1 = POV150/UNEMP/HBURD/NOHSDP/UNINSUR, verified via `SPL_THEME1`). PCI (2010/2000) documented as **inversely** related to vulnerability.
- License unchanged (`public-domain` + link).

### Verify
All three: `verify-stac.py <year-url>` → **0 hard** (advisories: the `F_*THEME*`/`*TF` columns are genuine flag *counts*, not coded domains). Jobs ran in `geo-workflows`. Recipe: `svi-reconvert-flats.yaml`.

Note: svi-2022 is handled separately under #407 (structural reshape), not here.