### PR TITLE
feat(#425): GBIF dataset→publisher sidecar + colonial-provenance map recipe

### DIFF
--- a/catalog/gbif/2026-06/gbif-2026-06-publishers.yaml
+++ b/catalog/gbif/2026-06/gbif-2026-06-publishers.yaml
@@ -1,0 +1,103 @@
+# GBIF 2026-06 — dataset → publisher lookup sidecar (data-workflows #425).
+# Tiny crosswalk: one row per GBIF dataset mapping dataset_key -> publishing_country
+# (+ org / license / type / counts), so occurrences can be attributed to a publishing
+# country by joining the hex's `datasetkey` column WITHOUT a slow external read_csv
+# mid-query. Registry snapshot is pinned to the 2026-06 release. Mirrors the species
+# sidecar (gbif-2026-06-sidecar.yaml). Reads the registry over https, writes S3 internal.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gbif-2026-06-publishers
+  namespace: geo-workflows
+  labels:
+    k8s-app: gbif-2026-06-publishers
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: gbif-2026-06-publishers
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: build-publishers
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {cpu: "2", memory: 8Gi, ephemeral-storage: 5Gi}
+          limits:   {cpu: "2", memory: 8Gi, ephemeral-storage: 10Gi}
+        env:
+        - name: REGISTRY_TSV
+          value: 'https://api.gbif.org/v1/dataset/search/export?format=TSV&'
+        - name: DST
+          value: 's3://public-gbif/2026-06/dataset-publishers.parquet'
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # Download the registry export to a local file first. DuckDB httpfs stalls on this
+          # endpoint (chunked, no content-length); curl streams it fine.
+          curl -sSL --retry 5 --retry-delay 5 -o /tmp/datasets.tsv "$REGISTRY_TSV"
+          wc -l /tmp/datasets.tsv
+          python3 - <<'PYEOF'
+          import duckdb, os
+          dst=os.environ["DST"]
+          key=os.environ["AWS_ACCESS_KEY_ID"]; secret=os.environ["AWS_SECRET_ACCESS_KEY"]
+          endpoint=os.environ.get("AWS_S3_ENDPOINT","rook-ceph-rgw-nautiluss3.rook")
+          con=duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute(f"CREATE SECRET s3_secret (TYPE S3, KEY_ID '{key}', SECRET '{secret}', ENDPOINT '{endpoint}', URL_STYLE 'path', USE_SSL false)")
+          # One row per GBIF dataset. all_varchar keeps the registry TSV robust to odd rows;
+          # occurrence_records_count is cast to BIGINT for numeric use downstream.
+          con.execute(f"""
+              COPY (
+                  SELECT dataset_key,
+                         doi,
+                         license,
+                         type,
+                         publishing_organization_key,
+                         publishing_organization_title,
+                         publishing_country,
+                         hosting_country,
+                         TRY_CAST(occurrence_records_count AS BIGINT) AS occurrence_records_count
+                  FROM read_csv('/tmp/datasets.tsv', delim='\t', header=true,
+                                all_varchar=true, ignore_errors=true)
+                  WHERE dataset_key IS NOT NULL
+                  -- GBIF's export lists a few datasets twice (byte-identical rows, e.g. one
+                  -- PANGAEA dataset); keep one row per key so the join is unambiguous.
+                  QUALIFY ROW_NUMBER() OVER (
+                      PARTITION BY dataset_key
+                      ORDER BY occurrence_records_count DESC NULLS LAST) = 1
+              ) TO '{dst}' (FORMAT PARQUET, COMPRESSION ZSTD)
+          """)
+          n, dk, pc = con.execute(
+              f"SELECT COUNT(*), COUNT(DISTINCT dataset_key), "
+              f"COUNT(*) FILTER (WHERE publishing_country IS NOT NULL) "
+              f"FROM read_parquet('{dst}')").fetchone()
+          print(f"  publishers rows={n} distinct_dataset_key={dk} with_publishing_country={pc}")
+          assert n > 50000, "publisher table suspiciously small"
+          assert n == dk, "dataset_key not unique"
+          print("  OK")
+          PYEOF

--- a/catalog/gbif/colonial-provenance-maps.md
+++ b/catalog/gbif/colonial-provenance-maps.md
@@ -1,0 +1,93 @@
+# GBIF colonial-provenance hex maps (geo-agent directions)
+
+Reproduce the "who published this biodiversity data" maps from **Faxon & Chapman 2025,
+*Beyond spatial bias*** (ERL [10.1088/1748-9326/add6b6](https://iopscience.iop.org/article/10.1088/1748-9326/add6b6);
+code: [milliechapman/colonial-patterns-gbif](https://github.com/milliechapman/colonial-patterns-gbif))
+as a hex layer in the GeoAgent Map panel.
+
+## Method
+
+For each hex cell, compare **where an occurrence was collected** to **where it was published**:
+
+- **where collected** = the occurrence `countrycode` column
+- **where published** = `datasetkey` joined to the GBIF dataset registry → `publishing_country`
+
+The original study did `count(countrycode, year, datasetkey)` over the occurrences and
+left-joined the GBIF dataset-registry export
+(`https://api.gbif.org/v1/dataset/search/export?format=TSV`) on `datasetkey` to attach
+`publishing_country`. Our hex already retains `datasetkey`, so it reproduces directly — no
+re-ingest, and no need for a per-occurrence `publishingcountry` column (which GBIF's AWS
+parquet does not have anyway).
+
+We publish the registry lookup as a **sidecar parquet pinned to the 2026-06 snapshot**
+(`dataset-publishers.parquet`, data-workflows #425), so the join is local and fast — no
+external API call mid-query.
+
+## Step 1 — publisher lookup (dataset → publishing country)
+
+```sql
+-- sidecar: local, pinned to the 2026-06 registry snapshot (built by gbif-2026-06-publishers.yaml)
+read_parquet('s3://public-gbif/2026-06/dataset-publishers.parquet')
+-- columns used: dataset_key, publishing_country
+```
+
+## Step 2 — aggregate the GBIF hex at a display resolution (h5)
+
+```sql
+WITH pub AS (
+  SELECT dataset_key AS datasetkey, publishing_country
+  FROM read_parquet('s3://public-gbif/2026-06/dataset-publishers.parquet')
+)
+SELECT g.h5,
+       COUNT(*)                                                        AS n_total,
+       COUNT(*) FILTER (WHERE p.publishing_country != g.countrycode)   AS n_foreign,
+       COUNT(*) FILTER (WHERE p.publishing_country != g.countrycode)::DOUBLE
+         / COUNT(*)                                                    AS frac_foreign
+FROM read_parquet('s3://public-gbif/2026-06/hex/h0=*/data_0.parquet', hive_partitioning=true) g
+JOIN pub p USING (datasetkey)
+WHERE g.countrycode IS NOT NULL AND p.publishing_country IS NOT NULL
+  AND NOT list_has_any(g.issue,
+      ['ZERO_COORDINATE','COORDINATE_INVALID','COORDINATE_OUT_OF_RANGE','COUNTRY_COORDINATE_MISMATCH'])
+GROUP BY g.h5
+```
+
+## Step 3 — render
+
+Register the result as hex tiles (key column `h5`, value `frac_foreign`) via the
+`register_hex_tiles` pattern documented in the `query` tool response, then `add_layer` with a
+sequential color ramp: **0 = published locally → 1 = entirely foreign-published**.
+
+## Variant — a specific colonial power
+
+To reproduce their per-empire panels (e.g. Britain), map the fraction of each cell's records
+published by one country:
+
+```sql
+WITH pub AS (
+  SELECT dataset_key AS datasetkey, publishing_country
+  FROM read_parquet('s3://public-gbif/2026-06/dataset-publishers.parquet')
+)
+SELECT g.h5,
+       COUNT(*)                                                       AS n_total,
+       COUNT(*) FILTER (WHERE p.publishing_country = 'GB')            AS n_gb,
+       COUNT(*) FILTER (WHERE p.publishing_country = 'GB')::DOUBLE
+         / COUNT(*)                                                   AS frac_gb
+FROM read_parquet('s3://public-gbif/2026-06/hex/h0=*/data_0.parquet', hive_partitioning=true) g
+JOIN pub p USING (datasetkey)
+WHERE g.countrycode IS NOT NULL AND g.countrycode != p.publishing_country   -- exclude in-country
+  AND NOT list_has_any(g.issue,
+      ['ZERO_COORDINATE','COORDINATE_INVALID','COORDINATE_OUT_OF_RANGE','COUNTRY_COORDINATE_MISMATCH'])
+GROUP BY g.h5
+```
+
+## Notes
+
+- Resolution: `h5` is a reasonable global default; use `h4`/`h3` for a cleaner whole-globe
+  view, `h6` for regional zoom-ins. All are present as parent columns on the hex.
+- `countrycode` is the occurrence locality attribute (used here to match the paper). For a
+  strict spatial clip to a country, semi-join on `h8` against the Overture divisions hex
+  instead (see the GBIF collection description).
+- The `issue` filter drops GBIF coordinate noise (a lat=-90 smear etc.); always applied
+  before hex rendering.
+- The publisher sidecar also carries `publishing_organization_title`, `license`, `type`, and
+  `occurrence_records_count` for richer provenance queries (e.g. group by publishing org).

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -925,6 +925,8 @@ def recall_pass(doc: dict, mcp: MCPClient) -> list[Finding]:
         s3 = _to_s3(asset.get("href", ""))
         if not s3:
             continue
+        # Collect this asset's candidate columns, then probe them all in ONE scan.
+        candidates = []
         for col in asset.get("table:columns", []):
             name = col.get("name", "")
             ctype = col.get("type", "")
@@ -938,15 +940,32 @@ def recall_pass(doc: dict, mcp: MCPClient) -> list[Finding]:
             if (s3, name) in seen:
                 continue
             seen.add((s3, name))
-            sql = f'SELECT COUNT(DISTINCT "{name}") AS n FROM read_parquet(\'{s3}\')'
+            candidates.append(name)
+        if not candidates:
+            continue
+        # One pass over the parquet instead of one scan per column, and
+        # approx_count_distinct (HyperLogLog: single pass, constant memory) instead of
+        # exact COUNT(DISTINCT) — the latter builds a full hash set and, on billion-row
+        # datasets with a high-cardinality column (e.g. GBIF `species` ~1.4M distinct),
+        # blows the query timeout. This is an ADVISORY cardinality nudge (is it ≤ N
+        # distinct?), so HLL's ~2% error near the threshold is immaterial: a genuine
+        # small categorical still reads small, a high-cardinality column still reads huge.
+        cols_sql = ", ".join(
+            f'approx_count_distinct("{n}") AS "{n}"' for n in candidates)
+        sql = f"SELECT {cols_sql} FROM read_parquet('{s3}')"
+        try:
+            rows = mcp.query(sql)
+            row = rows[0] if rows else {}
+        except (MCPError, ValueError, KeyError, IndexError):
+            continue
+        for name in candidates:
             try:
-                rows = mcp.query(sql)
-                n = int(rows[0]["n"]) if rows else None
-            except (MCPError, ValueError, KeyError, IndexError):
+                n = int(row[name])
+            except (KeyError, ValueError, TypeError):
                 continue
-            if n is not None and 2 <= n <= RECALL_MAX_DISTINCT:
+            if 2 <= n <= RECALL_MAX_DISTINCT:
                 out.append(Finding(ADVISORY, "recall-candidate-categorical",
-                                   f"asset '{key}' column '{name}' has {n} distinct values "
+                                   f"asset '{key}' column '{name}' has ~{n} distinct values "
                                    f"and no `values` array — possible undocumented "
                                    f"categorical (recall-gap check)."))
     return out


### PR DESCRIPTION
Closes #425.

## What

Adds a **dataset → publisher lookup sidecar** to the GBIF 2026-06 collection so occurrences can be attributed to a **publishing country** (Faxon & Chapman 2025 colonial-legacy method) by joining the hex's existing `datasetkey` column — no re-ingest, no external API call mid-query.

- `catalog/gbif/2026-06/gbif-2026-06-publishers.yaml` — geo-workflows build job: curl the GBIF registry export (pinned to the 2026-06 snapshot), dedup by `dataset_key`, write `s3://public-gbif/2026-06/dataset-publishers.parquet` over the internal endpoint.
- `catalog/gbif/colonial-provenance-maps.md` — geo-agent recipe to build the hex maps (fraction of each cell's observations published by a foreign country / a specific colonial power).
- STAC `gbif-dataset-publishers-2026-06` asset + a 'Publisher provenance' join hint on the collection description — published to `s3://public-gbif/stac-collection.json`.
- `scripts/verify-stac.py` — **recall-pass timeout fix** (see below).

## Results / validation

- **123,210** datasets, `dataset_key` unique, all with `publishing_country`.
- Occurrence-weighted join coverage against the 3.5 B-row hex: **99.997%** (~113k unmatched).
- ~28% of occurrences are foreign-published (969 M) — sensible provenance signal.
- `scripts/verify-stac.py --bucket public-gbif` (full, **incl. recall**) → **0 hard findings** in ~17 s. CI `verify` green.

## verify-stac recall-pass fix

The advisory recall pass ran an exact `COUNT(DISTINCT col)` as a **separate full scan per candidate column**. On the 3.5 B-row GBIF hex, a high-cardinality column (`species` ~1.4 M distinct) makes exact distinct build a huge hash set and blow the 300 s query timeout — failing the whole gate on a check that is only advisory. Fix: batch an asset's candidate columns into **one scan** and use **`approx_count_distinct`** (HyperLogLog, single pass, constant memory). It's a cardinality nudge (≤ 40 distinct?), so HLL's ~2% error near the threshold is immaterial. Timeout → ~17 s, integrity preserved.

## Notes

- The build hit a DuckDB `httpfs` stall on the GBIF export endpoint (chunked, no content-length); the job `curl`s the TSV to a local file first, then `read_csv`.
- `get_stac_details` may show a cached collection for a short TTL; the live S3 STAC is correct.