### PR TITLE
feat(#487): BLM National MLRS locatable-mineral operations (public-blm/locatable-operations)

### DIFF
--- a/catalog/blm/k8s/locatable-operations/configmap.yaml
+++ b/catalog/blm/k8s/locatable-operations/configmap.yaml
@@ -1,0 +1,436 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: locatable-operations-setup-bucket.yaml, locatable-operations-convert.yaml, locatable-operations-pmtiles.yaml, locatable-operations-hex.yaml, locatable-operations-repartition.yaml
+# DAG (workflow.yaml): setup-bucket -> convert -> (pmtiles || hex) -> repartition.
+# NOTE: locatable-operations-stage-raw.yaml (the two-layer ArcGIS union scrape) runs
+# standalone BEFORE this DAG and is not embedded here.
+apiVersion: v1
+data:
+  locatable-operations-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: locatable-operations-setup-bucket
+      labels:
+        k8s-app: locatable-operations-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: locatable-operations-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  locatable-operations-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: locatable-operations-convert
+      labels:
+        k8s-app: locatable-operations-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: locatable-operations-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-blm/raw/locatable-operations.geojson \
+                s3://public-blm/locatable-operations.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '2'
+                memory: 8Gi
+              limits:
+                cpu: '2'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  locatable-operations-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: locatable-operations-pmtiles
+      labels:
+        k8s-app: locatable-operations-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: locatable-operations-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: locatable-operations
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/locatable-operations.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '2'
+                memory: 8Gi
+              limits:
+                cpu: '2'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  locatable-operations-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: locatable-operations-hex
+      labels:
+        k8s-app: locatable-operations-hex
+    spec:
+      completions: 10
+      parallelism: 10
+      completionMode: Indexed
+      # chunk-size 300 x 10 completions = 3,000 capacity, covers all ~2,399 features
+      # (1,264 Notices + 1,135 Plans of Operations, unioned) with margin; the last few
+      # indices simply process empty ranges (tolerated, as in mining-claims #477).
+      # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+      # publishing a subset (#409).
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 2
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: locatable-operations-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: locatable-operations
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-blm/locatable-operations.parquet --output s3://public-blm/locatable-operations/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 300 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '2'
+                memory: 8Gi
+                ephemeral-storage: 5Gi
+              limits:
+                cpu: '2'
+                memory: 8Gi
+                ephemeral-storage: 5Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  locatable-operations-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: locatable-operations-repartition
+      labels:
+        k8s-app: locatable-operations-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: locatable-operations-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # This dataset is tiny (~2,399 small parcels), so the hex output is a few hundred
+              # thousand cell rows at most -- it merges into the 9 h0 partitions comfortably in
+              # memory. No cephfs scratch PVC needed (unlike mining-claims #477, whose oversized
+              # geometries inflated to ~1.9B rows). Local /tmp is sufficient for spill.
+              cng-datasets repartition --chunks-dir s3://public-blm/locatable-operations/chunks --output-dir s3://public-blm/locatable-operations/hex --source-parquet s3://public-blm/locatable-operations.parquet --cleanup --memory-limit 24GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: locatable-operations-yamls
+  namespace: geo-workflows

--- a/catalog/blm/k8s/locatable-operations/locatable-operations-convert.yaml
+++ b/catalog/blm/k8s/locatable-operations/locatable-operations-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-convert
+  labels:
+    k8s-app: locatable-operations-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: locatable-operations-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-blm/raw/locatable-operations.geojson \
+            s3://public-blm/locatable-operations.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '2'
+            memory: 8Gi
+          limits:
+            cpu: '2'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/locatable-operations/locatable-operations-hex.yaml
+++ b/catalog/blm/k8s/locatable-operations/locatable-operations-hex.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-hex
+  labels:
+    k8s-app: locatable-operations-hex
+spec:
+  completions: 10
+  parallelism: 10
+  completionMode: Indexed
+  # chunk-size 300 x 10 completions = 3,000 capacity, covers all ~2,399 features
+  # (1,264 Notices + 1,135 Plans of Operations, unioned) with margin; the last few
+  # indices simply process empty ranges (tolerated, as in mining-claims #477).
+  # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+  # publishing a subset (#409).
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: locatable-operations-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: locatable-operations
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-blm/locatable-operations.parquet --output s3://public-blm/locatable-operations/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 300 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '2'
+            memory: 8Gi
+            ephemeral-storage: 5Gi
+          limits:
+            cpu: '2'
+            memory: 8Gi
+            ephemeral-storage: 5Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/locatable-operations/locatable-operations-pmtiles.yaml
+++ b/catalog/blm/k8s/locatable-operations/locatable-operations-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-pmtiles
+  labels:
+    k8s-app: locatable-operations-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: locatable-operations-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: locatable-operations
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/locatable-operations.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '2'
+            memory: 8Gi
+          limits:
+            cpu: '2'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/locatable-operations/locatable-operations-repartition.yaml
+++ b/catalog/blm/k8s/locatable-operations/locatable-operations-repartition.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-repartition
+  labels:
+    k8s-app: locatable-operations-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: locatable-operations-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # This dataset is tiny (~2,399 small parcels), so the hex output is a few hundred
+          # thousand cell rows at most -- it merges into the 9 h0 partitions comfortably in
+          # memory. No cephfs scratch PVC needed (unlike mining-claims #477, whose oversized
+          # geometries inflated to ~1.9B rows). Local /tmp is sufficient for spill.
+          cng-datasets repartition --chunks-dir s3://public-blm/locatable-operations/chunks --output-dir s3://public-blm/locatable-operations/hex --source-parquet s3://public-blm/locatable-operations.parquet --cleanup --memory-limit 24GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/locatable-operations/locatable-operations-setup-bucket.yaml
+++ b/catalog/blm/k8s/locatable-operations/locatable-operations-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-setup-bucket
+  labels:
+    k8s-app: locatable-operations-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: locatable-operations-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/locatable-operations/locatable-operations-stage-raw.yaml
+++ b/catalog/blm/k8s/locatable-operations/locatable-operations-stage-raw.yaml
@@ -1,0 +1,197 @@
+# Stage raw BLM National MLRS locatable-mineral operations from the ArcGIS FeatureServers to S3.
+#
+# Unions the TWO locatable-operation service layers into a single GeoJSON, tagging each
+# feature with a derived `op_level` (Notice / Plan of Operations) so the two levels are
+# filterable in one collection (mirrors mining claims #477 holding both dispositions
+# together, and leases #451 holding all dispositions together). Each layer is paginated
+# (maxRecordCount 2000) with the same robustness as the leases/claims scrapes.
+#
+# Schema note (verified live against the FeatureServer, issue #487): these are the
+# locatable/materials MLRS schema family — unlike the mining-claims service, they DO carry
+# real case dates (EFF_DT/EXP_DT/SALE_DT/CSE_DISP_DT), a commodity field (CMMDTY), and
+# administrative/geographic state (ADMIN_STATE/GEO_STATE). So a numeric `op_year` (year of
+# EFF_DT) IS derivable for the year slider, and state is taken directly (no serial-prefix
+# derivation needed). MLRS dates arrive as epoch-milliseconds and are parsed to ISO.
+#
+#   Sources:
+#     https://gis.blm.gov/nlsdb/rest/services/HUB/BLM_Natl_MLRS_Locatable_Notices/FeatureServer/0
+#     https://gis.blm.gov/nlsdb/rest/services/HUB/BLM_Natl_MLRS_Locatable_Plans_Of_Operations/FeatureServer/0
+#   Issue:  https://github.com/boettiger-lab/data-workflows/issues/487
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-stage-raw
+  labels:
+    k8s-app: locatable-operations-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: locatable-operations-stage-raw
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: 3600
+      # Cluster DNS on some nodes intermittently fails to resolve external hosts
+      # (gis.blm.gov). Append public resolvers as a fallback; cluster DNS is still tried
+      # first so the internal rook-ceph-rgw-nautiluss3.rook rclone endpoint keeps resolving.
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+      containers:
+      - name: stage-raw
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, time, urllib.parse, urllib.request, urllib.error
+          from datetime import datetime, timedelta, timezone
+
+          LAYERS = [
+              ("Notice",
+               "https://gis.blm.gov/nlsdb/rest/services/HUB/"
+               "BLM_Natl_MLRS_Locatable_Notices/FeatureServer/0/query"),
+              ("Plan of Operations",
+               "https://gis.blm.gov/nlsdb/rest/services/HUB/"
+               "BLM_Natl_MLRS_Locatable_Plans_Of_Operations/FeatureServer/0/query"),
+          ]
+          PAGE = 2000
+          EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+          # gis.blm.gov 403s the default python-urllib User-Agent -- send an explicit one
+          UA = {"User-Agent": "data-workflows/1.0 (boettiger-lab; issue 487)"}
+
+          # Attributes to keep (everything else is internal/GIS junk). BLM_PROD is the
+          # operation product; CSE_DISP the disposition/status; CMMDTY the commodity worked;
+          # RCRD_ACRS the case acres (per-feature total, dedup by _cng_fid before SUM).
+          KEEP = ("CSE_NR", "CSE_NAME", "BLM_PROD", "CSE_DISP", "CMMDTY", "RCRD_ACRS",
+                  "ADMIN_STATE", "GEO_STATE", "PRDCNG",
+                  "EFF_DT", "EXP_DT", "SALE_DT", "CSE_DISP_DT", "Created", "Modified")
+          DATE_FIELDS = ("EFF_DT", "EXP_DT", "SALE_DT", "CSE_DISP_DT", "Created", "Modified")
+
+          def fetch_page(url, tries=6):
+              # the FeatureServer intermittently returns 503/timeouts; retry each page with
+              # exponential backoff so one transient blip does not lose the whole scrape.
+              for attempt in range(1, tries + 1):
+                  try:
+                      req = urllib.request.Request(url, headers=UA)
+                      with urllib.request.urlopen(req, timeout=180) as r:
+                          return json.load(r)
+                  except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+                      if attempt == tries:
+                          raise
+                      wait = min(60, 2 ** attempt)
+                      print(f"  retry {attempt}/{tries} after {type(e).__name__} ({e}); sleep {wait}s", flush=True)
+                      time.sleep(wait)
+
+          def ms_to_iso(v):
+              if v is None:
+                  return None
+              return (EPOCH + timedelta(milliseconds=v)).strftime("%Y-%m-%d")
+
+          def clean(feat, op_level):
+              p = feat.get("properties") or {}
+              out = {k: p.get(k) for k in KEEP}
+              # ISO dates (MLRS epoch-ms -> YYYY-MM-DD)
+              for d in DATE_FIELDS:
+                  out[d] = ms_to_iso(out.get(d))
+              # derived: which service layer this row came from
+              out["op_level"] = op_level
+              # derived numeric year of the effective date, for the time slider (null if absent)
+              eff = out.get("EFF_DT")
+              out["op_year"] = int(eff[:4]) if eff else None
+              feat["properties"] = out
+              return feat
+
+          feats = []
+          counts = {}
+          for op_level, base in LAYERS:
+              n0 = len(feats)
+              offset = 0
+              while True:
+                  q = {
+                      "where": "1=1",
+                      "outFields": "*",
+                      "outSR": "4326",              # WGS84 lon/lat (source is NAD83 / WKID 4269)
+                      "f": "geojson",
+                      "resultOffset": offset,
+                      "resultRecordCount": PAGE,
+                      "orderByFields": "OBJECTID",  # stable pagination order
+                  }
+                  url = base + "?" + urllib.parse.urlencode(q)
+                  fc = fetch_page(url)
+                  batch = fc.get("features", [])
+                  for feat in batch:
+                      feats.append(clean(feat, op_level))
+                  print(f"[{op_level}] offset {offset}: +{len(batch)} (total {len(feats)})", flush=True)
+                  more = fc.get("properties", {}).get("exceededTransferLimit") or fc.get("exceededTransferLimit")
+                  if len(batch) < PAGE and not more:
+                      break
+                  if not batch:
+                      break
+                  offset += len(batch)
+              counts[op_level] = len(feats) - n0
+              print(f"[{op_level}] DONE: {counts[op_level]} features", flush=True)
+
+          # sanity check: distinct states and year range
+          states = sorted({(f["properties"].get("ADMIN_STATE") or "") for f in feats})
+          years = sorted({y for f in feats if (y := f["properties"].get("op_year")) is not None})
+          print(f"distinct ADMIN_STATE: {states}", flush=True)
+          print(f"op_year range: {years[:1]}..{years[-1:]}", flush=True)
+
+          out = {"type": "FeatureCollection",
+                 "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
+                 "features": feats}
+          with open("/tmp/locatable-operations.geojson", "w") as f:
+              json.dump(out, f)
+          print(f"WROTE {len(feats)} features ({counts})", flush=True)
+          # fail loudly if the FeatureServers under-delivered vs the known counts
+          # (~1,264 Notices + ~1,135 Plans of Operations ~= 2,399, verified live 2026-07-23)
+          assert len(feats) >= 2300, f"expected ~2,399 features, got {len(feats)}"
+          PY
+          ls -la /tmp/locatable-operations.geojson
+          rclone copyto /tmp/locatable-operations.geojson nrp:public-blm/raw/locatable-operations.geojson --s3-no-check-bucket
+          echo "staged raw -> s3://public-blm/raw/locatable-operations.geojson"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 4Gi
+          limits:
+            cpu: '1'
+            memory: 4Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/locatable-operations/workflow-rbac.yaml
+++ b/catalog/blm/k8s/locatable-operations/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/blm/k8s/locatable-operations/workflow.yaml
+++ b/catalog/blm/k8s/locatable-operations/workflow.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locatable-operations-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - bash
+        - -c
+        args:
+        - |
+          set -e
+
+          echo "Starting locatable-operations workflow..."
+
+          # Step 0: Setup bucket with public access and CORS
+          echo "Step 0: Setting up bucket..."
+          kubectl apply -f /yamls/locatable-operations-setup-bucket.yaml -n geo-workflows
+          echo "Waiting for bucket setup to complete..."
+          kubectl wait --for=condition=complete --timeout=600s job/locatable-operations-setup-bucket -n geo-workflows
+
+          # Step 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)
+          echo "Step 1: Converting to optimized GeoParquet..."
+          kubectl apply -f /yamls/locatable-operations-convert.yaml -n geo-workflows
+          echo "Waiting for GeoParquet conversion to complete..."
+          kubectl wait --for=condition=complete --timeout=3600s job/locatable-operations-convert -n geo-workflows
+
+          # Step 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)
+          echo "Step 2: H3 hexagonal tiling and PMTiles generation (parallel)..."
+          kubectl apply -f /yamls/locatable-operations-pmtiles.yaml -n geo-workflows
+          kubectl apply -f /yamls/locatable-operations-hex.yaml -n geo-workflows
+          echo "Waiting for hex tiling to complete (PMTiles continues in background)..."
+          kubectl wait --for=condition=complete --timeout=7200s job/locatable-operations-hex -n geo-workflows
+
+          # Step 3: Repartition by h0
+          echo "Step 3: Repartitioning by h0..."
+          kubectl apply -f /yamls/locatable-operations-repartition.yaml -n geo-workflows
+          echo "Waiting for repartition to complete..."
+          kubectl wait --for=condition=complete --timeout=3600s job/locatable-operations-repartition -n geo-workflows
+
+          echo "✓ Workflow complete!"
+          echo "Note: PMTiles job may still be running in the background"
+          echo ""
+          echo "Clean up with:"
+          echo "  kubectl delete jobs locatable-operations-setup-bucket locatable-operations-convert locatable-operations-pmtiles locatable-operations-hex locatable-operations-repartition locatable-operations-workflow -n geo-workflows"
+          echo "  kubectl delete configmap locatable-operations-yamls -n geo-workflows"
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: locatable-operations-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #487 (pipeline setup; publishes on cluster run).

## What
Adds the k8s pipeline for **BLM National MLRS locatable-mineral operations** — the *activity* companion to the mining-claims layer (#477). Unions the two BLM MLRS FeatureServer layers into one `public-blm/locatable-operations` dataset:

| Source layer | Polygon features | op_level |
|---|--:|---|
| `BLM_Natl_MLRS_Locatable_Notices/FeatureServer/0` | 1,264 | `Notice` |
| `BLM_Natl_MLRS_Locatable_Plans_Of_Operations/FeatureServer/0` | 1,135 | `Plan of Operations` |

National scope, ~2,399 features total. Formats: GeoParquet + PMTiles + H3 hex (native res 10, parents `9,8,0`) — matched to leases #451 / mining-claims #477 so everything joins at `h8`.

## Approach
Modeled on the mining-claims #477 manifest set (which already unions two BLM layers). Differences, because these layers carry a richer schema than the claims service (verified live against the FeatureServer):
- **Real dates present** (`EFF_DT`/`EXP_DT`/`SALE_DT`/`CSE_DISP_DT`) → derive a numeric **`op_year`** (year of `EFF_DT`) for the year slider. (Mining claims had only record-management dates, so no year column.)
- **`CMMDTY` (commodity) and `ADMIN_STATE`/`GEO_STATE` present** → kept directly; no serial-prefix state derivation needed.
- `CSE_DISP` (status) retained; `RCRD_ACRS` is a per-feature total — dedup by `_cng_fid` before any acreage SUM.
- MLRS epoch-ms dates parsed to ISO `YYYY-MM-DD` in `stage-raw`.
- Scaled down for the small feature count: hex `chunk-size 300 × 10` completions; modest repartition (no cephfs scratch PVC — the claims job needed it only for its ~1.9B inflated rows).

## Files
`catalog/blm/k8s/locatable-operations/`: `stage-raw` (custom two-layer union scrape) + the generated `setup-bucket → convert → (pmtiles ‖ hex) → repartition` DAG (`workflow.yaml`, `configmap.yaml`, `workflow-rbac.yaml`). All nine YAMLs validated; the five DAG jobs are embedded in `configmap.yaml`.

STAC collection + README are authored and published to S3 after the cluster run completes (per repo convention), not in this PR.

## To run (cluster; requires kubectl + geo-workflows namespace)
```bash
D=catalog/blm/k8s/locatable-operations
kubectl apply -f $D/workflow-rbac.yaml -n geo-workflows          # one-time, likely already present
kubectl apply -f $D/locatable-operations-stage-raw.yaml -n geo-workflows
kubectl wait --for=condition=complete --timeout=3600s job/locatable-operations-stage-raw -n geo-workflows
kubectl apply -f $D/configmap.yaml -f $D/workflow.yaml -n geo-workflows
kubectl logs -f job/locatable-operations-workflow -n geo-workflows
```

## Verify after run
- `s3://public-blm/locatable-operations.parquet`, `.pmtiles`, and `locatable-operations/hex/h0=*/` present.
- Feature count ≈ 2,399; `op_level` ∈ {Notice, Plan of Operations}; `op_year` numeric.
- STAC `vector:layers` + per-asset `table:columns`; `verify-stac.py` exits 0.