### PR TITLE
feat(#488): BLM National MLRS land-use authorizations & land tenure — LUA leases/permits/easements, LUA ROW, acquisitions

### DIFF
--- a/catalog/blm/k8s/acquisitions/acquisitions-convert.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-convert
+  labels:
+    k8s-app: acquisitions-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-blm/raw/acquisitions.geojson \
+            s3://public-blm/acquisitions.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-hex-rechunk.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-hex-rechunk.yaml
@@ -1,0 +1,103 @@
+# Reprocess the single hex chunk that OOMed in the main acquisitions-hex run (issue #488).
+#
+# Chunk 13 completed ALL 327/327 unnest batches and then OOMKilled (exit 137) at 16Gi during
+# "Writing final output ... chunk_000013.parquet" -- i.e. the failure is in the final
+# aggregate-and-write step, NOT in pass-2 unnesting. That distinction matters:
+#   * lowering --intermediate-chunk-size (the usual first move for an unnest OOM) would NOT
+#     help here, because the unnest had already finished;
+#   * and the failure is deterministic, so the Job's automatic per-index retry would spend
+#     another ~2 h redoing all 327 batches only to die at the same write. It is cheaper to
+#     kill that retry and re-run this one chunk with enough RAM to land the write.
+#
+# So: same chunk-size/resolution as the main run (identical output contract), 96Gi instead of
+# 16Gi, and the full 50Gi ephemeral allowance for DuckDB spill. Runs standalone, AFTER the main
+# hex job and BEFORE repartition -- repartition reads every chunks/*.parquet, so publishing
+# without this chunk would silently drop ~2,500 case records' worth of cells.
+#
+#   Issue: https://github.com/boettiger-lab/data-workflows/issues/488
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-hex-rechunk
+  labels:
+    k8s-app: acquisitions-hex-rechunk
+spec:
+  completions: 1
+  parallelism: 1
+  completionMode: Indexed
+  # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+  # publishing a subset of h0 partitions (#409). Verified after the run with
+  # scripts/check-hex-coverage.sh.
+  backoffLimitPerIndex: 1
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-hex-rechunk
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: acquisitions
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          # CHUNK_MAP pattern (AGENTS.md "Reprocessing Failed Chunks"): remap this job's
+          # completion index onto the real chunk id that failed in the main run.
+          CHUNK_MAP=(13)
+          CHUNK_ID=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+          echo "reprocessing acquisitions hex chunk ${CHUNK_ID}"
+          cng-datasets vector --input s3://public-blm/acquisitions.parquet --output s3://public-blm/acquisitions/chunks --chunk-id ${CHUNK_ID} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 96Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 96Gi
+            ephemeral-storage: 50Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-hex.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-hex.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-hex
+  labels:
+    k8s-app: acquisitions-hex
+spec:
+  completions: 40
+  parallelism: 50
+  completionMode: Indexed
+  # chunk-size 2500 x 40 completions = 100,000 capacity, covers all 97,529
+  # features with margin.
+  # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+  # publishing a subset of h0 partitions (#409). Verified after the run with
+  # scripts/check-hex-coverage.sh.
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: acquisitions
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-blm/acquisitions.parquet --output s3://public-blm/acquisitions/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-pmtiles.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-pmtiles.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-pmtiles
+  labels:
+    k8s-app: acquisitions-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: acquisitions
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/acquisitions.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          # --coalesce-densest-as-needed (merge rather than discard) + -z13 is the
+          # established BLM MLRS tiling recipe (#451/#477/#487): these are small cadastral
+          # parcels, so merging neighbours in dense tiles preserves coverage where plain
+          # dropping would punch holes.
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-repartition-pvc.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-repartition-pvc.yaml
@@ -1,0 +1,105 @@
+# PVC-backed retry of the acquisitions h0 repartition (issue #488).
+#
+# The stock repartition (50Gi ephemeral) was EVICTED: "Pod ephemeral local storage usage
+# exceeds the total limit of containers 50Gi". That is DuckDB spilling to local disk while
+# merging 40 chunks -- one of which, chunk_000013.parquet, is 2.18 GB on its own -- into the
+# 8 h0 partitions. 50Gi is the namespace MAXIMUM for ephemeral-storage, so the fix is not a
+# bigger ephemeral request (the quota would reject it) but moving scratch onto the shared
+# 2Ti rook-cephfs `rechunk-scratch` PVC, exactly as mining-claims #477 does.
+#
+# Both scratch paths are redirected: TMPDIR (the tool's own temp writes) and the process CWD
+# (DuckDB's spill file is CWD-relative), plus /tmp/hex symlinked onto the PVC. Ephemeral is
+# then dropped to 20Gi because almost nothing lands on it. Memory is raised 64Gi -> 192Gi
+# (DuckDB --memory-limit 160GiB) since the previous attempt was running at 88% of its 64Gi
+# cap, which forces yet more spilling -- more RAM means less disk churn, not just less OOM
+# risk. cephfs handles a few large sequential spill files well; it is the many-small-file
+# case that is pathological there.
+#
+#   Issue: https://github.com/boettiger-lab/data-workflows/issues/488
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-repartition-pvc
+  labels:
+    k8s-app: acquisitions-repartition-pvc
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-repartition-pvc
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /scratch
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: scratch
+          mountPath: /scratch
+          subPath: acquisitions-repartition
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # put ALL scratch on the PVC: the tool's /tmp/hex writes and DuckDB's
+          # CWD-relative spill file both need to be off the 50Gi ephemeral disk.
+          mkdir -p /scratch/hex && cd /scratch
+          ln -s /scratch/hex /tmp/hex 2>/dev/null || true
+          cng-datasets repartition --chunks-dir s3://public-blm/acquisitions/chunks --output-dir s3://public-blm/acquisitions/hex --source-parquet s3://public-blm/acquisitions.parquet --cleanup --memory-limit 160GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 192Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 192Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: scratch
+        persistentVolumeClaim:
+          claimName: rechunk-scratch
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-repartition.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-repartition
+  labels:
+    k8s-app: acquisitions-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-blm/acquisitions/chunks --output-dir s3://public-blm/acquisitions/hex --source-parquet s3://public-blm/acquisitions.parquet --cleanup --memory-limit 54GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-setup-bucket.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-setup-bucket
+  labels:
+    k8s-app: acquisitions-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/acquisitions-stage-raw.yaml
+++ b/catalog/blm/k8s/acquisitions/acquisitions-stage-raw.yaml
@@ -1,0 +1,241 @@
+# Stage raw BLM National MLRS Acquisitions from the ArcGIS FeatureServer to S3.
+#
+# Lands and interests in land that BLM has purchased or otherwise acquired --- including
+# access and conservation easements and acquired mineral/water rights. The land-TENURE half
+# of the non-mineral MLRS records (the surface-USE half is LUA leases/permits/easements and
+# LUA ROW, same issue), alongside the mineral case records (#451 leases, #477 claims, #487
+# locatable operations). Paginated (maxRecordCount 2000) with the same robustness as those
+# scrapes: explicit User-Agent, per-page retry with backoff, stable OBJECTID ordering, and a
+# terminal count assert.
+#
+# ⚠️ The feature layer is at `/FeatureServer/1`, NOT `/0` --- layer 0 404s on this service.
+#
+# Schema note (verified live against the FeatureServer 2026-07-24, issue #488): this is the
+# MLRS **tenure hybrid variant**. Like the LUA layers it carries no leasing dates (no
+# EFF_DT/EXP_DT/SALE_DT); the only case date is CSE_DISP_DT (Case Disposition Date), so the
+# year-slider column is `disp_year`. ⚠️ CSE_DISP_DT is populated on only 30,438 of 97,529
+# features (31%) --- `disp_year` is NULL for the other 69%, which are predominantly the
+# "Status Record" disposition (historical status entries carried over from the pre-MLRS
+# record systems). Any year-slider UI must treat null-year features as always-visible or
+# explicitly excluded; it must not silently drop two thirds of the layer.
+#
+# ⚠️ PAT_NR (Patent Number) is NOT a year and no patent year is derivable from it. The issue
+# asked to confirm this at ingest: sampled values are patent volume/number strings such as
+# "3 1206", "2 784", "2 1292C" --- a volume, a serial, and an optional suffix letter, with no
+# date component. PAT_NR is retained verbatim as a General Land Office patent reference (it
+# joins to the BLM GLO patent records) but no `pat_year` column is derived.
+#
+# Instead of the LUA jurisdiction/dimension fields this variant carries the tenure fields
+# PAT_NR, SEG_MIN / SEG_SUR (segregation, mineral / surface), SUPP_USE (supplemental use),
+# REC_TYPE_CSE_GRP (record type - case group) and CSE_DISP_ACTION --- all retained. MLRS
+# dates arrive as epoch-MILLISECONDS even in GeoJSON output and are parsed to ISO here.
+#
+# Dropped fields and why:
+#   Shape__Area / Shape__Length  decimal-degree junk (real area is RCRD_ACRS)
+#   QLTY                         despite the "Data Quality" alias this is NOT a quality
+#                                code --- it is a multi-kilobyte free-text dump of the LLD
+#                                geocoder's debug log ("10 sections retrieved\n160
+#                                intersected features retrieved...", 2000+ distinct values).
+#                                Carrying it would bloat the GeoParquet and PMTiles for no
+#                                analytical value. `SRC` (5 clean values: LLD/CLS, BULK,
+#                                MIGRATE, PROTOOLS, None) is retained instead and is the
+#                                useful geocoding-provenance field.
+#   CSE_META, SF_ID, ID, OBJECTID  internal MLRS/Salesforce/GIS record keys
+#
+# Polygons are geocoded from Legal Land Descriptions via the PLSS, so some cases have no
+# geometry (751 of 97,529 have a null Shape__Area). Those rows are retained as
+# attribute-only records; cng-datasets drops them at hex time.
+#
+#   Source: https://gis.blm.gov/nlsdb/rest/services/HUB/BLM_Natl_MLRS_Acquisitions/FeatureServer/1
+#   Issue:  https://github.com/boettiger-lab/data-workflows/issues/488
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-stage-raw
+  labels:
+    k8s-app: acquisitions-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: acquisitions-stage-raw
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: 7200
+      # Cluster DNS on some nodes intermittently fails to resolve external hosts
+      # (gis.blm.gov). Append public resolvers as a fallback; cluster DNS is still tried
+      # first so the internal rook-ceph-rgw-nautiluss3.rook rclone endpoint keeps resolving.
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+      containers:
+      - name: stage-raw
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, time, urllib.parse, urllib.request, urllib.error
+          from datetime import datetime, timedelta, timezone
+
+          # NOTE: /FeatureServer/1 -- layer 0 404s on this service
+          BASE = ("https://gis.blm.gov/nlsdb/rest/services/HUB/"
+                  "BLM_Natl_MLRS_Acquisitions/FeatureServer/1/query")
+          PAGE = 2000
+          EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)  # handles pre-1970 (negative ms)
+          # gis.blm.gov 403s the default python-urllib User-Agent -- send an explicit one
+          UA = {"User-Agent": "data-workflows/1.0 (boettiger-lab; issue 488)"}
+
+          # Attributes to keep. CSE_DISP is the disposition/status (Authorized / Interim /
+          # Status Record); RCRD_ACRS the case acres (a per-feature total -- dedup by
+          # _cng_fid before any SUM); PAT_NR the GLO patent reference; SEG_MIN/SEG_SUR the
+          # mineral/surface segregation; SUPP_USE the supplemental use;
+          # CUST_NM_SEC/PCT_INT_SEC/INT_REL_SEC the business account (who acquired/holds the
+          # interest) and its share.
+          KEEP = ("CSE_NR", "LEG_CSE_NR", "CSE_NAME", "CSE_TYPE_NR", "BLM_PROD",
+                  "CSE_DISP", "CSE_DISP_ACTION", "REC_TYPE_CSE_GRP", "CMMDTY", "RCRD_ACRS",
+                  "ADMIN_STATE", "GEO_STATE",
+                  "PAT_NR", "SEG_MIN", "SEG_SUR", "SUPP_USE",
+                  "CUST_NM_SEC", "PCT_INT_SEC", "INT_REL_SEC",
+                  "SRC", "CSE_DISP_DT", "Created", "Modified")
+          DATE_FIELDS = ("CSE_DISP_DT", "Created", "Modified")
+
+          def fetch_page(url, tries=6):
+              # the FeatureServer intermittently returns 503/timeouts; retry each page with
+              # exponential backoff so one transient blip does not lose the whole scrape.
+              for attempt in range(1, tries + 1):
+                  try:
+                      req = urllib.request.Request(url, headers=UA)
+                      with urllib.request.urlopen(req, timeout=180) as r:
+                          return json.load(r)
+                  except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+                      if attempt == tries:
+                          raise
+                      wait = min(60, 2 ** attempt)
+                      print(f"  retry {attempt}/{tries} after {type(e).__name__} ({e}); sleep {wait}s", flush=True)
+                      time.sleep(wait)
+
+          def ms_to_iso(v):
+              if v is None:
+                  return None
+              return (EPOCH + timedelta(milliseconds=v)).strftime("%Y-%m-%d")
+
+          def clean(feat):
+              p = feat.get("properties") or {}
+              out = {k: p.get(k) for k in KEEP}
+              # normalize strings: strip surrounding whitespace/newlines (REC_TYPE_CSE_GRP
+              # ships with a trailing "\n" -- e.g. "Status - Acquisitions\n" -- and CSE_NAME /
+              # LEG_CSE_NR ship whitespace-only placeholders) and map empty -> None
+              for k, v in list(out.items()):
+                  if isinstance(v, str):
+                      v = v.strip()
+                      out[k] = v or None
+              # ISO dates (MLRS epoch-ms -> YYYY-MM-DD)
+              for d in DATE_FIELDS:
+                  out[d] = ms_to_iso(p.get(d))
+              # derived numeric year of the case disposition date, for the time slider. This
+              # is the ONLY case date this service exposes, and it is null on ~69% of
+              # features (mostly the "Status Record" disposition) -- documented in STAC.
+              disp = out.get("CSE_DISP_DT")
+              out["disp_year"] = int(disp[:4]) if disp else None
+              feat["properties"] = out
+              return feat
+
+          feats, offset = [], 0
+          while True:
+              q = {
+                  "where": "1=1",
+                  "outFields": "*",
+                  "outSR": "4326",              # WGS84 lon/lat (source is NAD83 / WKID 4269)
+                  "f": "geojson",
+                  "resultOffset": offset,
+                  "resultRecordCount": PAGE,
+                  "orderByFields": "OBJECTID",  # stable pagination order
+              }
+              url = BASE + "?" + urllib.parse.urlencode(q)
+              fc = fetch_page(url)
+              batch = fc.get("features", [])
+              for feat in batch:
+                  feats.append(clean(feat))
+              print(f"offset {offset}: +{len(batch)} (total {len(feats)})", flush=True)
+              more = fc.get("properties", {}).get("exceededTransferLimit") or fc.get("exceededTransferLimit")
+              if len(batch) < PAGE and not more:
+                  break
+              if not batch:
+                  break
+              offset += len(batch)
+
+          # sanity check: disposition set, record-type groups, states, year range, null geom
+          disps = sorted({(f["properties"].get("CSE_DISP") or "") for f in feats})
+          grps = sorted({(f["properties"].get("REC_TYPE_CSE_GRP") or "") for f in feats})
+          states = sorted({(f["properties"].get("ADMIN_STATE") or "") for f in feats})
+          years = sorted({y for f in feats if (y := f["properties"].get("disp_year")) is not None})
+          nogeom = sum(1 for f in feats if not f.get("geometry"))
+          nullyear = sum(1 for f in feats if f["properties"].get("disp_year") is None)
+          npat = sum(1 for f in feats if f["properties"].get("PAT_NR"))
+          print(f"CSE_DISP: {disps}", flush=True)
+          print(f"REC_TYPE_CSE_GRP: {grps}", flush=True)
+          print(f"distinct ADMIN_STATE: {states}", flush=True)
+          print(f"disp_year range: {years[:1]}..{years[-1:]} ({nullyear} null)", flush=True)
+          print(f"PAT_NR populated: {npat}", flush=True)
+          print(f"null-geometry features: {nogeom}", flush=True)
+
+          out = {"type": "FeatureCollection",
+                 "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
+                 "features": feats}
+          with open("/tmp/acquisitions.geojson", "w") as f:
+              json.dump(out, f)
+          print(f"WROTE {len(feats)} features", flush=True)
+          # fail loudly if the FeatureServer under-delivered vs the known count
+          # (97,529 polygon features, verified live 2026-07-24)
+          assert len(feats) >= 96000, f"expected ~97,529 features, got {len(feats)}"
+          PY
+          ls -la /tmp/acquisitions.geojson
+          rclone copyto /tmp/acquisitions.geojson nrp:public-blm/raw/acquisitions.geojson --s3-no-check-bucket
+          echo "staged raw -> s3://public-blm/raw/acquisitions.geojson"
+        resources:
+          requests:
+            cpu: '2'
+            memory: 12Gi
+            ephemeral-storage: 30Gi
+          limits:
+            cpu: '2'
+            memory: 12Gi
+            ephemeral-storage: 30Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/acquisitions/configmap.yaml
+++ b/catalog/blm/k8s/acquisitions/configmap.yaml
@@ -1,0 +1,450 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: acquisitions-setup-bucket.yaml, acquisitions-convert.yaml, acquisitions-pmtiles.yaml, acquisitions-hex.yaml, acquisitions-repartition.yaml
+# Generation command: cng-datasets workflow --dataset acquisitions --source-url s3://public-blm/raw/acquisitions.geojson --bucket public-blm --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap acquisitions-yamls \
+#     --from-file=acquisitions-setup-bucket.yaml \
+#     --from-file=acquisitions-convert.yaml \
+#     --from-file=acquisitions-pmtiles.yaml \
+#     --from-file=acquisitions-hex.yaml \
+#     --from-file=acquisitions-repartition.yaml
+#
+# NOTE: acquisitions-stage-raw.yaml (the ArcGIS FeatureServer scrape, /FeatureServer/1 --
+# layer 0 404s) runs standalone BEFORE this DAG and is not embedded here.
+# Hand-tuned after generation: hex completions 200->40 with --chunk-size 2500 (97,529
+# features), backoffLimit:0 -> backoffLimitPerIndex:2 + maxFailedIndexes:2 (#409), and the
+# tippecanoe line switched to the BLM parcel recipe (--coalesce-densest-as-needed -z13).
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  acquisitions-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acquisitions-setup-bucket
+      labels:
+        k8s-app: acquisitions-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acquisitions-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acquisitions-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acquisitions-convert
+      labels:
+        k8s-app: acquisitions-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acquisitions-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-blm/raw/acquisitions.geojson \
+                s3://public-blm/acquisitions.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acquisitions-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acquisitions-pmtiles
+      labels:
+        k8s-app: acquisitions-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acquisitions-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: acquisitions
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/acquisitions.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              # --coalesce-densest-as-needed (merge rather than discard) + -z13 is the
+              # established BLM MLRS tiling recipe (#451/#477/#487): these are small cadastral
+              # parcels, so merging neighbours in dense tiles preserves coverage where plain
+              # dropping would punch holes.
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acquisitions-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acquisitions-hex
+      labels:
+        k8s-app: acquisitions-hex
+    spec:
+      completions: 40
+      parallelism: 50
+      completionMode: Indexed
+      # chunk-size 2500 x 40 completions = 100,000 capacity, covers all 97,529
+      # features with margin.
+      # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+      # publishing a subset of h0 partitions (#409). Verified after the run with
+      # scripts/check-hex-coverage.sh.
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 2
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acquisitions-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: acquisitions
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-blm/acquisitions.parquet --output s3://public-blm/acquisitions/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  acquisitions-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: acquisitions-repartition
+      labels:
+        k8s-app: acquisitions-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: acquisitions-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-blm/acquisitions/chunks --output-dir s3://public-blm/acquisitions/hex --source-parquet s3://public-blm/acquisitions.parquet --cleanup --memory-limit 54GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: acquisitions-yamls
+  namespace: geo-workflows

--- a/catalog/blm/k8s/acquisitions/workflow-rbac.yaml
+++ b/catalog/blm/k8s/acquisitions/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/blm/k8s/acquisitions/workflow.yaml
+++ b/catalog/blm/k8s/acquisitions/workflow.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: acquisitions-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting acquisitions workflow...\"\n\n# Step 0: Setup\
+          \ bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/acquisitions-setup-bucket.yaml -n geo-workflows\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/acquisitions-setup-bucket -n geo-workflows\n\n# Step\
+          \ 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/acquisitions-convert.yaml -n geo-workflows\n\necho \"Waiting for\
+          \ GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/acquisitions-convert -n geo-workflows\n\n# Step 2:\
+          \ Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/acquisitions-pmtiles.yaml -n geo-workflows\nkubectl\
+          \ apply -f /yamls/acquisitions-hex.yaml -n geo-workflows\n\necho \"Waiting\
+          \ for hex tiling to complete (PMTiles continues in background)...\"\necho\
+          \ \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/acquisitions-hex -n geo-workflows\n\necho \"Step\
+          \ 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/acquisitions-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/acquisitions-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs acquisitions-setup-bucket acquisitions-convert\
+          \ acquisitions-pmtiles acquisitions-hex acquisitions-repartition acquisitions-workflow\
+          \ -n geo-workflows\"\necho \"  kubectl delete configmap acquisitions-yamls\
+          \ -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: acquisitions-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/blm/k8s/lua-leases-permits-easements/configmap.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/configmap.yaml
@@ -1,0 +1,451 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: lua-leases-permits-easements-setup-bucket.yaml, lua-leases-permits-easements-convert.yaml, lua-leases-permits-easements-pmtiles.yaml, lua-leases-permits-easements-hex.yaml, lua-leases-permits-easements-repartition.yaml
+# Generation command: cng-datasets workflow --dataset lua-leases-permits-easements --source-url s3://public-blm/raw/lua-leases-permits-easements.geojson --bucket public-blm --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap lua-leases-permits-easements-yamls \
+#     --from-file=lua-leases-permits-easements-setup-bucket.yaml \
+#     --from-file=lua-leases-permits-easements-convert.yaml \
+#     --from-file=lua-leases-permits-easements-pmtiles.yaml \
+#     --from-file=lua-leases-permits-easements-hex.yaml \
+#     --from-file=lua-leases-permits-easements-repartition.yaml
+#
+# NOTE: lua-leases-permits-easements-stage-raw.yaml (the ArcGIS FeatureServer scrape)
+# runs standalone BEFORE this DAG and is not embedded here.
+# Hand-tuned after generation: hex completions 200->40 with --chunk-size 1000 (39,598
+# features), backoffLimit:0 -> backoffLimitPerIndex:2 + maxFailedIndexes:2 (#409), and the
+# tippecanoe line switched to the BLM parcel recipe (--coalesce-densest-as-needed -z13).
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  lua-leases-permits-easements-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-leases-permits-easements-setup-bucket
+      labels:
+        k8s-app: lua-leases-permits-easements-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-leases-permits-easements-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-leases-permits-easements-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-leases-permits-easements-convert
+      labels:
+        k8s-app: lua-leases-permits-easements-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-leases-permits-easements-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-blm/raw/lua-leases-permits-easements.geojson \
+                s3://public-blm/lua-leases-permits-easements.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-leases-permits-easements-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-leases-permits-easements-pmtiles
+      labels:
+        k8s-app: lua-leases-permits-easements-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-leases-permits-easements-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: lua-leases-permits-easements
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/lua-leases-permits-easements.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              # --coalesce-densest-as-needed (merge rather than discard) + -z13 is the
+              # established BLM MLRS tiling recipe (#451/#477/#487): these are small cadastral
+              # parcels, so merging neighbours in dense tiles preserves coverage where plain
+              # dropping would punch holes.
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-leases-permits-easements-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-leases-permits-easements-hex
+      labels:
+        k8s-app: lua-leases-permits-easements-hex
+    spec:
+      completions: 40
+      parallelism: 50
+      completionMode: Indexed
+      # chunk-size 1000 x 40 completions = 40,000 capacity, covers all 39,598
+      # features with margin; the last index processes a short range (tolerated, as in
+      # locatable-operations #487).
+      # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+      # publishing a subset of h0 partitions (#409). Verified after the run with
+      # scripts/check-hex-coverage.sh.
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 2
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-leases-permits-easements-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: lua-leases-permits-easements
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-blm/lua-leases-permits-easements.parquet --output s3://public-blm/lua-leases-permits-easements/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-leases-permits-easements-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-leases-permits-easements-repartition
+      labels:
+        k8s-app: lua-leases-permits-easements-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-leases-permits-easements-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-blm/lua-leases-permits-easements/chunks --output-dir s3://public-blm/lua-leases-permits-easements/hex --source-parquet s3://public-blm/lua-leases-permits-easements.parquet --cleanup --memory-limit 54GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: lua-leases-permits-easements-yamls
+  namespace: geo-workflows

--- a/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-convert.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-convert
+  labels:
+    k8s-app: lua-leases-permits-easements-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-leases-permits-easements-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-blm/raw/lua-leases-permits-easements.geojson \
+            s3://public-blm/lua-leases-permits-easements.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-hex.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-hex.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-hex
+  labels:
+    k8s-app: lua-leases-permits-easements-hex
+spec:
+  completions: 40
+  parallelism: 50
+  completionMode: Indexed
+  # chunk-size 1000 x 40 completions = 40,000 capacity, covers all 39,598
+  # features with margin; the last index processes a short range (tolerated, as in
+  # locatable-operations #487).
+  # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+  # publishing a subset of h0 partitions (#409). Verified after the run with
+  # scripts/check-hex-coverage.sh.
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-leases-permits-easements-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: lua-leases-permits-easements
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-blm/lua-leases-permits-easements.parquet --output s3://public-blm/lua-leases-permits-easements/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-pmtiles.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-pmtiles.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-pmtiles
+  labels:
+    k8s-app: lua-leases-permits-easements-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-leases-permits-easements-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: lua-leases-permits-easements
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/lua-leases-permits-easements.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          # --coalesce-densest-as-needed (merge rather than discard) + -z13 is the
+          # established BLM MLRS tiling recipe (#451/#477/#487): these are small cadastral
+          # parcels, so merging neighbours in dense tiles preserves coverage where plain
+          # dropping would punch holes.
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-repartition.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-repartition
+  labels:
+    k8s-app: lua-leases-permits-easements-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-leases-permits-easements-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-blm/lua-leases-permits-easements/chunks --output-dir s3://public-blm/lua-leases-permits-easements/hex --source-parquet s3://public-blm/lua-leases-permits-easements.parquet --cleanup --memory-limit 54GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-setup-bucket.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-setup-bucket
+  labels:
+    k8s-app: lua-leases-permits-easements-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-leases-permits-easements-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-stage-raw.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/lua-leases-permits-easements-stage-raw.yaml
@@ -1,0 +1,217 @@
+# Stage raw BLM National MLRS LUA Leases / Permits / Easements from the ArcGIS
+# FeatureServer to S3.
+#
+# Land-use authorizations (leases, permits, easements) on BLM-administered land --- the
+# non-mineral surface-use counterpart to the MLRS mineral case records (#451 leases,
+# #477 claims, #487 locatable operations). Paginated (maxRecordCount 2000) with the same
+# robustness as those scrapes: explicit User-Agent, per-page retry with backoff, stable
+# OBJECTID ordering, and a terminal count assert.
+#
+# Schema note (verified live against the FeatureServer 2026-07-24, issue #488): this is the
+# MLRS **LUA variant**. It does NOT carry the leasing dates (no EFF_DT/EXP_DT/SALE_DT) ---
+# the only case date is CSE_DISP_DT (Case Disposition Date), so the year-slider column is
+# `disp_year` (year of CSE_DISP_DT), not a lease/effective year. CSE_DISP_DT is populated on
+# 39,530 of 39,598 features (99.8%). The LUA variant adds case-file jurisdiction
+# (CSE_JURIS_CD/CSE_JURIS_DESC) and corridor dimensions (CSE_WIDTH/CSE_LGTH), all retained.
+# MLRS dates arrive as epoch-MILLISECONDS even in GeoJSON output and are parsed to ISO here.
+#
+# Dropped fields and why:
+#   Shape__Area / Shape__Length  decimal-degree junk (real area is RCRD_ACRS)
+#   QLTY                         despite the "Data Quality" alias this is NOT a quality
+#                                code --- it is a multi-kilobyte free-text dump of the LLD
+#                                geocoder's debug log ("12 sections retrieved\n150
+#                                intersected features retrieved...", 2000+ distinct values).
+#                                Carrying it would bloat the GeoParquet and PMTiles for no
+#                                analytical value. `SRC` (7 clean values: LLD, LLD/CLS,
+#                                BULK, Batch, MIGRATE, PROTOOLS, None) is retained instead
+#                                and is the useful geocoding-provenance field.
+#   CSE_META, SF_ID, ID, OBJECTID  internal MLRS/Salesforce/GIS record keys
+#
+# Polygons are geocoded from Legal Land Descriptions via the PLSS, so some cases have no
+# geometry (2,121 of 39,598 have a null Shape__Area). Those rows are retained as
+# attribute-only records; cng-datasets drops them at hex time.
+#
+#   Source: https://gis.blm.gov/nlsdb/rest/services/HUB/BLM_Natl_MLRS_LUA_Leases_Permits_Esmts/FeatureServer/0
+#   Issue:  https://github.com/boettiger-lab/data-workflows/issues/488
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-stage-raw
+  labels:
+    k8s-app: lua-leases-permits-easements-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-leases-permits-easements-stage-raw
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: 3600
+      # Cluster DNS on some nodes intermittently fails to resolve external hosts
+      # (gis.blm.gov). Append public resolvers as a fallback; cluster DNS is still tried
+      # first so the internal rook-ceph-rgw-nautiluss3.rook rclone endpoint keeps resolving.
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+      containers:
+      - name: stage-raw
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, time, urllib.parse, urllib.request, urllib.error
+          from datetime import datetime, timedelta, timezone
+
+          BASE = ("https://gis.blm.gov/nlsdb/rest/services/HUB/"
+                  "BLM_Natl_MLRS_LUA_Leases_Permits_Esmts/FeatureServer/0/query")
+          PAGE = 2000
+          EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)  # handles pre-1970 (negative ms)
+          # gis.blm.gov 403s the default python-urllib User-Agent -- send an explicit one
+          UA = {"User-Agent": "data-workflows/1.0 (boettiger-lab; issue 488)"}
+
+          # Attributes to keep. CSE_DISP is the disposition/status; RCRD_ACRS the case acres
+          # (a per-feature total -- dedup by _cng_fid before any SUM); CSE_WIDTH/CSE_LGTH the
+          # authorized corridor dimensions; CUST_NM_SEC/PCT_INT_SEC/INT_REL_SEC the business
+          # account (who holds/applied for the authorization) and its interest.
+          KEEP = ("CSE_NR", "LEG_CSE_NR", "CSE_NAME", "CSE_TYPE_NR", "BLM_PROD",
+                  "CSE_DISP", "CMMDTY", "RCRD_ACRS",
+                  "ADMIN_STATE", "GEO_STATE",
+                  "CSE_JURIS_CD", "CSE_JURIS_DESC", "CSE_WIDTH", "CSE_LGTH",
+                  "CUST_NM_SEC", "PCT_INT_SEC", "INT_REL_SEC",
+                  "SRC", "CSE_DISP_DT", "Created", "Modified")
+          DATE_FIELDS = ("CSE_DISP_DT", "Created", "Modified")
+
+          def fetch_page(url, tries=6):
+              # the FeatureServer intermittently returns 503/timeouts; retry each page with
+              # exponential backoff so one transient blip does not lose the whole scrape.
+              for attempt in range(1, tries + 1):
+                  try:
+                      req = urllib.request.Request(url, headers=UA)
+                      with urllib.request.urlopen(req, timeout=180) as r:
+                          return json.load(r)
+                  except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+                      if attempt == tries:
+                          raise
+                      wait = min(60, 2 ** attempt)
+                      print(f"  retry {attempt}/{tries} after {type(e).__name__} ({e}); sleep {wait}s", flush=True)
+                      time.sleep(wait)
+
+          def ms_to_iso(v):
+              if v is None:
+                  return None
+              return (EPOCH + timedelta(milliseconds=v)).strftime("%Y-%m-%d")
+
+          def clean(feat):
+              p = feat.get("properties") or {}
+              out = {k: p.get(k) for k in KEEP}
+              # normalize strings: strip surrounding whitespace/newlines (the MLRS export
+              # ships whitespace-only CSE_NAME/LEG_CSE_NR placeholders) and map empty -> None
+              for k, v in list(out.items()):
+                  if isinstance(v, str):
+                      v = v.strip()
+                      out[k] = v or None
+              # ISO dates (MLRS epoch-ms -> YYYY-MM-DD)
+              for d in DATE_FIELDS:
+                  out[d] = ms_to_iso(p.get(d))
+              # derived numeric year of the case disposition date, for the time slider.
+              # This is the ONLY case date this service exposes (no EFF_DT/EXP_DT/SALE_DT).
+              disp = out.get("CSE_DISP_DT")
+              out["disp_year"] = int(disp[:4]) if disp else None
+              feat["properties"] = out
+              return feat
+
+          feats, offset = [], 0
+          while True:
+              q = {
+                  "where": "1=1",
+                  "outFields": "*",
+                  "outSR": "4326",              # WGS84 lon/lat (source is NAD83 / WKID 4269)
+                  "f": "geojson",
+                  "resultOffset": offset,
+                  "resultRecordCount": PAGE,
+                  "orderByFields": "OBJECTID",  # stable pagination order
+              }
+              url = BASE + "?" + urllib.parse.urlencode(q)
+              fc = fetch_page(url)
+              batch = fc.get("features", [])
+              for feat in batch:
+                  feats.append(clean(feat))
+              print(f"offset {offset}: +{len(batch)} (total {len(feats)})", flush=True)
+              more = fc.get("properties", {}).get("exceededTransferLimit") or fc.get("exceededTransferLimit")
+              if len(batch) < PAGE and not more:
+                  break
+              if not batch:
+                  break
+              offset += len(batch)
+
+          # sanity check: disposition set, states, year range, null-geometry count
+          disps = sorted({(f["properties"].get("CSE_DISP") or "") for f in feats})
+          states = sorted({(f["properties"].get("ADMIN_STATE") or "") for f in feats})
+          years = sorted({y for f in feats if (y := f["properties"].get("disp_year")) is not None})
+          nogeom = sum(1 for f in feats if not f.get("geometry"))
+          nullyear = sum(1 for f in feats if f["properties"].get("disp_year") is None)
+          print(f"CSE_DISP: {disps}", flush=True)
+          print(f"distinct ADMIN_STATE: {states}", flush=True)
+          print(f"disp_year range: {years[:1]}..{years[-1:]} ({nullyear} null)", flush=True)
+          print(f"null-geometry features: {nogeom}", flush=True)
+
+          out = {"type": "FeatureCollection",
+                 "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
+                 "features": feats}
+          with open("/tmp/lua-leases-permits-easements.geojson", "w") as f:
+              json.dump(out, f)
+          print(f"WROTE {len(feats)} features", flush=True)
+          # fail loudly if the FeatureServer under-delivered vs the known count
+          # (39,598 polygon features, verified live 2026-07-24)
+          assert len(feats) >= 39000, f"expected ~39,598 features, got {len(feats)}"
+          PY
+          ls -la /tmp/lua-leases-permits-easements.geojson
+          rclone copyto /tmp/lua-leases-permits-easements.geojson nrp:public-blm/raw/lua-leases-permits-easements.geojson --s3-no-check-bucket
+          echo "staged raw -> s3://public-blm/raw/lua-leases-permits-easements.geojson"
+        resources:
+          requests:
+            cpu: '2'
+            memory: 8Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '2'
+            memory: 8Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-leases-permits-easements/workflow-rbac.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/blm/k8s/lua-leases-permits-easements/workflow.yaml
+++ b/catalog/blm/k8s/lua-leases-permits-easements/workflow.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-leases-permits-easements-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting lua-leases-permits-easements workflow...\"\n\
+          \n# Step 0: Setup bucket with public access and CORS\necho \"Step 0: Setting\
+          \ up bucket...\"\nkubectl apply -f /yamls/lua-leases-permits-easements-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/lua-leases-permits-easements-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/lua-leases-permits-easements-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/lua-leases-permits-easements-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/lua-leases-permits-easements-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/lua-leases-permits-easements-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/lua-leases-permits-easements-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/lua-leases-permits-easements-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/lua-leases-permits-easements-repartition -n geo-workflows\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs lua-leases-permits-easements-setup-bucket lua-leases-permits-easements-convert\
+          \ lua-leases-permits-easements-pmtiles lua-leases-permits-easements-hex\
+          \ lua-leases-permits-easements-repartition lua-leases-permits-easements-workflow\
+          \ -n geo-workflows\"\necho \"  kubectl delete configmap lua-leases-permits-easements-yamls\
+          \ -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: lua-leases-permits-easements-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/blm/k8s/lua-row/configmap.yaml
+++ b/catalog/blm/k8s/lua-row/configmap.yaml
@@ -14,7 +14,9 @@
 # this DAG and is not embedded here.
 # Hand-tuned after generation: hex completions 200->80 with --chunk-size 2500 (196,751
 # features -- the largest MLRS HUB layer), backoffLimit:0 -> backoffLimitPerIndex:2 +
-# maxFailedIndexes:2 (#409), and the tippecanoe line switched to the ROW corridor recipe
+# maxFailedIndexes:2 (#409); hex re-tuned to 158 x --chunk-size 1250 @ 24Gi after the
+# acquisitions run showed the per-chunk final WRITE (not the unnest) is the memory
+# constraint; and the tippecanoe line switched to the ROW corridor recipe
 # (--drop-rate=1 --maximum-tile-bytes=1000000, tiny-polygon reduction left ON) so long thin
 # corridors survive at low zoom -- issue #488 acceptance criterion.
 #
@@ -304,11 +306,19 @@ data:
       labels:
         k8s-app: lua-row-hex
     spec:
-      completions: 80
+      completions: 158
       parallelism: 50
       completionMode: Indexed
-      # chunk-size 2500 x 80 completions = 200,000 capacity, covers all 196,751
-      # features (the largest MLRS HUB layer) with margin.
+      # chunk-size 1250 x 158 completions = 197,500 capacity, covers all 196,751 features
+      # (the largest MLRS HUB layer) with margin, staying under the k8s 200-completion cap.
+      #
+      # Deliberately HALVED from the 2500 that acquisitions used, because that run showed the
+      # binding constraint is the per-chunk FINAL WRITE, not the unnest: acquisitions chunk 13
+      # completed all 327 unnest batches and then OOMKilled at 16Gi while writing its output,
+      # and its sibling chunk 14 landed at 2.04 GB -- flirting with the 2 GB Parquet page limit.
+      # Output size scales with chunk-size, so halving the chunk halves each write's peak memory
+      # AND shortens the straggler tail (a pathological polygon drags 1,249 neighbours instead of
+      # 2,499). Memory is also raised 16Gi -> 24Gi as belt-and-braces for the write.
       # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
       # publishing a subset of h0 partitions (#409). Verified after the run with
       # scripts/check-hex-coverage.sh.
@@ -360,16 +370,16 @@ data:
             - -c
             - |-
               set -e
-              cng-datasets vector --input s3://public-blm/lua-row.parquet --output s3://public-blm/lua-row/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+              cng-datasets vector --input s3://public-blm/lua-row.parquet --output s3://public-blm/lua-row/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1250 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
             resources:
               requests:
                 cpu: '4'
-                memory: 16Gi
-                ephemeral-storage: 10Gi
+                memory: 24Gi
+                ephemeral-storage: 20Gi
               limits:
                 cpu: '4'
-                memory: 16Gi
-                ephemeral-storage: 10Gi
+                memory: 24Gi
+                ephemeral-storage: 20Gi
           priorityClassName: opportunistic
           affinity:
             nodeAffinity:

--- a/catalog/blm/k8s/lua-row/configmap.yaml
+++ b/catalog/blm/k8s/lua-row/configmap.yaml
@@ -1,0 +1,464 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: lua-row-setup-bucket.yaml, lua-row-convert.yaml, lua-row-pmtiles.yaml, lua-row-hex.yaml, lua-row-repartition.yaml
+# Generation command: cng-datasets workflow --dataset lua-row --source-url s3://public-blm/raw/lua-row.geojson --bucket public-blm --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap lua-row-yamls \
+#     --from-file=lua-row-setup-bucket.yaml \
+#     --from-file=lua-row-convert.yaml \
+#     --from-file=lua-row-pmtiles.yaml \
+#     --from-file=lua-row-hex.yaml \
+#     --from-file=lua-row-repartition.yaml
+#
+# NOTE: lua-row-stage-raw.yaml (the ArcGIS FeatureServer scrape) runs standalone BEFORE
+# this DAG and is not embedded here.
+# Hand-tuned after generation: hex completions 200->80 with --chunk-size 2500 (196,751
+# features -- the largest MLRS HUB layer), backoffLimit:0 -> backoffLimitPerIndex:2 +
+# maxFailedIndexes:2 (#409), and the tippecanoe line switched to the ROW corridor recipe
+# (--drop-rate=1 --maximum-tile-bytes=1000000, tiny-polygon reduction left ON) so long thin
+# corridors survive at low zoom -- issue #488 acceptance criterion.
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  lua-row-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-row-setup-bucket
+      labels:
+        k8s-app: lua-row-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-row-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-row-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-row-convert
+      labels:
+        k8s-app: lua-row-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-row-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-blm/raw/lua-row.geojson \
+                s3://public-blm/lua-row.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-row-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-row-pmtiles
+      labels:
+        k8s-app: lua-row-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-row-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: lua-row
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/lua-row.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              # ROW corridor tiling (issue #488 acceptance criterion: "LUA ROW corridors render
+              # at low zoom"). ROW footprints are long, thin polygons (a 40 ft x 1550 ft road
+              # easement is far narrower than one pixel below ~z12), and this is the largest HUB
+              # layer at 196,751 features -- so the default recipe thins them out of the low-zoom
+              # tiles. Three deliberate departures from the parcel recipe above:
+              #   --drop-rate=1            disable tippecanoe's automatic per-zoom feature
+              #                            thinning (default 2.5x per level below maxzoom), which
+              #                            is what actually erases corridors at z0-z8.
+              #   --maximum-tile-bytes     raise the per-tile budget 500 KB -> 1 MB so
+              #                            --coalesce/--drop-densest-as-needed has to intervene
+              #                            far less often at low zoom.
+              #   (no --no-tiny-polygon-reduction)  tippecanoe's DEFAULT tiny-polygon reduction is
+              #                            what keeps a sub-pixel corridor visible as a minimum-
+              #                            size mark instead of vanishing -- so it is deliberately
+              #                            left ON. Do not add that flag.
+              # Verified post-build by decoding low-zoom tiles and counting features (see PR).
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed --drop-rate=1 --maximum-tile-bytes=1000000 -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-row-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-row-hex
+      labels:
+        k8s-app: lua-row-hex
+    spec:
+      completions: 80
+      parallelism: 50
+      completionMode: Indexed
+      # chunk-size 2500 x 80 completions = 200,000 capacity, covers all 196,751
+      # features (the largest MLRS HUB layer) with margin.
+      # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+      # publishing a subset of h0 partitions (#409). Verified after the run with
+      # scripts/check-hex-coverage.sh.
+      backoffLimitPerIndex: 2
+      maxFailedIndexes: 2
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-row-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            - name: DATASET
+              value: lua-row
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-blm/lua-row.parquet --output s3://public-blm/lua-row/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  lua-row-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: lua-row-repartition
+      labels:
+        k8s-app: lua-row-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: lua-row-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-blm
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-blm/lua-row/chunks --output-dir s3://public-blm/lua-row/hex --source-parquet s3://public-blm/lua-row.parquet --cleanup --memory-limit 54GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: lua-row-yamls
+  namespace: geo-workflows

--- a/catalog/blm/k8s/lua-row/lua-row-convert.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-convert
+  labels:
+    k8s-app: lua-row-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-row-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-blm/raw/lua-row.geojson \
+            s3://public-blm/lua-row.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-row/lua-row-hex.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-hex.yaml
@@ -1,0 +1,83 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-hex
+  labels:
+    k8s-app: lua-row-hex
+spec:
+  completions: 80
+  parallelism: 50
+  completionMode: Indexed
+  # chunk-size 2500 x 80 completions = 200,000 capacity, covers all 196,751
+  # features (the largest MLRS HUB layer) with margin.
+  # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
+  # publishing a subset of h0 partitions (#409). Verified after the run with
+  # scripts/check-hex-coverage.sh.
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 2
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-row-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: lua-row
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-blm/lua-row.parquet --output s3://public-blm/lua-row/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-row/lua-row-hex.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-hex.yaml
@@ -5,11 +5,19 @@ metadata:
   labels:
     k8s-app: lua-row-hex
 spec:
-  completions: 80
+  completions: 158
   parallelism: 50
   completionMode: Indexed
-  # chunk-size 2500 x 80 completions = 200,000 capacity, covers all 196,751
-  # features (the largest MLRS HUB layer) with margin.
+  # chunk-size 1250 x 158 completions = 197,500 capacity, covers all 196,751 features
+  # (the largest MLRS HUB layer) with margin, staying under the k8s 200-completion cap.
+  #
+  # Deliberately HALVED from the 2500 that acquisitions used, because that run showed the
+  # binding constraint is the per-chunk FINAL WRITE, not the unnest: acquisitions chunk 13
+  # completed all 327 unnest batches and then OOMKilled at 16Gi while writing its output,
+  # and its sibling chunk 14 landed at 2.04 GB -- flirting with the 2 GB Parquet page limit.
+  # Output size scales with chunk-size, so halving the chunk halves each write's peak memory
+  # AND shortens the straggler tail (a pathological polygon drags 1,249 neighbours instead of
+  # 2,499). Memory is also raised 16Gi -> 24Gi as belt-and-braces for the write.
   # Per-index retries (not backoffLimit:0) so a partial run fails loudly rather than
   # publishing a subset of h0 partitions (#409). Verified after the run with
   # scripts/check-hex-coverage.sh.
@@ -61,16 +69,16 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets vector --input s3://public-blm/lua-row.parquet --output s3://public-blm/lua-row/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 2500 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+          cng-datasets vector --input s3://public-blm/lua-row.parquet --output s3://public-blm/lua-row/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1250 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
         resources:
           requests:
             cpu: '4'
-            memory: 16Gi
-            ephemeral-storage: 10Gi
+            memory: 24Gi
+            ephemeral-storage: 20Gi
           limits:
             cpu: '4'
-            memory: 16Gi
-            ephemeral-storage: 10Gi
+            memory: 24Gi
+            ephemeral-storage: 20Gi
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:

--- a/catalog/blm/k8s/lua-row/lua-row-pmtiles.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-pmtiles.yaml
@@ -1,0 +1,117 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-pmtiles
+  labels:
+    k8s-app: lua-row-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-row-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        - name: DATASET
+          value: lua-row
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-blm/lua-row.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          # ROW corridor tiling (issue #488 acceptance criterion: "LUA ROW corridors render
+          # at low zoom"). ROW footprints are long, thin polygons (a 40 ft x 1550 ft road
+          # easement is far narrower than one pixel below ~z12), and this is the largest HUB
+          # layer at 196,751 features -- so the default recipe thins them out of the low-zoom
+          # tiles. Three deliberate departures from the parcel recipe above:
+          #   --drop-rate=1            disable tippecanoe's automatic per-zoom feature
+          #                            thinning (default 2.5x per level below maxzoom), which
+          #                            is what actually erases corridors at z0-z8.
+          #   --maximum-tile-bytes     raise the per-tile budget 500 KB -> 1 MB so
+          #                            --coalesce/--drop-densest-as-needed has to intervene
+          #                            far less often at low zoom.
+          #   (no --no-tiny-polygon-reduction)  tippecanoe's DEFAULT tiny-polygon reduction is
+          #                            what keeps a sub-pixel corridor visible as a minimum-
+          #                            size mark instead of vanishing -- so it is deliberately
+          #                            left ON. Do not add that flag.
+          # Verified post-build by decoding low-zoom tiles and counting features (see PR).
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed --drop-rate=1 --maximum-tile-bytes=1000000 -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-blm/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-row/lua-row-repartition.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-repartition
+  labels:
+    k8s-app: lua-row-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-row-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-blm/lua-row/chunks --output-dir s3://public-blm/lua-row/hex --source-parquet s3://public-blm/lua-row.parquet --cleanup --memory-limit 54GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-row/lua-row-setup-bucket.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-setup-bucket
+  labels:
+    k8s-app: lua-row-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-row-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-blm
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-row/lua-row-stage-raw.yaml
+++ b/catalog/blm/k8s/lua-row/lua-row-stage-raw.yaml
@@ -1,0 +1,219 @@
+# Stage raw BLM National MLRS LUA Rights-of-Way (ROW) from the ArcGIS FeatureServer to S3.
+#
+# Right-of-way authorizations (roads, pipelines, transmission lines, communication sites,
+# canals) across BLM-administered land --- the non-mineral surface-use counterpart to the
+# MLRS mineral case records (#451 leases, #477 claims, #487 locatable operations). At
+# 196,751 polygon features this is the LARGEST of the MLRS HUB layers. Paginated
+# (maxRecordCount 2000) with the same robustness as those scrapes: explicit User-Agent,
+# per-page retry with backoff, stable OBJECTID ordering, and a terminal count assert.
+#
+# Schema note (verified live against the FeatureServer 2026-07-24, issue #488): this is the
+# MLRS **LUA variant** --- an identical field list to LUA Leases/Permits/Easements. It does
+# NOT carry the leasing dates (no EFF_DT/EXP_DT/SALE_DT) --- the only case date is
+# CSE_DISP_DT (Case Disposition Date), so the year-slider column is `disp_year` (year of
+# CSE_DISP_DT), not a lease/effective year. CSE_DISP_DT is populated on 195,754 of 196,751
+# features (99.5%). The LUA variant adds case-file jurisdiction
+# (CSE_JURIS_CD/CSE_JURIS_DESC) and corridor dimensions (CSE_WIDTH/CSE_LGTH) --- the latter
+# are especially meaningful here, since a ROW is authorized as a width x length corridor.
+# MLRS dates arrive as epoch-MILLISECONDS even in GeoJSON output and are parsed to ISO here.
+#
+# Dropped fields and why:
+#   Shape__Area / Shape__Length  decimal-degree junk (real area is RCRD_ACRS)
+#   QLTY                         despite the "Data Quality" alias this is NOT a quality
+#                                code --- it is a multi-kilobyte free-text dump of the LLD
+#                                geocoder's debug log ("12 sections retrieved\n150
+#                                intersected features retrieved...", 2000+ distinct values).
+#                                Carrying it would bloat the GeoParquet and PMTiles for no
+#                                analytical value. `SRC` (7 clean values: LLD, LLD/CLS,
+#                                BULK, Batch, MIGRATE, PROTOOLS, None) is retained instead
+#                                and is the useful geocoding-provenance field.
+#   CSE_META, SF_ID, ID, OBJECTID  internal MLRS/Salesforce/GIS record keys
+#
+# Polygons are geocoded from Legal Land Descriptions via the PLSS, so some cases have no
+# geometry (4,787 of 196,751 have a null Shape__Area). Those rows are retained as
+# attribute-only records; cng-datasets drops them at hex time.
+#
+#   Source: https://gis.blm.gov/nlsdb/rest/services/HUB/BLM_Natl_MLRS_LUA_ROW/FeatureServer/0
+#   Issue:  https://github.com/boettiger-lab/data-workflows/issues/488
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-stage-raw
+  labels:
+    k8s-app: lua-row-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: lua-row-stage-raw
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: 10800
+      # Cluster DNS on some nodes intermittently fails to resolve external hosts
+      # (gis.blm.gov). Append public resolvers as a fallback; cluster DNS is still tried
+      # first so the internal rook-ceph-rgw-nautiluss3.rook rclone endpoint keeps resolving.
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+      containers:
+      - name: stage-raw
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, time, urllib.parse, urllib.request, urllib.error
+          from datetime import datetime, timedelta, timezone
+
+          BASE = ("https://gis.blm.gov/nlsdb/rest/services/HUB/"
+                  "BLM_Natl_MLRS_LUA_ROW/FeatureServer/0/query")
+          PAGE = 2000
+          EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)  # handles pre-1970 (negative ms)
+          # gis.blm.gov 403s the default python-urllib User-Agent -- send an explicit one
+          UA = {"User-Agent": "data-workflows/1.0 (boettiger-lab; issue 488)"}
+
+          # Attributes to keep. CSE_DISP is the disposition/status; RCRD_ACRS the case acres
+          # (a per-feature total -- dedup by _cng_fid before any SUM); CSE_WIDTH/CSE_LGTH the
+          # authorized corridor dimensions; CUST_NM_SEC/PCT_INT_SEC/INT_REL_SEC the business
+          # account (who holds/applied for the authorization) and its interest.
+          KEEP = ("CSE_NR", "LEG_CSE_NR", "CSE_NAME", "CSE_TYPE_NR", "BLM_PROD",
+                  "CSE_DISP", "CMMDTY", "RCRD_ACRS",
+                  "ADMIN_STATE", "GEO_STATE",
+                  "CSE_JURIS_CD", "CSE_JURIS_DESC", "CSE_WIDTH", "CSE_LGTH",
+                  "CUST_NM_SEC", "PCT_INT_SEC", "INT_REL_SEC",
+                  "SRC", "CSE_DISP_DT", "Created", "Modified")
+          DATE_FIELDS = ("CSE_DISP_DT", "Created", "Modified")
+
+          def fetch_page(url, tries=6):
+              # the FeatureServer intermittently returns 503/timeouts; retry each page with
+              # exponential backoff so one transient blip does not lose the whole scrape.
+              for attempt in range(1, tries + 1):
+                  try:
+                      req = urllib.request.Request(url, headers=UA)
+                      with urllib.request.urlopen(req, timeout=180) as r:
+                          return json.load(r)
+                  except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+                      if attempt == tries:
+                          raise
+                      wait = min(60, 2 ** attempt)
+                      print(f"  retry {attempt}/{tries} after {type(e).__name__} ({e}); sleep {wait}s", flush=True)
+                      time.sleep(wait)
+
+          def ms_to_iso(v):
+              if v is None:
+                  return None
+              return (EPOCH + timedelta(milliseconds=v)).strftime("%Y-%m-%d")
+
+          def clean(feat):
+              p = feat.get("properties") or {}
+              out = {k: p.get(k) for k in KEEP}
+              # normalize strings: strip surrounding whitespace/newlines (the MLRS export
+              # ships whitespace-only CSE_NAME/LEG_CSE_NR placeholders) and map empty -> None
+              for k, v in list(out.items()):
+                  if isinstance(v, str):
+                      v = v.strip()
+                      out[k] = v or None
+              # ISO dates (MLRS epoch-ms -> YYYY-MM-DD)
+              for d in DATE_FIELDS:
+                  out[d] = ms_to_iso(p.get(d))
+              # derived numeric year of the case disposition date, for the time slider.
+              # This is the ONLY case date this service exposes (no EFF_DT/EXP_DT/SALE_DT).
+              disp = out.get("CSE_DISP_DT")
+              out["disp_year"] = int(disp[:4]) if disp else None
+              feat["properties"] = out
+              return feat
+
+          feats, offset = [], 0
+          while True:
+              q = {
+                  "where": "1=1",
+                  "outFields": "*",
+                  "outSR": "4326",              # WGS84 lon/lat (source is NAD83 / WKID 4269)
+                  "f": "geojson",
+                  "resultOffset": offset,
+                  "resultRecordCount": PAGE,
+                  "orderByFields": "OBJECTID",  # stable pagination order
+              }
+              url = BASE + "?" + urllib.parse.urlencode(q)
+              fc = fetch_page(url)
+              batch = fc.get("features", [])
+              for feat in batch:
+                  feats.append(clean(feat))
+              print(f"offset {offset}: +{len(batch)} (total {len(feats)})", flush=True)
+              more = fc.get("properties", {}).get("exceededTransferLimit") or fc.get("exceededTransferLimit")
+              if len(batch) < PAGE and not more:
+                  break
+              if not batch:
+                  break
+              offset += len(batch)
+
+          # sanity check: disposition set, states, year range, null-geometry count
+          disps = sorted({(f["properties"].get("CSE_DISP") or "") for f in feats})
+          states = sorted({(f["properties"].get("ADMIN_STATE") or "") for f in feats})
+          years = sorted({y for f in feats if (y := f["properties"].get("disp_year")) is not None})
+          nogeom = sum(1 for f in feats if not f.get("geometry"))
+          nullyear = sum(1 for f in feats if f["properties"].get("disp_year") is None)
+          print(f"CSE_DISP: {disps}", flush=True)
+          print(f"distinct ADMIN_STATE: {states}", flush=True)
+          print(f"disp_year range: {years[:1]}..{years[-1:]} ({nullyear} null)", flush=True)
+          print(f"null-geometry features: {nogeom}", flush=True)
+
+          out = {"type": "FeatureCollection",
+                 "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
+                 "features": feats}
+          with open("/tmp/lua-row.geojson", "w") as f:
+              json.dump(out, f)
+          print(f"WROTE {len(feats)} features", flush=True)
+          # fail loudly if the FeatureServer under-delivered vs the known count
+          # (196,751 polygon features -- the largest of the MLRS HUB layers, verified live 2026-07-24)
+          assert len(feats) >= 194000, f"expected ~196,751 features, got {len(feats)}"
+          PY
+          ls -la /tmp/lua-row.geojson
+          rclone copyto /tmp/lua-row.geojson nrp:public-blm/raw/lua-row.geojson --s3-no-check-bucket
+          echo "staged raw -> s3://public-blm/raw/lua-row.geojson"
+        resources:
+          requests:
+            cpu: '2'
+            memory: 16Gi
+            ephemeral-storage: 40Gi
+          limits:
+            cpu: '2'
+            memory: 16Gi
+            ephemeral-storage: 40Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/blm/k8s/lua-row/workflow-rbac.yaml
+++ b/catalog/blm/k8s/lua-row/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/blm/k8s/lua-row/workflow.yaml
+++ b/catalog/blm/k8s/lua-row/workflow.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lua-row-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting lua-row workflow...\"\n\n# Step 0: Setup bucket\
+          \ with public access and CORS\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/lua-row-setup-bucket.yaml -n geo-workflows\n\necho \"\
+          Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/lua-row-setup-bucket -n geo-workflows\n\n# Step 1:\
+          \ Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/lua-row-convert.yaml -n geo-workflows\n\necho \"Waiting for GeoParquet\
+          \ conversion to complete...\"\nkubectl wait --for=condition=complete --timeout=3600s\
+          \ job/lua-row-convert -n geo-workflows\n\n# Step 2: Run pmtiles and hex\
+          \ tiling in parallel (both use the converted geoparquet)\necho \"Step 2:\
+          \ H3 hexagonal tiling and PMTiles generation (parallel)...\"\nkubectl apply\
+          \ -f /yamls/lua-row-pmtiles.yaml -n geo-workflows\nkubectl apply -f /yamls/lua-row-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/lua-row-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/lua-row-repartition.yaml -n geo-workflows\n\necho \"Waiting\
+          \ for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/lua-row-repartition -n geo-workflows\n\necho \"\u2713\
+          \ Workflow complete!\"\necho \"Note: PMTiles job may still be running in\
+          \ the background\"\necho \"\"\necho \"Clean up with:\"\necho \"  kubectl\
+          \ delete jobs lua-row-setup-bucket lua-row-convert lua-row-pmtiles lua-row-hex\
+          \ lua-row-repartition lua-row-workflow -n geo-workflows\"\necho \"  kubectl\
+          \ delete configmap lua-row-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: lua-row-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/sync/source-coop/license-inventory.md
+++ b/catalog/sync/source-coop/license-inventory.md
@@ -15,6 +15,9 @@ Full recursive STAC walk (130 nodes). Verdict per collection:
 - **OK** · `public-domain` — public-blm/mineral-materials  · BLM National MLRS Mineral Materials (salable — sand, gravel, stone; ArcGIS FeatureServer, gis.blm.gov). US federal cadastral work → public domain. Mirror-eligible. Tracked: data-workflows #486.
 - **OK** · `public-domain` — public-blm/oil-gas-agreements  · BLM National MLRS Oil & Gas Agreements (unit / communitization agreements; ArcGIS FeatureServer, gis.blm.gov). US federal cadastral work → public domain. Mirror-eligible. Tracked: data-workflows #486.
 - **OK** · `public-domain` — public-blm/oil-gas-participating-areas  · BLM National MLRS Oil & Gas Participating Areas (within unit agreements; ArcGIS FeatureServer, gis.blm.gov). US federal cadastral work → public domain. Mirror-eligible. Tracked: data-workflows #486.
+- **OK** · `public-domain` — public-blm/lua-leases-permits-easements  · BLM National MLRS land-use authorizations: leases, permits, easements (ArcGIS FeatureServer, gis.blm.gov). US federal cadastral work → public domain. Mirror-eligible. Tracked: data-workflows #488.
+- **OK** · `public-domain` — public-blm/lua-row  · BLM National MLRS land-use authorizations: rights-of-way (ArcGIS FeatureServer, gis.blm.gov). US federal cadastral work → public domain. Mirror-eligible. Tracked: data-workflows #488.
+- **OK** · `public-domain` — public-blm/acquisitions  · BLM National MLRS acquisitions — lands & interests acquired by BLM, incl. access/conservation easements and mineral/water rights (ArcGIS FeatureServer, gis.blm.gov). US federal cadastral work → public domain. Mirror-eligible. Tracked: data-workflows #488.
 
 ## public-ca-dac
 - **OK** · `CC-BY-4.0` — public-ca-dac  · CA DWR via CNRA open data + US Census ACS (confirm exact)


### PR DESCRIPTION
Closes #488.

Ingests the three **non-mineral** BLM National MLRS HUB layers — the surface-use and land-tenure records that sit alongside the mineral case records (#451 O&G leases, #477 mining claims, #487 locatable operations) — **nationally**, into the existing `public-blm` bucket.

| dataset | service layer | features | distinct `CSE_NR` | null geom |
|---|---|--:|--:|--:|
| `lua-leases-permits-easements` | `BLM_Natl_MLRS_LUA_Leases_Permits_Esmts/FeatureServer/0` | 39,598 | 39,598 | 2,121 |
| `lua-row` | `BLM_Natl_MLRS_LUA_ROW/FeatureServer/0` | 196,751 | 196,598 | 4,787 |
| `acquisitions` | `BLM_Natl_MLRS_Acquisitions/FeatureServer/1` ⚠️ | 97,529 | 97,529 | 751 |

Counts were verified live against the FeatureServers and reproduced **exactly** by the stage-raw scrapes. Acquisitions is pulled from `/FeatureServer/1` (layer 0 404s), per the issue.

Each layer produces **GeoParquet + PMTiles + H3 hex**, native H3 resolution **10**, parents **9,8,0** — so all three join the other BLM layers at `h8`.

## Two issue questions answered at ingest

1. **`PAT_NR` is not a year, and no patent year is derivable.** The issue asked to confirm this. Sampled values are GLO patent volume/serial strings — `"3 1206"`, `"2 784"`, `"2 1292C"` — with no date component. It is also populated on only **150 of 97,529** records. Retained verbatim as a patent reference; no `pat_year` derived.
2. **`disp_year` is derived from `CSE_DISP_DT`, but its coverage differs sharply by layer:** 39,530/39,598 (99.8%) for LUA leases and 195,754/196,751 (99.5%) for LUA ROW, but only **30,438/97,529 (31%) for acquisitions** — the other 69% are mostly the `Status Record` disposition. Documented prominently so a year-slider treats undated records as undated rather than dropping two thirds of the layer.

## Notable data findings, documented in STAC

- **`QLTY` is dropped.** Despite its "Data Quality" alias it is not a quality code but a multi-kilobyte free-text dump of the LLD geocoder's debug log (`"12 sections retrieved\n150 intersected features retrieved…"`, 2000+ distinct values). Carrying it would bloat the GeoParquet and PMTiles for no analytical value. **`SRC`** (6–8 clean values: `LLD`, `LLD/CLS`, `BULK`, `Batch`, `MIGRATE`, `PROTOOLS`) is retained instead and is the useful geocoding-provenance field.
- **`CUST_NM_SEC` / `PCT_INT_SEC` / `INT_REL_SEC` are retained.** These are not in the issue's column contract but are present on all three layers with real values (18,893 / 150,832 / 10,573 populated) and record *who holds or applied for* the authorization.
- **`CSE_WIDTH` / `CSE_LGTH` are free text with no stated units**, and are far sparser than the issue implies (209 and 220 of 39,598 on LUA leases). Retained as required, flagged as un-castable-without-care.
- **`REC_TYPE_CSE_GRP` ships inconsistent hyphenation** of the same group (`Land Tenure - Acquisitions` vs `Land Tenure-Acquisitions`). Retained verbatim; STAC tells consumers to normalize before matching.
- **`disp_year` contains a handful of upstream data-entry errors** (max 2117 on LUA leases, 3023 on ROW, 2907 on acquisitions; 42 future-dated ROW rows). Retained verbatim rather than silently altered, and flagged so slider UIs clamp their domain.
- **Row duplication is axis-1 only.** Rows == distinct `CSE_NR` exactly for leases and acquisitions; ROW has 153 duplicated serials out of 196,751 (0.08%). So `_cng_fid` is the correct dedup key and `RCRD_ACRS` needs deduping only for the hex cell expansion — recorded in the hex asset description.

## Manifest tuning (hand-edits after generation)

`cng-datasets workflow` has no tippecanoe or chunk-size flag, so the generated YAMLs are edited and the configmaps rebuilt from the edited step files (verified byte-identical):

- **hex sizing** per layer — 40x1000, 80x2500, 40x2500 — instead of the generator's 200x1000 default, which would have left 160 indices running empty ranges on the smallest layer.
- **`backoffLimit: 0` → `backoffLimitPerIndex: 2` + `maxFailedIndexes: 2`** so a partial indexed run fails loudly instead of publishing a subset of h0 partitions (#409).
- **`ulimit -n 65536`** before tippecanoe (#154).
- **tippecanoe tuned per layer.** The two parcel layers use the established BLM recipe (`--coalesce-densest-as-needed --drop-densest-as-needed -z 13`). `lua-row` additionally gets **`--drop-rate=1`** (disable per-zoom feature thinning) and **`--maximum-tile-bytes=1000000`** so its long thin corridors survive low zoom — the issue's acceptance criterion. Tiny-polygon reduction is deliberately left **ON**: it is what keeps a sub-pixel corridor visible as a minimum-size mark rather than vanishing.

## Sync registration

`public-blm` is already in scope for both the MinIO backup (`gen-minio-sync.sh`) and the source.coop mirror (`gen-source-sync.sh`), so **no sync-scope regeneration is needed** — this PR only appends the license-inventory verdicts (`public-domain`, mirror-eligible). It also fills in the **missing `locatable-operations` entry from #487**, which was never added to the inventory.

Backup/mirror *execution* remains owned by geo-agent-ops in `boettiger-lab`; nothing here applies a sync job.

## Verification — all gates green

Cluster runs are complete and every artifact is published. Verified with the repo's own scripts:

- [x] **stage-raw counts match the FeatureServers exactly** — 39,598 / 196,751 / 97,529
- [x] **all workflows `Complete` with empty `failedIndexes`** — hex 40/40, 158/158, 40/40 (+ a 96Gi rechunk for acquisitions chunk 13)
- [x] **`scripts/check-hex-coverage.sh`** — PASS on all three (9 / 10 / 8 populated h0, zero empty partitions)
- [x] **`scripts/audit-feature-dup.py --key _cng_fid`** — all attributes correctly classified REPEATED on all three
- [x] **low-zoom corridor decode for `lua-row`** — 3,516 features at z0; ~3x the parcel recipe's retention at z4–z6
- [x] **`scripts/verify-stac.py --bucket public-blm --dataset <ds>`** — **0 hard findings on all three**; CI Verify STAC green

### Published output

| | features | geocoded | hex rows | distinct `_cng_fid` in hex | h0 |
|---|--:|--:|--:|--:|--:|
| lua-leases-permits-easements | 39,598 | 37,477 | 63,933,834 | 37,477 ✓ | 9 |
| lua-row | 196,751 | 191,959 | 72,029,004 | 191,959 ✓ | 10 |
| acquisitions | 97,529 | 96,777 | 1,063,389,783 | 96,777 ✓ | 8 |

Hex feature counts equal geocoded counts exactly; `h10`/`h9`/`h8`/`h0` complete with no nulls, so joins work at any resolution. Deduped acreage reconciles with source in every case.

The dedup warnings are well earned — a naive `SUM(RCRD_ACRS)` on hex inflates **184,000x / 20,900x / 33,900x**. Each is documented on the hex asset with the correct query.

### Corrections found by the gates

- **`verify-stac.py` caught a real error**: `lua-row`'s `INT_REL_SEC` was missing `'Vested Interest'` because I hand-transcribed the value list from a wrapped markdown table. Refetched as JSON and fixed — exactly the #114/#294 class the data-backed check exists for.
- **`lua-row` crosses the antimeridian.** One Alaska ROW (`AKAK106269603`) sits at +173.2 deg; a naive min/max bbox would claim the dataset spans Eurasia. Encoded with the GeoJSON convention (`xmin` > `xmax`) and propagated to the parent extent.
- **`SUPP_USE` is pipe-delimited multi-value composites**, not a flat vocabulary — documented as such with a token glossary rather than pretending `'CULTURAL SITES|FEE'` is an atomic code.

### Two production failures worth recording

Both were caught by guardrails rather than shipped:

1. **acquisitions hex chunk 13 OOMKilled at 16Gi** after completing all 327 unnest batches, during the final write — its output is 2.18 GB, the largest in the dataset. The lesson is that hex memory must be sized for the **per-chunk final write**, not the unnest, which also means the usual fix (lowering `--intermediate-chunk-size`) does not apply. `lua-row` was retuned pre-emptively to `--chunk-size 1250` and finished its 158 chunks in **9m31s**, versus 2+ hours for acquisitions' 40.
2. **acquisitions repartition was evicted twice on the 50Gi ephemeral cap**, leaving **3 of 8 h0 partitions on S3** — a partial dataset that would have looked complete to any `hex/h0=*/` reader. Purged and verified empty, then re-run with scratch on the `rechunk-scratch` PVC.

Because hex uses `backoffLimitPerIndex` rather than `backoffLimit: 0`, both surfaced as failures instead of silently-missing partitions (#409).

### Downstream

The three layers are added to the Utah Public Lands app in [cassiebuhler/utah-public-lands#25](https://github.com/cassiebuhler/utah-public-lands/pull/25).
