### PR TITLE
feat(#506,#507): per-cell GAP fractions on conserved-areas-2025 + res-10 California land grid

### DIFF
--- a/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-weights-parents.yaml
+++ b/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-weights-parents.yaml
@@ -1,0 +1,198 @@
+# data-workflows#506 Stage 2 — res-9 / res-8 rollups of the per-cell GAP weights.
+#
+# Depends on #507 (ecoregion re-indexed at native res 10): a parent-cell weight is an
+# AREA-WEIGHTED MEAN over the parent's res-10 LAND children, so it needs an authoritative
+# res-10 California land grid to supply the denominator `nland`. The old stand-in
+# (cwhr13 hex-fractions) is a habitat dataset and is not clipped to California — 1.36M
+# acres of it lie in Nevada/Oregon/Arizona — so a rollup built on it would bake that
+# error into the asset. `ecoregion/hex` is the same footprint as the pinned statewide
+# denominator (101,498,000 acres), which is why it is the right grid.
+#
+#   land10  = DISTINCT (h0,h9,h8,h10) from ecoregion/hex        -- res-10 CA land grid
+#   wN(res9)= SUM(COALESCE(child wN, 0)) / nland  over land children of the h9
+#   nland   = COUNT(*) of res-10 land children present in the parent (<=7 at res 9,
+#             <=49 at res 8; boundary parents have fewer)
+#
+# Conserved res-10 cells that are NOT land cells (state-boundary overhang, water) are
+# excluded from both numerator and denominator, so wN stays in [0,1] and the parent value
+# is the conserved fraction OF CALIFORNIA LAND in that cell.
+#
+# Row counts: every land parent gets a row, including parents with zero conserved area
+# (wN = 0) — that is what makes the asset usable as a denominator, not just a mask.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: conserved-areas-2025-hex-weights-parents
+  namespace: geo-workflows
+  labels:
+    k8s-app: conserved-areas-2025-hex-weights-parents
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: conserved-areas-2025-hex-weights-parents
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: hex-weights-parents
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "=== #506 Stage 2: res-9 / res-8 rollups with nland (needs #507 res-10 ecoregion) ==="
+          python3 - <<'PYEOF'
+          import duckdb, os
+
+          W10  = 's3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/h0=*/data_0.parquet'
+          ECO  = 's3://public-ca30x30/ecoregion/hex/h0=*/data_0.parquet'
+          BASE = 's3://public-ca30x30/conserved-areas-terrestrial-2025'
+
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET preserve_insertion_order=false")
+          con.execute("SET temp_directory='/tmp/duckdb-spill'")
+          con.execute("SET memory_limit='100GiB'")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', "
+              "ENDPOINT '{}', URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ.get('AWS_S3_ENDPOINT', 'rook-ceph-rgw-nautiluss3.rook')))
+
+          # Guard: #507 must have landed — the ecoregion hex must actually carry h10.
+          eco_cols = {r[0] for r in con.execute(
+              "DESCRIBE SELECT * FROM read_parquet('{}')".format(ECO)).fetchall()}
+          assert {'h10', 'h9', 'h8', 'h0'} <= eco_cols, (
+              'ecoregion hex lacks res-10 index columns {} — #507 has not landed; '
+              'refusing to roll up on an unclipped stand-in grid'.format(sorted(eco_cols)))
+
+          con.execute("""
+              CREATE OR REPLACE TABLE land10 AS
+              SELECT DISTINCT h0, h9, h8, h10 FROM read_parquet('{}')
+          """.format(ECO))
+          con.execute("""
+              CREATE OR REPLACE TABLE child AS
+              SELECT l.h0, l.h9, l.h8, l.h10,
+                     COALESCE(w.w1, 0) AS w1, COALESCE(w.w2, 0) AS w2,
+                     COALESCE(w.w3, 0) AS w3, COALESCE(w.w4, 0) AS w4
+              FROM land10 l
+              LEFT JOIN read_parquet('{}') w USING (h0, h8, h10)
+          """.format(W10))
+
+          n_land, n_cons = con.execute(
+              "SELECT COUNT(*), SUM(CASE WHEN w1+w2+w3+w4 > 0 THEN 1 ELSE 0 END) FROM child").fetchone()
+          n_w10, n_offland = con.execute("""
+              SELECT COUNT(*), SUM(CASE WHEN l.h10 IS NULL THEN 1 ELSE 0 END)
+              FROM read_parquet('{}') w LEFT JOIN land10 l USING (h0, h8, h10)
+          """.format(W10)).fetchone()
+          print('LAND10_CELLS={}  OF_WHICH_CONSERVED={}'.format(n_land, n_cons))
+          print('W10_CELLS={}  OUTSIDE_LAND_GRID={} ({:.3f}%)'.format(
+              n_w10, n_offland, 100.0 * n_offland / n_w10))
+
+          for res, keys in ((9, 'h0, h9, h8'), (8, 'h0, h8')):
+              con.execute("""
+                  CREATE OR REPLACE TABLE parent{res} AS
+                  SELECT {keys}, COUNT(*)::INTEGER AS nland,
+                         SUM(w1)/COUNT(*) AS w1, SUM(w2)/COUNT(*) AS w2,
+                         SUM(w3)/COUNT(*) AS w3, SUM(w4)/COUNT(*) AS w4
+                  FROM child GROUP BY {keys}
+              """.format(res=res, keys=keys))
+              cols = ('h9, h8, w1, w2, w3, w4, nland, h0' if res == 9
+                      else 'h8, w1, w2, w3, w4, nland, h0')
+              order = 'h9' if res == 9 else 'h8'
+              staging = '{}/hex-weights-res{}-staging'.format(BASE, res)
+              parts = [r[0] for r in con.execute(
+                  "SELECT DISTINCT h0 FROM parent{} ORDER BY h0".format(res)).fetchall()]
+              for h0 in parts:
+                  out = '{}/h0={}/data_0.parquet'.format(staging, h0)
+                  con.execute(
+                      "COPY (SELECT {cols} FROM parent{res} WHERE h0 = {h0} ORDER BY {order}) "
+                      "TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)".format(
+                          cols=cols, res=res, h0=h0, order=order, out=out))
+                  print('wrote {}'.format(out))
+              (rows, cells, mx_nland, mn_nland, mx_tot, mn_w) = con.execute("""
+                  SELECT COUNT(*), COUNT(DISTINCT {order}), MAX(nland), MIN(nland),
+                         MAX(w1+w2+w3+w4), MIN(LEAST(w1,w2,w3,w4))
+                  FROM read_parquet('{s}/h0=*/data_0.parquet')
+              """.format(order=order, s=staging)).fetchone()
+              print('RES{} ROWS={} CELLS={} NLAND=[{},{}] MAX_TOTAL_W={:.9f} MIN_W={:.9f}'.format(
+                  res, rows, cells, mn_nland, mx_nland, mx_tot, mn_w))
+              assert rows == cells, 'res{} not one row per cell'.format(res)
+              assert mn_nland >= 1 and mx_nland <= (7 if res == 9 else 49), \
+                  'res{} nland outside [1,{}]'.format(res, 7 if res == 9 else 49)
+              assert mx_tot <= 1.0 + 1e-9 and mn_w >= 0.0, 'res{} weight outside [0,1]'.format(res)
+
+          # --- invariant: land-clipped conserved area is identical at all three levels ---
+          a10 = con.execute("SELECT SUM(w1+w2), SUM(w3+w4) FROM child").fetchone()
+          a9  = con.execute("SELECT SUM((w1+w2)*nland), SUM((w3+w4)*nland) FROM parent9").fetchone()
+          a8  = con.execute("SELECT SUM((w1+w2)*nland), SUM((w3+w4)*nland) FROM parent8").fetchone()
+          print('CELL_EQUIV_GAP12 res10={:.4f} res9={:.4f} res8={:.4f}'.format(a10[0], a9[0], a8[0]))
+          print('CELL_EQUIV_GAP34 res10={:.4f} res9={:.4f} res8={:.4f}'.format(a10[1], a9[1], a8[1]))
+          for i in (0, 1):
+              assert abs(a9[i] - a10[i]) / a10[i] < 1e-9, 'res9 rollup does not conserve total'
+              assert abs(a8[i] - a10[i]) / a10[i] < 1e-9, 'res8 rollup does not conserve total'
+
+          # --- acceptance: the res-8 join that used to be silently wrong now agrees ---
+          gap12, gap34, nonc = con.execute("""
+              WITH feature AS (
+                  SELECT DISTINCT h0, h8
+                  FROM read_parquet('s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex/h0=*/data_0.parquet')
+                  WHERE BioRankSW = 5)
+              SELECT ROUND(100.0*SUM((p.w1+p.w2)*p.nland)/SUM(p.nland), 2),
+                     ROUND(100.0*SUM((p.w3+p.w4)*p.nland)/SUM(p.nland), 2),
+                     ROUND(100.0*SUM((1-p.w1-p.w2-p.w3-p.w4)*p.nland)/SUM(p.nland), 2)
+              FROM feature f JOIN parent8 p USING (h0, h8)
+          """).fetchone()
+          print('ACCEPTANCE res8 join, BioRankSW=5: gap12={} (target 21.05) gap34={} (target 29.54) '
+                'non_conserved={} (report 49.81)'.format(gap12, gap34, nonc))
+          assert abs(float(gap12) - 21.05) <= 1.0, 'res8 gap12 outside +/-1.0pp of 21.05'
+          assert abs(float(gap34) - 29.54) <= 1.0, 'res8 gap34 outside +/-1.0pp of 29.54'
+
+          open('/tmp/ok', 'w').write('ok')
+          PYEOF
+          test -f /tmp/ok || { echo 'staging validation failed; NOT flipping'; exit 1; }
+
+          for RES in 9 8; do
+            echo "--- flipping hex-weights-res${RES} ---"
+            rclone purge nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res${RES}/ 2>/dev/null || true
+            REMAIN=$(rclone lsf -R nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res${RES}/ 2>/dev/null | wc -l)
+            test "$REMAIN" -eq 0 || { echo "target res${RES} not empty after purge ($REMAIN); refusing to flip"; exit 1; }
+            rclone move nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res${RES}-staging/ \
+                        nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res${RES}/
+            rclone lsf -R --format sp nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-res${RES}/
+          done
+          echo '=== #506 Stage 2 res-9 / res-8 rollups published ==='
+        resources:
+          requests: {cpu: '8', memory: 120Gi, ephemeral-storage: 50Gi}
+          limits:   {cpu: '8', memory: 120Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-weights.yaml
+++ b/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-weights.yaml
@@ -1,0 +1,186 @@
+# data-workflows#506 Stage 1 — per-cell GAP fractions at res 10.
+#
+# The published hex asset is one row per (unit, res-10 cell) and carries only PER-UNIT
+# attributes (Final_g1_p..Final_g4_p, Acres, Total_Acre, reGAP). There is no per-cell
+# conserved fraction anywhere in the catalog, so every consumer derives one — and the
+# easy derivation (GROUP BY h8 on the conserved layer before joining a res-8 feature
+# grid) discards the coverage fraction of the 49 res-10 children and overstates the
+# conserved share by +11.3pp (reported 30% of top-biodiversity land unprotected where
+# the 2025 assessment says 49.8%). Publishing the aggregation removes the decision.
+#
+# Normalization — option (a) from the issue, proportional cap at 1:
+#   rN = SUM(Final_gN_p)/100 over the DISTINCT units covering the cell
+#   wN = rN / GREATEST(r1+r2+r3+r4, 1.0)
+# Every unit has Final_g1_p+..+Final_g4_p = 100 exactly (verified: min = max = 100 over
+# all 13,340,094 hex rows / 45,811 units), so the raw total equals the covering-unit
+# count and the rule is an unweighted mean of the covering units' GAP mixes — order-free,
+# unlike GAP-precedence (option b), which would bake California's "GAP 1+2 counts toward
+# 30x30" convention into the data layer. Only 0.42% of cells are multi-unit, but max
+# stacking is 222 units, so the rule cannot be left implicit.
+#
+# The source hex has 70,806 duplicate (h10, _cng_fid) rows (0.53%), so the aggregation
+# MUST dedup by (cell, unit) first or those units count twice in those cells.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: conserved-areas-2025-hex-weights
+  namespace: geo-workflows
+  labels:
+    k8s-app: conserved-areas-2025-hex-weights
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: conserved-areas-2025-hex-weights
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: hex-weights
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "=== #506 Stage 1: per-cell GAP weights (res 10) ==="
+          python3 - <<'PYEOF'
+          import duckdb, os
+
+          SRC     = 's3://public-ca30x30/conserved-areas-terrestrial-2025/hex/h0=*/data_0.parquet'
+          STAGING = 's3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-staging'
+
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET preserve_insertion_order=false")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', "
+              "ENDPOINT '{}', URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ.get('AWS_S3_ENDPOINT', 'rook-ceph-rgw-nautiluss3.rook')))
+
+          # Dedup (cell, unit) BEFORE summing. Final_g*_p is constant per _cng_fid
+          # (verified: exactly 1 distinct value per unit), so MAX() is a safe pick-one.
+          con.execute("""
+              CREATE VIEW weights AS
+              WITH cell_unit AS (
+                  SELECT h0, h8, h9, h10, _cng_fid,
+                         MAX(Final_g1_p) AS g1, MAX(Final_g2_p) AS g2,
+                         MAX(Final_g3_p) AS g3, MAX(Final_g4_p) AS g4
+                  FROM read_parquet('{src}')
+                  GROUP BY h0, h8, h9, h10, _cng_fid),
+              raw AS (
+                  SELECT h0, h8, h9, h10,
+                         COUNT(*)::INTEGER AS n_units,
+                         SUM(g1)/100.0 AS r1, SUM(g2)/100.0 AS r2,
+                         SUM(g3)/100.0 AS r3, SUM(g4)/100.0 AS r4
+                  FROM cell_unit
+                  GROUP BY h0, h8, h9, h10)
+              SELECT h10, h9, h8,
+                     r1/GREATEST(r1+r2+r3+r4, 1.0) AS w1,
+                     r2/GREATEST(r1+r2+r3+r4, 1.0) AS w2,
+                     r3/GREATEST(r1+r2+r3+r4, 1.0) AS w3,
+                     r4/GREATEST(r1+r2+r3+r4, 1.0) AS w4,
+                     n_units, h0
+              FROM raw
+          """.format(src=SRC))
+
+          # --- write one file per h0 partition (California spans 2 res-0 cells) ---
+          parts = [r[0] for r in con.execute("SELECT DISTINCT h0 FROM weights ORDER BY h0").fetchall()]
+          print('H0_PARTITIONS={}'.format(parts))
+          assert parts, 'no partitions produced'
+          for h0 in parts:
+              out = '{}/h0={}/data_0.parquet'.format(STAGING, h0)
+              con.execute(
+                  "COPY (SELECT * FROM weights WHERE h0 = {h0} ORDER BY h10) TO '{out}' "
+                  "(FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)".format(h0=h0, out=out))
+              print('wrote {}'.format(out))
+
+          # --- structural validation ---
+          STAGED = '{}/h0=*/data_0.parquet'.format(STAGING)
+          src_cells = con.execute(
+              "SELECT COUNT(DISTINCT h10) FROM read_parquet('{}')".format(SRC)).fetchone()[0]
+          (rows, cells, n_h0, min_tot, max_tot, min_w, max_w, max_units, null_idx) = con.execute("""
+              SELECT COUNT(*), COUNT(DISTINCT h10), COUNT(DISTINCT h0),
+                     MIN(w1+w2+w3+w4), MAX(w1+w2+w3+w4),
+                     MIN(LEAST(w1,w2,w3,w4)), MAX(GREATEST(w1,w2,w3,w4)),
+                     MAX(n_units),
+                     SUM(CASE WHEN h9 IS NULL OR h8 IS NULL OR h0 IS NULL THEN 1 ELSE 0 END)
+              FROM read_parquet('{}')
+          """.format(STAGED)).fetchone()
+          print('ROWS={} CELLS={} SRC_CELLS={} N_H0={} TOTAL_W=[{:.9f},{:.9f}] '
+                'W=[{:.9f},{:.9f}] MAX_UNITS={} NULL_IDX={}'.format(
+                    rows, cells, src_cells, n_h0, min_tot, max_tot, min_w, max_w, max_units, null_idx))
+          assert rows == cells,      'not one row per res-10 cell'
+          assert cells == src_cells, 'cell count {} != source DISTINCT h10 {}'.format(cells, src_cells)
+          assert null_idx == 0,      'NULL h9/h8/h0 index column'
+          # Every covered cell has raw total >= 1, so the cap always binds and w sums to 1.
+          # Tolerance is 1e-6, not 1e-9: Final_g*_p are DOUBLEs that sum to 100 only to
+          # float precision (observed min 0.99999988), so the cap inherits that residual.
+          assert abs(min_tot - 1.0) < 1e-6 and abs(max_tot - 1.0) < 1e-6, \
+              'w1+w2+w3+w4 must equal 1 on every row under the proportional cap'
+          assert min_w >= 0.0 and max_w <= 1.0 + 1e-9, 'weight outside [0,1]'
+
+          # --- acceptance criterion from the issue: ACE BioRank-5 overlay at res 10 ---
+          gap12, gap34 = con.execute("""
+              WITH land AS (
+                  SELECT DISTINCT h0, h8, h10
+                  FROM read_parquet('s3://public-ca30x30/cwhr13/hex-fractions/h0=*/data_0.parquet')
+                  WHERE whr13num <> 0),
+              feature AS (
+                  SELECT DISTINCT h0, h8
+                  FROM read_parquet('s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex/h0=*/data_0.parquet')
+                  WHERE BioRankSW = 5),
+              w AS (SELECT h0, h8, h10, w1, w2, w3, w4 FROM read_parquet('{}'))
+              SELECT ROUND(100.0*SUM(COALESCE(w.w1,0)+COALESCE(w.w2,0))/COUNT(*), 2),
+                     ROUND(100.0*SUM(COALESCE(w.w3,0)+COALESCE(w.w4,0))/COUNT(*), 2)
+              FROM feature f JOIN land l USING (h0, h8) LEFT JOIN w USING (h0, h8, h10)
+          """.format(STAGED)).fetchone()
+          print('ACCEPTANCE BioRankSW=5  gap12={} (target 21.05)  gap34={} (target 29.54)'.format(gap12, gap34))
+          assert abs(float(gap12) - 21.05) <= 0.5, 'gap12 outside +/-0.5pp of 21.05'
+          assert abs(float(gap34) - 29.54) <= 0.5, 'gap34 outside +/-0.5pp of 29.54'
+
+          open('/tmp/ok', 'w').write('ok')
+          PYEOF
+          test -f /tmp/ok || { echo 'staging validation failed; NOT flipping'; exit 1; }
+
+          echo '--- staging validated; purge-and-verify-empty target, then flip ---'
+          rclone purge nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/ 2>/dev/null || true
+          REMAIN=$(rclone lsf -R nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/ 2>/dev/null | wc -l)
+          test "$REMAIN" -eq 0 || { echo "target not empty after purge ($REMAIN objects); refusing to flip"; exit 1; }
+          rclone move nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights-staging/ \
+                      nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/
+          rclone lsf -R --format sp nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/
+          echo '=== #506 Stage 1 hex-weights published ==='
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-flip-res10.yaml
+++ b/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-flip-res10.yaml
@@ -54,10 +54,12 @@ spec:
           N=$(rclone lsf -R "$STAGING/" | grep -c 'data_0.parquet$' || true)
           echo "staging partitions: $N"
           test "$N" -ge 1 || { echo 'staging is empty; refusing to flip'; exit 1; }
-          # every staged partition must be a real file, not a 0-row placeholder
-          SMALL=$(rclone lsf -R --format sp "$STAGING/" | awk -F';' '$1 < 4096' | wc -l)
+          # every staged partition must be a real file, not a 0-row placeholder.
+          # --files-only matters: `lsf -R --format sp` reports size -1 for directory rows,
+          # which a bare `$1 < 4096` test counts as undersized partitions.
+          SMALL=$(rclone lsf -R --files-only --format sp "$STAGING/" | awk -F';' '$1 < 4096' | wc -l)
           test "$SMALL" -eq 0 || { echo "$SMALL staged partitions under 4096 bytes; refusing to flip"; \
-            rclone lsf -R --format sp "$STAGING/"; exit 1; }
+            rclone lsf -R --files-only --format sp "$STAGING/"; exit 1; }
 
           echo '--- purge live path and verify empty ---'
           rclone purge "$LIVE/" 2>/dev/null || true

--- a/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-flip-res10.yaml
+++ b/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-flip-res10.yaml
@@ -1,0 +1,84 @@
+# data-workflows#507 — flip the validated res-10 ecoregion hex into the live asset path.
+#
+# Deliberately a separate job from the repartition: the precise acceptance gate (cell-union
+# area within ~1.5% of the pinned 101,498,000 acres, via the duckdb-geo MCP against the
+# staging prefix) runs BETWEEN repartition and this flip, so an unvalidated rebuild can
+# never replace the live asset. The href does not change — `ecoregion/hex/h0=*/data_0.parquet`
+# stays the asset path, and the res-10 build is a strict superset of the old res-8 one
+# (it still carries h8), so `SELECT DISTINCT h0,h8` masking queries keep working.
+#
+# purge-and-VERIFY-empty before the move: `rclone purge` can silently no-op under S3 load,
+# and the old res-8 partitions must not survive alongside res-10 rows.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ecoregion-flip-res10
+  namespace: geo-workflows
+  labels:
+    k8s-app: ecoregion-flip-res10
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ecoregion-flip-res10
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: flip
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          STAGING=nrp:public-ca30x30/ecoregion/hex-res10-staging
+          LIVE=nrp:public-ca30x30/ecoregion/hex
+
+          N=$(rclone lsf -R "$STAGING/" | grep -c 'data_0.parquet$' || true)
+          echo "staging partitions: $N"
+          test "$N" -ge 1 || { echo 'staging is empty; refusing to flip'; exit 1; }
+          # every staged partition must be a real file, not a 0-row placeholder
+          SMALL=$(rclone lsf -R --format sp "$STAGING/" | awk -F';' '$1 < 4096' | wc -l)
+          test "$SMALL" -eq 0 || { echo "$SMALL staged partitions under 4096 bytes; refusing to flip"; \
+            rclone lsf -R --format sp "$STAGING/"; exit 1; }
+
+          echo '--- purge live path and verify empty ---'
+          rclone purge "$LIVE/" 2>/dev/null || true
+          REMAIN=$(rclone lsf -R "$LIVE/" 2>/dev/null | wc -l)
+          test "$REMAIN" -eq 0 || { echo "live path not empty after purge ($REMAIN objects); refusing to flip"; exit 1; }
+
+          echo '--- move staging -> live ---'
+          rclone move "$STAGING/" "$LIVE/"
+          rclone lsf -R --format sp "$LIVE/"
+          echo '=== #507 ecoregion res-10 hex published at ecoregion/hex/ ==='
+        resources:
+          requests: {cpu: '2', memory: 4Gi, ephemeral-storage: 10Gi}
+          limits:   {cpu: '2', memory: 4Gi, ephemeral-storage: 10Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-hex-res10.yaml
+++ b/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-hex-res10.yaml
@@ -1,0 +1,75 @@
+# data-workflows#507 — re-index ca30x30-ecoregion at native H3 resolution 10.
+#
+# `ecoregion` is the app's canonical definition of California (pinned statewide
+# denominator 101,498,000 acres = SUM(Shape_Area) in EPSG:3310). Its hex asset was
+# native res 8 with parents [0], which is enough to MASK a feature to California but
+# cannot serve as a DENOMINATOR: an overlay against the res-10 conserved-areas layer
+# has to enumerate the res-10 land children of a parent cell (`nland`, needed by #506).
+# Consumers fell back to cwhr13 as a stand-in land grid, which is a habitat dataset and
+# is not clipped to California (1.36M acres out of state).
+#
+# 20 features, largest 66,834 km2 (~4.4M res-10 cells) — chunk-size 1 puts each
+# ecoregion in its own pod so one big polygon can't stall or OOM the others.
+# Chunks go to a res10-specific prefix so the live res-8 asset is untouched until
+# ecoregion-flip-res10 has validated the rebuild.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ecoregion-hex-res10
+  namespace: geo-workflows
+  labels:
+    k8s-app: ecoregion-hex-res10
+spec:
+  completions: 20
+  parallelism: 20
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  ttlSecondsAfterFinished: 10800
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  template:
+    metadata:
+      labels:
+        k8s-app: ecoregion-hex-res10
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: TMPDIR, value: /tmp}
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector \
+            --input s3://public-ca30x30/ecoregion.parquet \
+            --output s3://public-ca30x30/ecoregion/chunks-res10 \
+            --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1 --intermediate-chunk-size 1 \
+            --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-repartition-res10.yaml
+++ b/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-repartition-res10.yaml
@@ -1,0 +1,63 @@
+# data-workflows#507 — merge the res-10 ecoregion chunks into h0-partitioned hex.
+# Output goes to a STAGING prefix; ecoregion-flip-res10 validates it against the pinned
+# 101,498,000-acre denominator before it replaces the live res-8 asset.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ecoregion-repartition-res10
+  namespace: geo-workflows
+  labels:
+    k8s-app: ecoregion-repartition-res10
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ecoregion-repartition-res10
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: TMPDIR, value: /tmp}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition \
+            --chunks-dir s3://public-ca30x30/ecoregion/chunks-res10 \
+            --output-dir s3://public-ca30x30/ecoregion/hex-res10-staging \
+            --source-parquet s3://public-ca30x30/ecoregion.parquet \
+            --cleanup --memory-limit 100GiB
+          rclone lsf -R --format sp nrp:public-ca30x30/ecoregion/hex-res10-staging/
+        resources:
+          requests: {cpu: '8', memory: 120Gi, ephemeral-storage: 50Gi}
+          limits:   {cpu: '8', memory: 120Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -245,9 +245,18 @@ def is_parquet(asset: dict) -> bool:
     return "parquet" in asset.get("type", "")
 
 
+_H0_PARTITION = re.compile(r"/h0=\*/")
+
+
 def is_hex_asset(key: str, asset: dict) -> bool:
+    """A hive-partitioned H3 asset. The `h0=*` partition glob is the substantive signal:
+    partition-dir names vary across the catalog (hex, hex-fractions, hex-max, hex-mean,
+    hex-weights, taxonomy, p80-hex), and keying only off `/hex/` or a `-hex` key suffix
+    silently skipped the h3-resolution / glob / hex-dup checks on every variant name and
+    mis-flagged them as flat GeoParquet missing a geometry column."""
     href = asset.get("href", "")
-    return "/hex/" in href or key.endswith("-hex") or key == "hex"
+    return ("/hex/" in href or key.endswith("-hex") or key == "hex"
+            or bool(_H0_PARTITION.search(href)))
 
 
 def is_pmtiles(asset: dict) -> bool:
@@ -550,7 +559,6 @@ def check_inline_area_formula(doc: dict) -> list[Finding]:
     return out
 
 
-_H0_PARTITION = re.compile(r"/h0=\*/")
 
 
 def _asset_has_geom(asset: dict) -> bool:
@@ -581,6 +589,47 @@ def _collection_has_vector_source(doc: dict) -> bool:
     return False
 
 
+def _flat_vector_attrs(doc: dict) -> set[str]:
+    """Lowercased attribute names documented on the collection's flat vector asset(s),
+    excluding H3 indexes, bbox and geometry."""
+    out = set()
+    for key, asset in doc.get("assets", {}).items():
+        if not is_parquet(asset) or is_hex_asset(key, asset):
+            continue
+        if not _asset_has_geom(asset):
+            continue
+        for col in asset.get("table:columns", []):
+            name = col.get("name", "").lower()
+            if name in SAFE_HEX_COLS or _is_geom_col(name):
+                continue
+            out.add(name)
+    return out
+
+
+def _is_percell_aggregation(doc: dict, asset: dict) -> bool:
+    """True for a hex asset that is a per-CELL aggregation — one row per cell — derived
+    from the collection's own features, rather than a per-(feature, cell) conversion.
+
+    A cng-datasets vector hex always carries the source feature attributes forward, so it
+    necessarily shares attribute names with the flat GeoParquet. A derived aggregation
+    shares NONE: every non-index column is newly computed (data-workflows#506
+    `…-hex-weights`: h-indexes + w1…w4 + nland + n_units). Such an asset has collapsed the
+    feature dimension away, so there is no per-feature identity left to carry and
+    `_cng_fid` is as meaningless on it as on a raster reduce — where a row-unique id would
+    in fact be actively misleading, since `COUNT(DISTINCT _cng_fid)` would then equal the
+    cell count rather than a feature count.
+
+    Deliberately a positive schema test rather than an opt-out flag: a genuine
+    `_cng_fid`-missing defect still carries its source attributes and so still HARD-fails.
+    """
+    flat = _flat_vector_attrs(doc)
+    if not flat:
+        return False
+    attrs = {c.get("name", "").lower() for c in asset.get("table:columns", [])}
+    attrs = {c for c in attrs if c not in SAFE_HEX_COLS and not _is_geom_col(c)}
+    return bool(attrs) and not (attrs & flat)
+
+
 def check_cng_fid(doc: dict) -> list[Finding]:
     """Enforce the universal `_cng_fid` contract (#369).
 
@@ -605,6 +654,12 @@ def check_cng_fid(doc: dict) -> list[Finding]:
         conversion, so it correctly has no per-feature id. Detected as a hex asset whose
         collection has NO vector source (COG-independent — covers carbon/ghs-pop which
         ship a COG *and* richness/cwhr/gbif which do not).
+
+      exempt (silent) — per-cell aggregation of a VECTOR collection's own features
+        (#506 `…-hex-weights`): one row per cell, not per (feature, cell). The feature
+        dimension is aggregated away, so `_cng_fid` has nothing to identify. Detected by
+        `_is_percell_aggregation`: it shares no attribute column with the collection's
+        flat GeoParquet, whereas a real conversion always carries its source attributes.
 
       ADVISORY — a non-spatial parquet table (no geometry, not a vector hex): could be a
         fact table that SHOULD carry `_cng_fid` (tpl `…-funding`, keyed by tpl_id) or a
@@ -636,6 +691,8 @@ def check_cng_fid(doc: dict) -> list[Finding]:
         if hex_:
             if not has_vector_source:
                 continue  # raster-derived hex → no per-feature id by design
+            if _is_percell_aggregation(doc, asset):
+                continue  # per-cell aggregation → feature dimension collapsed by design
             out.append(Finding(HARD, "cng-fid-missing",
                 f"vector hex asset '{key}' does not document '_cng_fid'. " + common))
         elif _asset_has_geom(asset):


### PR DESCRIPTION
Closes #506. Closes #507.

## #506 — per-cell GAP fractions (`hex-weights`)

The hex asset is one row per (unit, res-10 cell) and carries only **per-unit** attributes, so there was no per-cell conserved fraction anywhere in the catalog. The easy derivation — `GROUP BY h8` on the res-10 conserved layer before joining a res-8 feature grid — compiles, prunes partitions, runs fast, and is silently wrong: it discards the coverage fraction of the 49 res-10 children. On ACE BioRank-5 that overstates GAP 1+2 by **+11.3pp** and reports **30%** of top-biodiversity land unprotected where the 2025 assessment says **49.8%**.

Three new assets on `ca30x30-conserved-areas-terrestrial-2025`, one row per **cell**:

| Asset | Grain | Columns |
|---|---|---|
| `…-hex-weights` | res-10 cell | `h10, h9, h8, w1..w4, n_units, h0` |
| `…-hex-weights-res9` | res-9 cell | `h9, h8, w1..w4, nland, h0` |
| `…-hex-weights-res8` | res-8 cell | `h8, w1..w4, nland, h0` |

**Normalization: rule (a)** from the issue — proportional cap at 1, `wN = rN / GREATEST(r1+r2+r3+r4, 1)`. Every unit's `Final_g1_p..Final_g4_p` sum to exactly 100 (verified: min = max = 100 over all 13,340,094 rows / 45,811 units), so this is an unweighted mean of the covering units' GAP mixes — order-free. Rejected (b) GAP-precedence: it would bake California's "GAP 1+2 counts toward 30x30" convention into the data layer, the same per-application convention the issue rightly keeps out of `w12`/`w34`.

Parent weights are area-weighted means over each cell's res-10 **California-land** children (`SUM(child wN)/nland`), so a native-res-8 feature grid joins directly.

**Correction to the issue's premise:** the source hex has 70,806 duplicate `(h10, _cng_fid)` rows, up to **221 copies of one unit on a single cell**. The reported "max total weight 222" was that duplication, not 222 overlapping units — after dedup the deepest real stack is **16**. The build dedups `(cell, unit)` before aggregating; a naive `SUM` over hex rows would have double-counted.

### Acceptance (published res-10 asset, live)

| feature | gap12 | gap34 | non-conserved | issue target / report |
|---|---:|---:|---:|---|
| `BioRankSW=5` | 21.01 | 29.58 | 49.40 | 21.05 / 29.54 · report 21.09 / 29.10 / 49.81 |
| `NtvAmph` p80 | 19.56 | 24.12 | 56.32 | report 19.48 / 23.69 / 56.83 |
| `NtvBird` p80 | 11.90 | 14.80 | 73.30 | report 11.88 / 14.63 / 73.49 |
| `NtvRept` p80 | 40.94 | 24.04 | 35.02 | report 40.93 / 23.91 / 35.16 |

All four rows reproduce the issue's table within 0.05pp — inside the ±0.5pp criterion.

## #507 — res-10 California land grid

`ca30x30-ecoregion` is the app's canonical definition of California (pinned denominator 101,498,000 acres), but its hex asset was native res 8 / parents `[0]`: fine as a **mask**, useless as a **denominator**, because a res-10 overlay must enumerate the res-10 land children of a parent cell. Consumers fell back to `cwhr13`, a habitat dataset that is not clipped to California (1.36M acres out of state).

Re-indexed to **native res 10, parents `[9, 8, 0]`**, same href. `h8` is still carried, so existing `SELECT DISTINCT h0, h8` masking is unaffected. This is the grid that supplies `nland` above.

## `verify-stac.py`

- **`is_hex_asset` now recognizes any `h0=*` partition glob**, not just `/hex/` or a `-hex` key suffix. Variant partition dirs (`hex-fractions`, `hex-max`, `hex-mean`, `hex-weights`, `taxonomy`) were skipping the h3-resolution / glob / hex-dup checks entirely *and* getting a spurious `geoparquet-no-geom-column` advisory — reproduced on the live `cwhr13-hex-fractions`. No new HARD findings across the collections I spot-checked (cwhr13, plant-richness, ecoregion, nlcd-2024, ace, conserved-areas).
- **`check_cng_fid` exempts a per-CELL aggregation** of a vector collection's own features. `_cng_fid` identifies a feature; an asset that has aggregated the feature dimension away has nothing to identify, and a row-unique id there would be actively misleading (`COUNT(DISTINCT _cng_fid)` would return the cell count). Detected **positively** — the asset shares no attribute column with the flat GeoParquet, whereas a real conversion always carries its source attributes forward — so a genuine missing-`_cng_fid` defect still HARD-fails.

## Notes for review

- STAC/README are published to NRP S3, not committed (HARD BOUNDARY 1). The Verify-STAC check is expected RED until the cluster run finishes and the STAC lands; it will be re-fired then.
- Jobs run in `geo-workflows`. Each build writes to a staging prefix, validates (structural invariants + the issue's acceptance query as an in-job assertion), then purges-and-verifies-empty before flipping — an unvalidated build cannot replace a live asset.