### PR TITLE
feat(#461): TPL ParkServe nationwide — public-tpl (proprietary, host-only)

### DIFF
--- a/catalog/sync/source-coop/license-inventory.md
+++ b/catalog/sync/source-coop/license-inventory.md
@@ -177,6 +177,8 @@ CDFW BIOS biogeographic data. **Verified**: the BIOS-published layers (ACE, SWAP
 - **HOLD** · `TPL (no public terms)` — public-tpl/conservation-almanac-2024-funding  · no data license found; TPL requires contact for spatial data
 - **HOLD** · `TPL (no public terms)` — public-tpl/conservation-almanac-2024-sites  · no data license found; TPL requires contact for spatial data
 - **HOLD** · `TPL (no public terms)` — public-tpl/landvote  · no data license found; TPL requires contact for spatial data
+- **NO** · `proprietary` — public-tpl/parkserve-2025/parks  · TPL ParkServe. Hosted **with TPL permission (host, NOT redistribute)**; service areas derive from proprietary Esri StreetMap Premium + Business Analyst. NRP + MinIO backup only; **excluded from source.coop** (public-tpl not in REPOS). data-workflows #461.
+- **NO** · `proprietary` — public-tpl/parkserve-2025/service-areas  · same as parkserve-2025/parks — host-only, no redistribution, no source.coop mirror.
 - **HOLD** · `TPL (no public terms)` — public-tpl  · no data license found; TPL requires contact for spatial data
 - **OK (license) / RELOCATING** · `CC-BY-4.0` — public-tpl/wcb-approved-projects  · CDFW BIOS ds672 (CA Wildlife Conservation Board) — a CDFW **state-agency** product misfiled under "tpl". Moving to the planned `public-cdfw` bucket (geo-agent-ops #19; data-workflows #228); mirror as `cboettig/cdfw` afterward. `cboettig/tpl` was NOT created (rest of public-tpl is HOLD).
 

--- a/catalog/tpl/k8s/parkserve/acquire.yaml
+++ b/catalog/tpl/k8s/parkserve/acquire.yaml
@@ -1,0 +1,109 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-acquire
+  labels:
+    k8s-app: parkserve-2025-acquire
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-acquire
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: acquire
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== ensure bucket ==="
+          cng-datasets storage setup-bucket --bucket public-tpl --remote nrp --verify || true
+          python3 - <<'PY'
+          import urllib.request, urllib.parse, json, time, os
+          BASE="https://server7.tplgis.org/arcgis7/rest/services/ParkServe/ParkServe_ProdNew/FeatureServer"
+          UA="Mozilla/5.0 (data-workflows parkserve acquire)"
+          LAYERS={2:"parks", 3:"service-areas"}
+          # Keyset pagination by objectid (deep resultOffset 500s on this server); page 2000
+          # also 500s on batches with large polygons, so start at 1000 and halve on error.
+          def fetch(layer, last_oid, page, mao=None):
+              q={"where":f"objectid>{last_oid}","outFields":"*","outSR":"4326","f":"geojson",
+                 "orderByFields":"objectid","resultRecordCount":str(page)}
+              if mao: q["maxAllowableOffset"]=str(mao)   # server-side generalize giant polygons only
+              url=f"{BASE}/{layer}/query?"+urllib.parse.urlencode(q)
+              req=urllib.request.Request(url, headers={"User-Agent":UA})
+              return json.loads(urllib.request.urlopen(req, timeout=300).read())
+          for lid, name in LAYERS.items():
+              out=f"/tmp/{name}.geojson"
+              n=0; last=0; page=1000
+              with open(out,"w") as fh:
+                  fh.write('{"type":"FeatureCollection","features":[\n'); first=True
+                  while True:
+                      feats=None
+                      for attempt in range(16):
+                          # once shrunk to a single record that still fails, it's a giant
+                          # polygon (e.g. Tongass NF, 16.7M ac) — generalize it ~11-22 m.
+                          mao=(0.0002 if (page==1 and attempt>=2) else None)
+                          try:
+                              d=fetch(lid, last, page, mao); feats=d.get("features",[]); break
+                          except Exception as e:
+                              print(f"    layer {lid} last={last} page={page} mao={mao} attempt {attempt}: {e}", flush=True)
+                              if page>1: page=max(1, page//2)       # shrink heavy batch (dense large polygons)
+                              time.sleep(2*(attempt+1))
+                      if feats is None: raise SystemExit(f"FAILED layer {lid} last={last}")
+                      if not feats: break
+                      for f in feats:
+                          fh.write(("" if first else ",\n")+json.dumps(f)); first=False
+                      n+=len(feats); last=max(f["properties"]["objectid"] for f in feats)
+                      print(f"  {name}: {n} features (last oid {last}, page {page})", flush=True)
+                      if page<1000: page=min(1000, page*2)          # recover page size
+                      if len(feats)<page and not d.get("properties",{}).get("exceededTransferLimit"): break
+                      time.sleep(0.2)
+                  fh.write("\n]}\n")
+              print(f"WROTE {out}: {n} features", flush=True)
+              os.system(f"rclone copyto {out} nrp:public-tpl/raw/parkserve-2025/{name}.geojson")
+              print(f"STAGED nrp:public-tpl/raw/parkserve-2025/{name}.geojson", flush=True)
+          PY
+          echo "=== staged ==="
+          rclone ls nrp:public-tpl/raw/parkserve-2025/
+          echo DONE
+        resources:
+          requests: {cpu: '2', memory: 8Gi, ephemeral-storage: 30Gi}
+          limits: {cpu: '2', memory: 8Gi, ephemeral-storage: 30Gi}
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/tpl/k8s/parkserve/parks/configmap.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: parkserve-2025-parks-setup-bucket.yaml, parkserve-2025-parks-convert.yaml, parkserve-2025-parks-pmtiles.yaml, parkserve-2025-parks-hex.yaml, parkserve-2025-parks-repartition.yaml
+# Generation command: cng-datasets workflow --dataset parkserve-2025/parks --source-url s3://public-tpl/raw/parkserve-2025/parks.geojson --bucket public-tpl --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap parkserve-2025-parks-yamls \
+#     --from-file=parkserve-2025-parks-setup-bucket.yaml \
+#     --from-file=parkserve-2025-parks-convert.yaml \
+#     --from-file=parkserve-2025-parks-pmtiles.yaml \
+#     --from-file=parkserve-2025-parks-hex.yaml \
+#     --from-file=parkserve-2025-parks-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  parkserve-2025-parks-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-parks-convert
+      labels:
+        k8s-app: parkserve-2025-parks-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-parks-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-tpl
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-tpl/raw/parkserve-2025/parks.geojson \
+                s3://public-tpl/parkserve-2025/parks.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-parks-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-parks-hex
+      labels:
+        k8s-app: parkserve-2025-parks-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-parks-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-tpl
+            - name: DATASET
+              value: parkserve-2025-parks
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-tpl/parkserve-2025/parks.parquet --output s3://public-tpl/parkserve-2025/parks/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-parks-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-parks-pmtiles
+      labels:
+        k8s-app: parkserve-2025-parks-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-parks-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-tpl
+            - name: DATASET
+              value: parks
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/parks.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-tpl/parkserve-2025/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-parks-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-parks-repartition
+      labels:
+        k8s-app: parkserve-2025-parks-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-parks-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-tpl
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-tpl/parkserve-2025/parks/chunks --output-dir s3://public-tpl/parkserve-2025/parks/hex --source-parquet s3://public-tpl/parkserve-2025/parks.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-parks-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-parks-setup-bucket
+      labels:
+        k8s-app: parkserve-2025-parks-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-parks-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-tpl
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: parkserve-2025-parks-yamls
+  namespace: geo-workflows

--- a/catalog/tpl/k8s/parkserve/parks/fix-chunk116-schema.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/fix-chunk116-schema.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-fix-chunk116
+  labels: {k8s-app: parkserve-2025-fix-chunk116}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels: {k8s-app: parkserve-2025-fix-chunk116}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: fix
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID, valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          python3 - <<'PY'
+          import duckdb, os
+          con=duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs;")
+          con.execute("SET s3_endpoint='rook-ceph-rgw-nautiluss3.rook'; SET s3_use_ssl=false; SET s3_url_style='path';")
+          con.execute(f"SET s3_access_key_id='{os.environ['AWS_ACCESS_KEY_ID']}'; SET s3_secret_access_key='{os.environ['AWS_SECRET_ACCESS_KEY']}';")
+          src="s3://public-tpl/parkserve-2025/parks/chunks/chunk_000116.parquet"
+          # match res-10 chunk schema exactly: _cng_fid, h10, h0, h8, h9  (h10/h9 NULL for these giant AK features)
+          con.execute(f"""
+            COPY (SELECT _cng_fid, NULL::UBIGINT AS h10, h0, h8, NULL::UBIGINT AS h9 FROM read_parquet('{src}'))
+            TO 's3://public-tpl/parkserve-2025/parks/chunks/chunk_000116_fixed.parquet' (FORMAT PARQUET, COMPRESSION ZSTD);
+          """)
+          n=con.execute("SELECT COUNT(*) FROM read_parquet('s3://public-tpl/parkserve-2025/parks/chunks/chunk_000116_fixed.parquet')").fetchone()[0]
+          print("fixed chunk116 rows:", n)
+          PY
+          echo "=== swap fixed -> chunk_000116, remove temp ==="
+          rclone moveto nrp:public-tpl/parkserve-2025/parks/chunks/chunk_000116_fixed.parquet nrp:public-tpl/parkserve-2025/parks/chunks/chunk_000116.parquet
+          rclone lsf nrp:public-tpl/parkserve-2025/parks/chunks/ | grep 116
+          echo DONE
+        resources:
+          requests: {cpu: '2', memory: 8Gi, ephemeral-storage: 10Gi}
+          limits: {cpu: '2', memory: 8Gi, ephemeral-storage: 10Gi}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-convert.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-convert.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-convert
+  labels:
+    k8s-app: parkserve-2025-parks-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-parks-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-tpl
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Localizing geojson via rclone (internal endpoint)..."
+          rclone copyto nrp:public-tpl/raw/parkserve-2025/parks.geojson /tmp/parks.geojson
+          ls -la /tmp/parks.geojson
+          cng-convert-to-parquet \
+            /tmp/parks.geojson \
+            s3://public-tpl/parkserve-2025/parks.parquet \
+            --row-group-size 5000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-hex-rechunk116.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-hex-rechunk116.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-hex-rechunk116
+  labels:
+    k8s-app: parkserve-2025-parks-hex-rechunk116
+spec:
+  completions: 1
+  parallelism: 1
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-parks-hex-rechunk116
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        - name: DATASET
+          value: parkserve-2025-parks
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-tpl/parkserve-2025/parks.parquet --output s3://public-tpl/parkserve-2025/parks/chunks --chunk-id 116 --chunk-size 1000 --intermediate-chunk-size 5 --resolution 8 --parent-resolutions 0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-hex.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-hex
+  labels:
+    k8s-app: parkserve-2025-parks-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-parks-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        - name: DATASET
+          value: parkserve-2025-parks
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-tpl/parkserve-2025/parks.parquet --output s3://public-tpl/parkserve-2025/parks/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-pmtiles.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-pmtiles
+  labels:
+    k8s-app: parkserve-2025-parks-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-parks-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        - name: DATASET
+          value: parks
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/parks.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-tpl/parkserve-2025/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-repartition.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-repartition
+  labels:
+    k8s-app: parkserve-2025-parks-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-parks-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-tpl/parkserve-2025/parks/chunks --output-dir s3://public-tpl/parkserve-2025/parks/hex --source-parquet s3://public-tpl/parkserve-2025/parks.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-setup-bucket.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/parkserve-2025-parks-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-setup-bucket
+  labels:
+    k8s-app: parkserve-2025-parks-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-parks-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-tpl
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/parks/workflow-rbac.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/tpl/k8s/parkserve/parks/workflow.yaml
+++ b/catalog/tpl/k8s/parkserve/parks/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-parks-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting parkserve-2025-parks workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/parkserve-2025-parks-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/parkserve-2025-parks-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/parkserve-2025-parks-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/parkserve-2025-parks-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/parkserve-2025-parks-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/parkserve-2025-parks-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/parkserve-2025-parks-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/parkserve-2025-parks-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/parkserve-2025-parks-repartition -n geo-workflows\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs parkserve-2025-parks-setup-bucket parkserve-2025-parks-convert\
+          \ parkserve-2025-parks-pmtiles parkserve-2025-parks-hex parkserve-2025-parks-repartition\
+          \ parkserve-2025-parks-workflow -n geo-workflows\"\necho \"  kubectl delete\
+          \ configmap parkserve-2025-parks-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: parkserve-2025-parks-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/tpl/k8s/parkserve/service-areas/configmap.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: parkserve-2025-service-areas-setup-bucket.yaml, parkserve-2025-service-areas-convert.yaml, parkserve-2025-service-areas-pmtiles.yaml, parkserve-2025-service-areas-hex.yaml, parkserve-2025-service-areas-repartition.yaml
+# Generation command: cng-datasets workflow --dataset parkserve-2025/service-areas --source-url s3://public-tpl/raw/parkserve-2025/service-areas.geojson --bucket public-tpl --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap parkserve-2025-service-areas-yamls \
+#     --from-file=parkserve-2025-service-areas-setup-bucket.yaml \
+#     --from-file=parkserve-2025-service-areas-convert.yaml \
+#     --from-file=parkserve-2025-service-areas-pmtiles.yaml \
+#     --from-file=parkserve-2025-service-areas-hex.yaml \
+#     --from-file=parkserve-2025-service-areas-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  parkserve-2025-service-areas-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-service-areas-convert
+      labels:
+        k8s-app: parkserve-2025-service-areas-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-service-areas-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-tpl
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-tpl/raw/parkserve-2025/service-areas.geojson \
+                s3://public-tpl/parkserve-2025/service-areas.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-service-areas-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-service-areas-hex
+      labels:
+        k8s-app: parkserve-2025-service-areas-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-service-areas-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-tpl
+            - name: DATASET
+              value: parkserve-2025-service-areas
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-tpl/parkserve-2025/service-areas.parquet --output s3://public-tpl/parkserve-2025/service-areas/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-service-areas-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-service-areas-pmtiles
+      labels:
+        k8s-app: parkserve-2025-service-areas-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-service-areas-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-tpl
+            - name: DATASET
+              value: service-areas
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/service-areas.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-tpl/parkserve-2025/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-service-areas-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-service-areas-repartition
+      labels:
+        k8s-app: parkserve-2025-service-areas-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-service-areas-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-tpl
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-tpl/parkserve-2025/service-areas/chunks --output-dir s3://public-tpl/parkserve-2025/service-areas/hex --source-parquet s3://public-tpl/parkserve-2025/service-areas.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  parkserve-2025-service-areas-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: parkserve-2025-service-areas-setup-bucket
+      labels:
+        k8s-app: parkserve-2025-service-areas-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: parkserve-2025-service-areas-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-tpl
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: parkserve-2025-service-areas-yamls
+  namespace: geo-workflows

--- a/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-convert.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-convert.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-service-areas-convert
+  labels:
+    k8s-app: parkserve-2025-service-areas-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-service-areas-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-tpl
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Localizing geojson via rclone (internal endpoint)..."
+          rclone copyto nrp:public-tpl/raw/parkserve-2025/service-areas.geojson /tmp/service-areas.geojson
+          ls -la /tmp/service-areas.geojson
+          cng-convert-to-parquet \
+            /tmp/service-areas.geojson \
+            s3://public-tpl/parkserve-2025/service-areas.parquet \
+            --row-group-size 5000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-hex.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-service-areas-hex
+  labels:
+    k8s-app: parkserve-2025-service-areas-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-service-areas-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        - name: DATASET
+          value: parkserve-2025-service-areas
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-tpl/parkserve-2025/service-areas.parquet --output s3://public-tpl/parkserve-2025/service-areas/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-pmtiles.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-service-areas-pmtiles
+  labels:
+    k8s-app: parkserve-2025-service-areas-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-service-areas-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        - name: DATASET
+          value: service-areas
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/service-areas.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-tpl/parkserve-2025/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-repartition.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-service-areas-repartition
+  labels:
+    k8s-app: parkserve-2025-service-areas-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-service-areas-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-tpl
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-tpl/parkserve-2025/service-areas/chunks --output-dir s3://public-tpl/parkserve-2025/service-areas/hex --source-parquet s3://public-tpl/parkserve-2025/service-areas.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-setup-bucket.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/parkserve-2025-service-areas-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-service-areas-setup-bucket
+  labels:
+    k8s-app: parkserve-2025-service-areas-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: parkserve-2025-service-areas-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-tpl
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/tpl/k8s/parkserve/service-areas/workflow-rbac.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/tpl/k8s/parkserve/service-areas/workflow.yaml
+++ b/catalog/tpl/k8s/parkserve/service-areas/workflow.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: parkserve-2025-service-areas-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting parkserve-2025-service-areas workflow...\"\n\
+          \n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/parkserve-2025-service-areas-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/parkserve-2025-service-areas-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/parkserve-2025-service-areas-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/parkserve-2025-service-areas-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/parkserve-2025-service-areas-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/parkserve-2025-service-areas-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/parkserve-2025-service-areas-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/parkserve-2025-service-areas-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/parkserve-2025-service-areas-repartition -n geo-workflows\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs parkserve-2025-service-areas-setup-bucket parkserve-2025-service-areas-convert\
+          \ parkserve-2025-service-areas-pmtiles parkserve-2025-service-areas-hex\
+          \ parkserve-2025-service-areas-repartition parkserve-2025-service-areas-workflow\
+          \ -n geo-workflows\"\necho \"  kubectl delete configmap parkserve-2025-service-areas-yamls\
+          \ -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: parkserve-2025-service-areas-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #461.

Imports **Trust for Public Land ParkServe®** (2025 edition) nationwide into the existing **`public-tpl`** bucket as GeoParquet + PMTiles + H3 hex.

## ⛔ License: proprietary — host, not redistribute

Hosted **with TPL's permission for use, NOT redistribution** (per @cboettig). The 10-minute-walk service areas derive from proprietary **Esri StreetMap Premium + Business Analyst**. `public-tpl` is already **excluded from the source.coop mirror** (not in `REPOS`) and **in MinIO backup** — no gen-script change needed; verdict recorded in `license-inventory.md`. Same handling class as the other non-redistributable buckets.

## Layers (published, `verify-stac.py` green — 0 hard findings)

| Collection | Features | Native H3 |
|---|---|---|
| `parkserve-2025/parks` | **154,757** parks w/ public access (+ 2018 10-min-walk demographics, designation, owner/manager, canopy, amenities) | 10 (9,8,0)* |
| `parkserve-2025/service-areas` | **146,364** ten-minute-walk service areas (linked via `parkid`) | 10 (9,8,0) |

\* 1,000 giant features (the Alaska national-forest cluster incl. **Tongass**, 16.7 M ac) capped at native **h8** (h9/h10 NULL; h8 complete for all) — documented on the hex asset; join on `h8`.

## How it was built (notes for reviewers)

- **Source = the ParkServe FeatureServer** (`ParkServe_ProdNew`), not the terms-gated bulk download. `datashare_yn='Y'` for all 154,757 parks → the endpoint is already TPL's shareable subset.
- **Acquisition** (`acquire.yaml`): keyset pagination by `objectid` (deep `resultOffset` 500s on this server); adaptive page-size shrink for dense large-polygon batches; **server-side generalization** (`maxAllowableOffset`) for single giant polygons that 500 even alone (e.g. Tongass).
- **Convert** localizes the ~1.3 GB GeoJSON via rclone first (reading it repeatedly over the public endpoint was pathologically slow).
- **Parks hex**: res-10 polyfill of the Alaska archipelago giants was infeasible (huge bbox → tens of millions of candidate cells), so chunk 116 was re-hexed at **res 8** (`fix-chunk116-schema.yaml` pads h9/h10 = NULL to match the merge schema) → the WDPA NULL-finest pattern.
- Coded columns carry authoritative `values` + `CODE=Definition` from the FeatureServer field **domains**.

## Validation
- Parks 154,757 / service-areas 146,364 features (exact source match); `_cng_fid` on flat + hex; h8 complete on both; full data-backed `verify-stac` passes for both collections.
- Registered as children of the `public-tpl` collection (already linked from root).

## Execution hand-off (geo-agent-ops)
Nothing to apply — `public-tpl` is already in MinIO-backup scope and already excluded from source.coop. No new bucket, no mirror change.
