### PR TITLE
feat(#459): ACS 2020–2024 block-group demographics (national)

### DIFF
--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-convert.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-convert
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-census
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-census/acs-2020-2024/blockgroup.parquet \
+            s3://public-census/acs-2020-2024/blockgroup.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-hex.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-hex.yaml
@@ -8,7 +8,8 @@ spec:
   completions: 200
   parallelism: 50
   completionMode: Indexed
-  backoffLimit: 0
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 10
   podFailurePolicy:
     rules:
     - action: Ignore
@@ -21,6 +22,7 @@ spec:
         k8s-app: acs-2020-2024-blockgroup-hex
     spec:
       restartPolicy: Never
+      activeDeadlineSeconds: 10800
       containers:
       - name: hex-task
         image: ghcr.io/boettiger-lab/datasets:latest
@@ -55,15 +57,15 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets vector --input s3://public-census/acs-2020-2024/blockgroup.parquet --output s3://public-census/acs-2020-2024/blockgroup/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1300 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+          cng-datasets vector --input s3://public-census/acs-2020-2024/blockgroup-hexin.parquet --output s3://public-census/acs-2020-2024/blockgroup/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1300 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
         resources:
           requests:
             cpu: '4'
-            memory: 16Gi
+            memory: 32Gi
             ephemeral-storage: 10Gi
           limits:
             cpu: '4'
-            memory: 16Gi
+            memory: 32Gi
             ephemeral-storage: 10Gi
       priorityClassName: opportunistic
       affinity:

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-hex.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-hex
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-census
+        - name: DATASET
+          value: acs-2020-2024-blockgroup
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-census/acs-2020-2024/blockgroup.parquet --output s3://public-census/acs-2020-2024/blockgroup/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1300 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-pmtiles.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-pmtiles.yaml
@@ -1,0 +1,103 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-pmtiles
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-census
+        - name: DATASET
+          value: blockgroup
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-census/acs-2020-2024/blockgroup.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-census/acs-2020-2024/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-repartition.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-repartition.yaml
@@ -51,15 +51,15 @@ spec:
         - -c
         - |
           set -e
-          cng-datasets repartition --chunks-dir s3://public-census/acs-2020-2024/blockgroup/chunks --output-dir s3://public-census/acs-2020-2024/blockgroup/hex --source-parquet s3://public-census/acs-2020-2024/blockgroup.parquet --cleanup --memory-limit 27GiB
+          cng-datasets repartition --chunks-dir s3://public-census/acs-2020-2024/blockgroup/chunks --output-dir s3://public-census/acs-2020-2024/blockgroup/hex --source-parquet s3://public-census/acs-2020-2024/blockgroup.parquet --cleanup --memory-limit 100GiB
         resources:
           requests:
             cpu: '4'
-            memory: 32Gi
+            memory: 120Gi
             ephemeral-storage: 50Gi
           limits:
             cpu: '4'
-            memory: 32Gi
+            memory: 120Gi
             ephemeral-storage: 50Gi
       volumes:
       - name: rclone-config

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-repartition.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-repartition
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-census
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-census/acs-2020-2024/blockgroup/chunks --output-dir s3://public-census/acs-2020-2024/blockgroup/hex --source-parquet s3://public-census/acs-2020-2024/blockgroup.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-setup-bucket.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-setup-bucket
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-census
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-stage-hexinput.yaml
+++ b/catalog/census/k8s/blockgroup/acs-2020-2024-blockgroup-stage-hexinput.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-stage-hexinput
+  namespace: geo-workflows
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-stage-hexinput
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 900
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-stage-hexinput
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ["true"]
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests: {memory: "24Gi", cpu: "4", ephemeral-storage: "20Gi"}
+          limits: {memory: "24Gi", cpu: "4", ephemeral-storage: "20Gi"}
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: "rook-ceph-rgw-nautiluss3.rook"}
+        - {name: AWS_HTTPS, value: "false"}
+        - {name: AWS_VIRTUAL_HOSTING, value: "FALSE"}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          # Hex input = canonical flat parquet MINUS the one antimeridian-crossing feature
+          # (_cng_fid 4127, GEOID 020160001001) that cannot be polyfilled. The flat
+          # blockgroup.parquet keeps 4127; only the hex omits it.
+          python3 - <<'PYEOF'
+          import duckdb, os
+          c=duckdb.connect(); c.execute("INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;")
+          c.execute("SET s3_endpoint='rook-ceph-rgw-nautiluss3.rook'; SET s3_use_ssl=false; SET s3_url_style='path';")
+          c.execute(f"SET s3_access_key_id='{os.environ['AWS_ACCESS_KEY_ID']}'; SET s3_secret_access_key='{os.environ['AWS_SECRET_ACCESS_KEY']}';")
+          c.execute("""
+            COPY (SELECT * FROM read_parquet('s3://public-census/acs-2020-2024/blockgroup.parquet')
+                  WHERE _cng_fid <> 4127)
+            TO 's3://public-census/acs-2020-2024/blockgroup-hexin.parquet'
+            (FORMAT PARQUET, ROW_GROUP_SIZE 2000, COMPRESSION ZSTD)
+          """)
+          n=c.execute("SELECT COUNT(*), COUNT(geom) FROM read_parquet('s3://public-census/acs-2020-2024/blockgroup-hexin.parquet')").fetchone()
+          print(f"hex input features: {n[0]} (geom {n[1]}) -- expect 242747")
+          PYEOF
+          echo done
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/census/k8s/blockgroup/configmap.yaml
+++ b/catalog/census/k8s/blockgroup/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: acs-2020-2024-blockgroup-setup-bucket.yaml, acs-2020-2024-blockgroup-convert.yaml, acs-2020-2024-blockgroup-pmtiles.yaml, acs-2020-2024-blockgroup-hex.yaml, acs-2020-2024-blockgroup-repartition.yaml
+# Generation command: cng-datasets workflow --dataset acs-2020-2024/blockgroup --source-url s3://public-census/acs-2020-2024/blockgroup.parquet --bucket public-census --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap acs-2020-2024-blockgroup-yamls \
+#     --from-file=acs-2020-2024-blockgroup-setup-bucket.yaml \
+#     --from-file=acs-2020-2024-blockgroup-convert.yaml \
+#     --from-file=acs-2020-2024-blockgroup-pmtiles.yaml \
+#     --from-file=acs-2020-2024-blockgroup-hex.yaml \
+#     --from-file=acs-2020-2024-blockgroup-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  acs-2020-2024-blockgroup-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acs-2020-2024-blockgroup-convert
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acs-2020-2024-blockgroup-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-census
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-census/acs-2020-2024/blockgroup.parquet \
+                s3://public-census/acs-2020-2024/blockgroup.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acs-2020-2024-blockgroup-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acs-2020-2024-blockgroup-hex
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acs-2020-2024-blockgroup-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-census
+            - name: DATASET
+              value: acs-2020-2024-blockgroup
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-census/acs-2020-2024/blockgroup.parquet --output s3://public-census/acs-2020-2024/blockgroup/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acs-2020-2024-blockgroup-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acs-2020-2024-blockgroup-pmtiles
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acs-2020-2024-blockgroup-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-census
+            - name: DATASET
+              value: blockgroup
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-census/acs-2020-2024/blockgroup.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-census/acs-2020-2024/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acs-2020-2024-blockgroup-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acs-2020-2024-blockgroup-repartition
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acs-2020-2024-blockgroup-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-census
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-census/acs-2020-2024/blockgroup/chunks --output-dir s3://public-census/acs-2020-2024/blockgroup/hex --source-parquet s3://public-census/acs-2020-2024/blockgroup.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acs-2020-2024-blockgroup-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acs-2020-2024-blockgroup-setup-bucket
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acs-2020-2024-blockgroup-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-census
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: acs-2020-2024-blockgroup-yamls
+  namespace: geo-workflows

--- a/catalog/census/k8s/blockgroup/preprocess-blockgroup.yaml
+++ b/catalog/census/k8s/blockgroup/preprocess-blockgroup.yaml
@@ -1,0 +1,178 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-preprocess
+  namespace: geo-workflows
+  labels:
+    k8s-app: acs-2020-2024-blockgroup-preprocess
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acs-2020-2024-blockgroup-preprocess
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - "true"
+      containers:
+      - name: preprocess
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "32Gi"
+            cpu: "8"
+            ephemeral-storage: "50Gi"
+          limits:
+            memory: "32Gi"
+            cpu: "8"
+            ephemeral-storage: "50Gi"
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: "rook-ceph-rgw-nautiluss3.rook"
+        - name: AWS_PUBLIC_ENDPOINT
+          value: "s3-west.nrp-nautilus.io"
+        - name: AWS_HTTPS
+          value: "false"
+        - name: AWS_VIRTUAL_HOSTING
+          value: "FALSE"
+        - name: BUCKET
+          value: "public-census"
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+
+          # State/territory FIPS with TIGER 2024 block-group files (50 states + DC + PR + island areas).
+          # ACS 5yr summary file covers 50 states + DC + PR (72); island areas (60/66/69/78) have no ACS
+          # in this file and get NULL demographics via LEFT JOIN (documented in STAC).
+          STATE_FIPS="01 02 04 05 06 08 09 10 11 12 13 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 44 45 46 47 48 49 50 51 53 54 55 56 60 66 69 72 78"
+
+          echo "=== 1. Download TIGER 2024 block-group shapefiles (per state) ==="
+          mkdir -p /tmp/bg && cd /tmp/bg
+          for fips in $STATE_FIPS; do
+            curl -sS --retry 5 -O "https://www2.census.gov/geo/tiger/TIGER2024/BG/tl_2024_${fips}_bg.zip" &
+          done
+          wait
+          echo "Downloaded $(ls -1 *.zip | wc -l) zips"
+          unzip -q -o "*.zip"
+          echo "Staging raw zips to s3://public-census/raw/blockgroup/ ..."
+          rclone copy /tmp/bg nrp:public-census/raw/blockgroup/ --include "*.zip" || true
+
+          echo "=== 2. Merge all block-group shapefiles -> GeoParquet (cng adds _cng_fid) ==="
+          cng-convert-to-parquet /tmp/bg/*.shp /tmp/bg_geom.parquet \
+            --compression ZSTD --compression-level 15 --row-group-size 100000
+
+          echo "=== 3. Download ACS 2020-2024 5yr table-based Summary File tables ==="
+          # Block-group-available tables only. B09001/B17001/B08201 have NO block-group data
+          # (tract-minimum), so Under18 is derived from B01001 age brackets, PovInd from C17002
+          # (collapsed poverty ratio), and NoCar from B25044 (tenure by vehicles).
+          mkdir -p /tmp/acs && cd /tmp/acs
+          BASE="https://www2.census.gov/programs-surveys/acs/summary_file/2024/table-based-SF/data/5YRData"
+          for t in b01003 b01001 c17002 b19013 b19301 b25044; do
+            curl -sS --retry 5 -O "${BASE}/acsdt5y2024-${t}.dat" &
+          done
+          wait
+          echo "Downloaded ACS tables:"; ls -la /tmp/acs/*.dat
+          rclone copy /tmp/acs nrp:public-census/raw/blockgroup-acs/ --include "*.dat" || true
+
+          echo "=== 4. Build ACS attributes, join to geometry, write canonical GeoParquet ==="
+          python3 - <<'PYEOF'
+          import duckdb
+          c = duckdb.connect()
+          c.execute("INSTALL spatial; LOAD spatial;")
+          D = "/tmp/acs"
+
+          def dat(table):
+              # Block-group rows: GEO_ID = '1500000US' (9-char prefix) + 12-digit code; strip prefix.
+              return (f"(SELECT substr(GEO_ID,10) AS GEOID, * "
+                      f"FROM read_csv('{D}/acsdt5y2024-{table}.dat', delim='|', header=true, all_varchar=true) "
+                      f"WHERE GEO_ID LIKE '1500000US%')")
+
+          # non-negative integer estimate (jam/no-data codes are negative -> NULL)
+          def pos(col):
+              return f"CASE WHEN TRY_CAST({col} AS BIGINT) < 0 THEN NULL ELSE TRY_CAST({col} AS BIGINT) END"
+          # count component floored at 0 (never legitimately negative; jam codes -> 0)
+          def cnt(col):
+              return f"GREATEST(COALESCE(TRY_CAST({col} AS BIGINT),0),0)"
+          def sm(*cols):
+              return "(" + " + ".join(cnt(c) for c in cols) + ")"
+
+          # Under18 and Senior65 derived from B01001 (sex-by-age; block-group-available);
+          # PovInd from C17002 (ratio < 1.00 = under .50 + .50-.99); NoCar from B25044.
+          under18  = sm(*[f'"B01001_E{n:03d}"' for n in [3,4,5,6,27,28,29,30]])
+          senior65 = sm(*[f'"B01001_E{n:03d}"' for n in [20,21,22,23,24,25,44,45,46,47,48,49]])
+          povind   = sm('"C17002_E002"', '"C17002_E003"')
+          nocar    = sm('"B25044_E003"', '"B25044_E010"')
+
+          sql = f"""
+          CREATE TEMP TABLE acs AS
+          SELECT
+            GEOID,
+            {pos('pop."B01003_E001"')}  AS TotPop,
+            {under18}                   AS Under18,
+            {senior65}                  AS Senior65,
+            {povind}                    AS PovInd,
+            {pos('mhi."B19013_E001"')}  AS MHHI,
+            {pos('pci."B19301_E001"')}  AS PCI,
+            {nocar}                     AS NoCar
+          FROM {dat('b01003')} pop
+          LEFT JOIN {dat('b01001')} age USING (GEOID)
+          LEFT JOIN {dat('c17002')} pov USING (GEOID)
+          LEFT JOIN {dat('b19013')} mhi USING (GEOID)
+          LEFT JOIN {dat('b19301')} pci USING (GEOID)
+          LEFT JOIN {dat('b25044')} car USING (GEOID)
+          """
+          c.execute(sql)
+          n = c.execute("SELECT COUNT(*), COUNT(MHHI) FROM acs").fetchone()
+          print(f"ACS block-group rows: {n[0]:,}  (with non-null MHHI: {n[1]:,})")
+
+          # Join ACS attrs onto geometry (1:1 on GEOID); write canonical GeoParquet.
+          c.execute("""
+          COPY (
+            SELECT g.*,
+                   a.TotPop, a.Under18, a.Senior65, a.PovInd, a.MHHI, a.PCI, a.NoCar
+            FROM read_parquet('/tmp/bg_geom.parquet') g
+            LEFT JOIN acs a ON g.GEOID = a.GEOID
+          ) TO '/tmp/blockgroup.parquet'
+            (FORMAT PARQUET, ROW_GROUP_SIZE 2000, COMPRESSION ZSTD)
+          """)
+          m = c.execute("""SELECT COUNT(*), COUNT(geom), COUNT(TotPop)
+                           FROM read_parquet('/tmp/blockgroup.parquet')""").fetchone()
+          print(f"Final: {m[0]:,} block groups | geom non-null {m[1]:,} | TotPop non-null {m[2]:,}")
+          PYEOF
+
+          echo "=== 5. Upload canonical GeoParquet to S3 ==="
+          rclone copyto /tmp/blockgroup.parquet nrp:public-census/acs-2020-2024/blockgroup.parquet -P
+          echo "✓ Preprocess complete: s3://public-census/acs-2020-2024/blockgroup.parquet"
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/census/k8s/blockgroup/workflow-rbac.yaml
+++ b/catalog/census/k8s/blockgroup/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/census/k8s/blockgroup/workflow.yaml
+++ b/catalog/census/k8s/blockgroup/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acs-2020-2024-blockgroup-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting acs-2020-2024-blockgroup workflow...\"\n\n\
+          # Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/acs-2020-2024-blockgroup-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/acs-2020-2024-blockgroup-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/acs-2020-2024-blockgroup-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/acs-2020-2024-blockgroup-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/acs-2020-2024-blockgroup-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/acs-2020-2024-blockgroup-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/acs-2020-2024-blockgroup-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/acs-2020-2024-blockgroup-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/acs-2020-2024-blockgroup-repartition -n geo-workflows\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs acs-2020-2024-blockgroup-setup-bucket acs-2020-2024-blockgroup-convert\
+          \ acs-2020-2024-blockgroup-pmtiles acs-2020-2024-blockgroup-hex acs-2020-2024-blockgroup-repartition\
+          \ acs-2020-2024-blockgroup-workflow -n geo-workflows\"\necho \"  kubectl\
+          \ delete configmap acs-2020-2024-blockgroup-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: acs-2020-2024-blockgroup-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #459.

Adds **ACS 2020–2024 5-year block-group demographics** for all 50 states + DC + PR + island areas — the demographics layer behind tools like the Parks for California Community FactFinder, published as a standalone reusable layer.

## What was built
- **242,748** TIGER 2024 block groups joined to ACS 2020–2024 5-year demographics from the public **table-based Summary File** (no API key), published to `s3://public-census/acs-2020-2024/blockgroup{.parquet,.pmtiles,/hex/…}` and registered under the `us-census` catalog.
- Variables: `TotPop` (B01003), `Under18` + `Senior65` (B01001 age brackets), `PovInd` (C17002, ratio<1.0), `MHHI` (B19013), `PCI` (B19301), `NoCar` (B25044). B09001/B17001/B08201 are tract-minimum, so those three were re-derived from block-group-available tables.
- H3 native res 10, parents 9,8,0. Hex covers **242,747** of 242,748 (see below).

## Validation
- National roll-ups match published ACS: population **338.1M**, under-18 **74.0M**, 65+ **58.4M**, poverty rate **12.4%**.
- Hex deduped population (by `_cng_fid`) = 338.1M; `h8`/`h10`/`h0` present; 15 h0 partitions.
- `scripts/verify-stac.py --bucket public-census --dataset acs-2020-2024/blockgroup` → **PASS** (0 hard findings).

## Known limitation (documented in STAC + README)
One block group — GEOID `020160001001` (Aleutians West, AK) — crosses the antimeridian (~359° bbox) and hangs cng-datasets' vector H3 polyfill; it is **omitted from the hex** (present in the GeoParquet + PMTiles). Filed as **boettiger-lab/datasets#167**.

## Notes
- `public-census` is already in the MinIO + source.coop scope lists; ACS/TIGER is public-domain, so no Step-7 changes needed.
- STAC/README live on NRP S3 (not in this repo); this PR is the k8s recipe.