### PR TITLE
feat(#65): Important Marine Mammal Areas (IMMA) — Dec 2025 global import

### DIFF
--- a/catalog/high-seas/k8s/imma/configmap.yaml
+++ b/catalog/high-seas/k8s/imma/configmap.yaml
@@ -1,0 +1,441 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: imma-setup-bucket.yaml, imma-convert.yaml, imma-pmtiles.yaml, imma-hex.yaml, imma-repartition.yaml
+# Generation command: cng-datasets workflow --dataset imma --source-url s3://public-high-seas/imma.parquet --bucket public-high-seas --resolution-by-area "12:8,600:6,5" --parent-resolutions "6,5,4,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap imma-yamls \
+#     --from-file=imma-setup-bucket.yaml \
+#     --from-file=imma-convert.yaml \
+#     --from-file=imma-pmtiles.yaml \
+#     --from-file=imma-hex.yaml \
+#     --from-file=imma-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  imma-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: imma-convert
+      labels:
+        k8s-app: imma-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: imma-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-high-seas
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -euo pipefail
+              # IMMA ships one GPKG layer with spaced/`#`-prefixed column names and 3D
+              # polygons. Clean column names to snake_case (SQLite dialect), flatten
+              # 3D->2D, then convert. See imma-convert.yaml for the canonical copy.
+              mkdir -p /tmp/raw
+              rclone copy nrp:public-high-seas/raw/imma/ /tmp/raw/ --include "iucn-imma.gpkg"
+              ogr2ogr -f FlatGeobuf -dialect SQLITE -nlt MULTIPOLYGON -nln imma -dim XY /tmp/imma.fgb \
+                /tmp/raw/iucn-imma.gpkg \
+                -sql 'SELECT "Ident Code" AS ident_code, Status AS status, Title AS title, "Criteria cat" AS criteria_cat, Criteria AS criteria, "Qualifying Sp" AS qualifying_sp, "Qual Sp Order" AS qual_sp_order, "Qual Sp Family" AS qual_sp_family, "# Qualifying Sp" AS n_qualifying_sp, "Supporting Sp" AS supporting_sp, "# Supporting Sp" AS n_supporting_sp, Region AS region, "Region Code" AS region_code, Jurisdiction AS jurisdiction, "Jurisdiction Code" AS jurisdiction_code, "Area Sqkm" AS area_sqkm, month_submitted, year_submitted, month_classified, year_classified, month_modified, year_modified, Details AS details, ST_SimplifyPreserveTopology(geom, 0.001) AS geom FROM "iucn-imma"'
+              cng-convert-to-parquet /tmp/imma.fgb \
+                s3://public-high-seas/imma.parquet \
+                --row-group-size 2000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  imma-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: imma-hex
+      labels:
+        k8s-app: imma-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: imma-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-high-seas
+            - name: DATASET
+              value: imma
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-high-seas/imma.parquet --output s3://public-high-seas/imma/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution-by-area "12:8,600:6,5" --parent-resolutions 6,5,4,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  imma-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: imma-pmtiles
+      labels:
+        k8s-app: imma-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: imma-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-high-seas
+            - name: DATASET
+              value: imma
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-high-seas/imma.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-high-seas/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  imma-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: imma-repartition
+      labels:
+        k8s-app: imma-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: imma-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-high-seas
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-high-seas/imma/chunks --output-dir s3://public-high-seas/imma/hex --source-parquet s3://public-high-seas/imma.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  imma-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: imma-setup-bucket
+      labels:
+        k8s-app: imma-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: imma-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-high-seas
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: imma-yamls
+  namespace: geo-workflows

--- a/catalog/high-seas/k8s/imma/imma-convert.yaml
+++ b/catalog/high-seas/k8s/imma/imma-convert.yaml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imma-convert
+  labels:
+    k8s-app: imma-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: imma-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-high-seas
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          # IMMA ships one GPKG layer with spaced/`#`-prefixed column names and 3D
+          # polygons. Preprocess: clean column names to snake_case (SQLite dialect),
+          # flatten 3D->2D (-dim XY), then convert. 323 features, all MULTIPOLYGON.
+          mkdir -p /tmp/raw
+          echo "Localizing IMMA GeoPackage from raw/..."
+          rclone copy nrp:public-high-seas/raw/imma/ /tmp/raw/ --include "iucn-imma.gpkg"
+          echo "Cleaning column names + flattening to 2D..."
+          ogr2ogr -f FlatGeobuf -dialect SQLITE -nlt MULTIPOLYGON -nln imma -dim XY /tmp/imma.fgb \
+            /tmp/raw/iucn-imma.gpkg \
+            -sql 'SELECT "Ident Code" AS ident_code, Status AS status, Title AS title, "Criteria cat" AS criteria_cat, Criteria AS criteria, "Qualifying Sp" AS qualifying_sp, "Qual Sp Order" AS qual_sp_order, "Qual Sp Family" AS qual_sp_family, "# Qualifying Sp" AS n_qualifying_sp, "Supporting Sp" AS supporting_sp, "# Supporting Sp" AS n_supporting_sp, Region AS region, "Region Code" AS region_code, Jurisdiction AS jurisdiction, "Jurisdiction Code" AS jurisdiction_code, "Area Sqkm" AS area_sqkm, month_submitted, year_submitted, month_classified, year_classified, month_modified, year_modified, Details AS details, ST_SimplifyPreserveTopology(geom, 0.001) AS geom FROM "iucn-imma"'
+          echo "Converting to GeoParquet (row-group-size 2000)..."
+          cng-convert-to-parquet /tmp/imma.fgb \
+            s3://public-high-seas/imma.parquet \
+            --row-group-size 2000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/high-seas/k8s/imma/imma-hex.yaml
+++ b/catalog/high-seas/k8s/imma/imma-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imma-hex
+  labels:
+    k8s-app: imma-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: imma-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-high-seas
+        - name: DATASET
+          value: imma
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-high-seas/imma.parquet --output s3://public-high-seas/imma/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution-by-area "12:8,600:6,5" --parent-resolutions 6,5,4,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/high-seas/k8s/imma/imma-pmtiles.yaml
+++ b/catalog/high-seas/k8s/imma/imma-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imma-pmtiles
+  labels:
+    k8s-app: imma-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: imma-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-high-seas
+        - name: DATASET
+          value: imma
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-high-seas/imma.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 11 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-high-seas/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/high-seas/k8s/imma/imma-repartition.yaml
+++ b/catalog/high-seas/k8s/imma/imma-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imma-repartition
+  labels:
+    k8s-app: imma-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: imma-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-high-seas
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-high-seas/imma/chunks --output-dir s3://public-high-seas/imma/hex --source-parquet s3://public-high-seas/imma.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/high-seas/k8s/imma/imma-setup-bucket.yaml
+++ b/catalog/high-seas/k8s/imma/imma-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imma-setup-bucket
+  labels:
+    k8s-app: imma-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: imma-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-high-seas
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/high-seas/k8s/imma/workflow-rbac.yaml
+++ b/catalog/high-seas/k8s/imma/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/high-seas/k8s/imma/workflow.yaml
+++ b/catalog/high-seas/k8s/imma/workflow.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imma-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting imma workflow...\"\n\n# Step 0: Setup bucket\
+          \ with public access and CORS\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/imma-setup-bucket.yaml -n geo-workflows\n\necho \"Waiting\
+          \ for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/imma-setup-bucket -n geo-workflows\n\n# Step 1: Convert\
+          \ to optimized GeoParquet (needed by both pmtiles and hex jobs)\necho \"\
+          Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f /yamls/imma-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/imma-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/imma-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/imma-hex.yaml -n geo-workflows\n\
+          \necho \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/imma-hex -n geo-workflows\n\necho \"Step 3: Repartitioning\
+          \ by h0...\"\nkubectl apply -f /yamls/imma-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/imma-repartition -n geo-workflows\n\necho \"\u2713\
+          \ Workflow complete!\"\necho \"Note: PMTiles job may still be running in\
+          \ the background\"\necho \"\"\necho \"Clean up with:\"\necho \"  kubectl\
+          \ delete jobs imma-setup-bucket imma-convert imma-pmtiles imma-hex imma-repartition\
+          \ imma-workflow -n geo-workflows\"\necho \"  kubectl delete configmap imma-yamls\
+          \ -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: imma-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/sync/k8s/source-sync-cron-config.yaml
+++ b/catalog/sync/k8s/source-sync-cron-config.yaml
@@ -26,7 +26,7 @@ data:
     gfw sync */chunks/** */hex-staging/** 
     globio sync */chunks/** */hex-staging/** 
     hazard sync */chunks/** */hex-staging/** mid-century-habitat-climate-exposure/**
-    high-seas sync */chunks/** */hex-staging/** mpa-candidates/**
+    high-seas sync */chunks/** */hex-staging/** mpa-candidates/** imma/** imma.parquet imma.pmtiles
     inat sync */chunks/** */hex-staging/** 
     indigenous sync */chunks/** */hex-staging/** 
     land-cover sync */chunks/** */hex-staging/** 

--- a/catalog/sync/k8s/source-sync-high-seas.yaml
+++ b/catalog/sync/k8s/source-sync-high-seas.yaml
@@ -53,7 +53,7 @@ spec:
               # DRYRUN=true (env) lists changes without writing. Default: real sync.
               if [ "${DRYRUN:-false}" = "true" ]; then RCLONE_FLAGS="$RCLONE_FLAGS --dry-run"; fi
               echo "Syncing: $SRC -> $DEST  (DRYRUN=${DRYRUN:-false})"
-              rclone sync $RCLONE_FLAGS --exclude '*/chunks/**' --exclude '*/hex-staging/**' --exclude 'mpa-candidates/**' "$SRC" "$DEST"
+              rclone sync $RCLONE_FLAGS --exclude '*/chunks/**' --exclude '*/hex-staging/**' --exclude 'mpa-candidates/**' --exclude 'imma/**' --exclude 'imma.parquet' --exclude 'imma.pmtiles' "$SRC" "$DEST"
               echo "Done: high-seas"
       volumes:
         - name: rclone-config

--- a/catalog/sync/source-coop/gen-source-sync.sh
+++ b/catalog/sync/source-coop/gen-source-sync.sh
@@ -55,7 +55,7 @@ REPOS=(
 # Space-separated rclone --exclude patterns, relative to the bucket root.
 declare -A EXCLUDES=(
   [rivers]="american-rivers/campaigns/** american-rivers/ira-watersheds/** american-rivers/roo-cjest/**"
-  [high-seas]="mpa-candidates/**"
+  [high-seas]="mpa-candidates/** imma/** imma.parquet imma.pmtiles"
   # hazard: flood-hazard (FEMA) + sea-level-rise (NOAA) are public-domain and mirror.
   # mid-century-habitat-climate-exposure (Thorne et al. 2016, CDFW-commissioned) is NOT a
   # Dryad/Zenodo deposit and its STAC states redistribution terms "are not explicitly

--- a/catalog/sync/source-coop/license-inventory.md
+++ b/catalog/sync/source-coop/license-inventory.md
@@ -80,6 +80,7 @@ CDFW BIOS biogeographic data. **Verified**: the BIOS-published layers (ACE, SWAP
 - **STALE** · `—` — public-high-seas/ghs-pop-2020  · dead STAC file
 - **OK-NC** · `CC-BY-NC-SA-4.0` — public-high-seas/hydrothermal-vents  
 - **OK** · `CC-BY-4.0` — public-high-seas/iho  
+- **NO** · `proprietary (IUCN-MMPATF ToS)` — public-high-seas/imma  · Important Marine Mammal Areas (IUCN-MMPATF). Non-commercial User Licence Agreement; no third-party sharing, no republishing in original format, derived products carry same terms (https://www.marinemammalhabitat.org/immas/imma-spatial-layer-download/). NRP + MinIO backup only; EXCLUDED from source.coop (EXCLUDES: imma/**, imma.parquet, imma.pmtiles). WDPA/IUCN class. data-workflows #65.
 - **OK** · `CC-BY-4.0` — public-high-seas/longhurst  
 - **OK** · `CC0-1.0` — public-high-seas/megamove/corridors  
 - **OK** · `CC0-1.0` — public-high-seas/megamove/immegas  


### PR DESCRIPTION
Addresses the **IMMA** part of #65 (ISRAs, IBAs, and the marine-KBA subset remain; full KBA is now at `public-kba`, #432).

## What
Imports the IUCN-MMPATF Important Marine Mammal Areas (**December 2025** release, **323 IMMAs**) to `public-high-seas/imma` — GeoParquet + PMTiles + H3 hex, a sibling of `ebsa`/`megamove`.

## Preprocess
The single GPKG layer has spaced/`#`-prefixed column names and 3D polygons, and several polygons carry **up to 745k coastline vertices** (which made res-8 polyfill run >40 min on one feature). The convert step:
- cleans column names to snake_case (SQLite dialect), flattens 3D→2D;
- **simplifies geometry at ~110 m (0.001°) topology-preserving tolerance** — cuts total vertices 4.4M→657k; negligible at the res-5–8 hex scale and z≤11 tiles (documented in STAC/README provenance).

## Resolution
IMMA polygons span 1 km² → **11.8M km²** (ocean-scale migratory corridors), so hex uses **`--resolution-by-area "12:8,600:6,5"`** (small→res 8, mid→res 6, ocean-scale→res 5), **parents `6,5,4,0`**. `h5` is present on every row (the universal join key, matching EBSA's h5); `h8`/`h6` are NULL for coarser-native large features — documented on the hex asset (join at the coarsest shared resolution / `h3_cell_to_parent`).

## License — ⛔ proprietary / non-commercial / non-redistributable
IUCN-MMPATF User Licence Agreement: no third-party sharing, no republishing in original format, derived products carry the same terms. STAC `license: proprietary` + link.
- `public-high-seas` already on MinIO backup.
- source.coop: **excluded** (`imma/**`, `imma.parquet`, `imma.pmtiles` added to the high-seas `EXCLUDES`; **NO** verdict in `license-inventory.md`). Execution owned by geo-agent-ops.

## Validation
- flat: 323 rows = 323 `_cng_fid` = 323 `ident_code`, 0 null geom.
- hex: 9.85M rows, `COUNT(DISTINCT _cng_fid)` = **323**; `h5` non-null on every row.
- `scripts/verify-stac.py --bucket public-high-seas --dataset imma` → **PASS (0 hard)**.

Recipe was run against the cluster; STAC + high-seas catalog registration are already published, so the Verify STAC CI check reads the live artifact.