### PR TITLE
Add well-formed .zenodo.json for DOI minting

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,8 +11,9 @@
       "orcid": "0000-0002-1642-628X"
     },
     {
-      "name": "Buhler, Cassie",
-      "affiliation": "University of California, Berkeley"
+      "name": "Buhler, Cassidy Kim",
+      "orcid": "0000-0003-4157-4273",
+      "affiliation": "University of Colorado Boulder"
     }
   ],
   "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,27 @@
+{
+  "title": "Agentic Data Workflows: cloud-native, AI-ready data preparation on Kubernetes",
+  "description": "Dataset processing workflows that turn disparate legacy and proprietary data into AI-ready, cloud-native data with rich STAC metadata — through an AI-driven pipeline powered by cng-datasets and autoscaled on NRP Kubernetes. One of three open-source components that make the cloud-native data stack reachable by the AI tools researchers already use.",
+  "license": "bsd-3-clause",
+  "upload_type": "software",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Boettiger, Carl",
+      "affiliation": "University of California, Berkeley",
+      "orcid": "0000-0002-1642-628X"
+    },
+    {
+      "name": "Buhler, Cassie",
+      "affiliation": "University of California, Berkeley"
+    }
+  ],
+  "keywords": [
+    "cloud-native",
+    "AI-ready data",
+    "STAC",
+    "Kubernetes",
+    "agentic workflows",
+    "data engineering",
+    "geospatial"
+  ]
+}


### PR DESCRIPTION
Adds a `.zenodo.json` so a GitHub release mints a correct Zenodo DOI with proper metadata (title, description, authors + ORCID, keywords).

Formed to avoid the two failure modes we hit elsewhere:
- **license** uses the lowercase SPDX id `"bsd-3-clause"` (Zenodo's InvenioRDM vocabulary rejects the capitalized `BSD-3-Clause` with HTTP 400);
- **no `grants` block** (an unresolvable funder award rejects the whole deposit).

Metadata mirrors the repo's existing `CITATION.cff` (software license BSD-3-Clause). Only `.zenodo.json` is added. Validated as JSON.