### PR TITLE
fix(#509): dedup conserved-areas-2025 hex + gate (feature, cell) uniqueness in verify-stac

### DIFF
--- a/catalog/audit/k8s/hex-dedup-batch-ca.yaml
+++ b/catalog/audit/k8s/hex-dedup-batch-ca.yaml
@@ -1,0 +1,188 @@
+# data-workflows#509 — batch dedup of the CA-app vector hex assets built before the
+# 2026-07-12 polyfill fix (boettiger-lab/datasets#150 / PR #158).
+#
+# The old polyfill emitted one row per (feature, cell, geometry PART), so MultiPolygons
+# whose parts share a cell produced byte-identical duplicate rows. Already fixed upstream;
+# these are stale artifacts. This job covers the California app's data surface only —
+# the rest of the 108 pre-fix assets are a separate pass on #509.
+#
+# SAFETY: per target, the job proves the duplicates are pure redundancy BEFORE writing:
+#   COUNT(*) over SELECT DISTINCT *  ==  COUNT(DISTINCT (finest non-NULL cell, _cng_fid))
+# If those differ, some duplicate pair differs in a column — it is NOT a byte-identical
+# copy, SELECT DISTINCT * would not collapse it, and rewriting could destroy information.
+# Such a target is SKIPPED and reported, never rewritten.
+#
+# The cell key uses the FINEST NON-NULL h column, not h3:native_resolution. A build that
+# caps large features at a coarser resolution leaves the native column NULL for them
+# (WDPA: h9 NULL on 37.5% of rows) and COUNT(DISTINCT) drops NULL keys — keying on the
+# native column alone reported 77,991,738 phantom duplicates on WDPA against a true 0.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hex-dedup-batch-ca
+  namespace: geo-workflows
+  labels:
+    k8s-app: hex-dedup-batch-ca
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: hex-dedup-batch-ca
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: hex-dedup
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== #509 CA-app hex dedup batch ==="
+
+          TARGETS="
+          public-ca30x30/williamson-act/all-years/hex
+          public-ca30x30/williamson-act/2021/hex
+          public-ca30x30/williamson-act/2022/hex
+          public-ca30x30/williamson-act/2023/hex
+          public-ca30x30/williamson-act/2024/hex
+          public-ca30x30/williamson-act/2025/hex
+          public-ca30x30/freshwater-species-richness/hex
+          public-ca30x30/fmmp-2022/hex
+          public-cdfw/ace/terrestrial-biodiversity-summary/hex
+          public-cpad/cpad-2025b-units/hex
+          public-fire/calfire-2025/firep/hex
+          public-fire/calfire-2025/rxburn/hex
+          public-swap/california/swap-2025/conservation-units/hex
+          public-swap/california/swap-2025/marine-bioregions/hex
+          "
+
+          # partition manifest: "<target> <h0dir>" per line
+          : > /tmp/parts.txt
+          for T in $TARGETS; do
+            for D in $(rclone lsf --dirs-only "nrp:${T}/"); do
+              echo "${T} ${D%/}" >> /tmp/parts.txt
+            done
+          done
+          echo "targets: $(echo $TARGETS | wc -w)  partitions: $(wc -l < /tmp/parts.txt)"
+
+          python3 - <<'PY'
+          import os, collections, duckdb
+
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET preserve_insertion_order=false")
+          con.execute("SET temp_directory='/tmp/duckdb-spill'")
+          con.execute("SET memory_limit='100GiB'")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', ENDPOINT '{}', "
+              "URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ['AWS_S3_ENDPOINT']))
+
+          parts = collections.OrderedDict()
+          for line in open('/tmp/parts.txt'):
+              t, d = line.split()
+              parts.setdefault(t, []).append(d)
+
+          plan, skipped, clean = [], [], []
+          for t, dirs in parts.items():
+              glob = "s3://{}/h0=*/data_0.parquet".format(t)
+              cols = [r[0] for r in con.execute(
+                  "DESCRIBE SELECT * FROM read_parquet('{}')".format(glob)).fetchall()]
+              hcols = sorted([c for c in cols if c.startswith('h') and c[1:].isdigit()],
+                             key=lambda c: int(c[1:]), reverse=True)
+              if '_cng_fid' not in cols or not hcols:
+                  skipped.append((t, 'not a vector hex')); continue
+              cell = "COALESCE(" + ", ".join('"{}"::VARCHAR'.format(h) for h in hcols) + ", 'z')"
+              rows, dfull, dpair = con.execute("""
+                  SELECT COUNT(*),
+                         (SELECT COUNT(*) FROM (SELECT DISTINCT * FROM read_parquet('{g}'))),
+                         COUNT(DISTINCT ({c} || '-' || _cng_fid::VARCHAR))
+                  FROM read_parquet('{g}')
+              """.format(g=glob, c=cell)).fetchone()
+              if rows == dfull == dpair:
+                  clean.append((t, rows)); continue
+              if dfull != dpair:
+                  # duplicates differ in some column -> NOT byte-identical, do not touch
+                  skipped.append((t, 'distinct_full={} != distinct_pair={} — duplicates carry '
+                                     'differing values; needs manual review'.format(dfull, dpair)))
+                  continue
+              plan.append((t, dirs, rows, dfull, cell))
+              print('PLAN {}: {} -> {} ({} dup rows)'.format(t, rows, dfull, rows - dfull), flush=True)
+
+          for t, _ in clean:
+              print('CLEAN (no action): {}'.format(t), flush=True)
+          for t, why in skipped:
+              print('SKIPPED: {} — {}'.format(t, why), flush=True)
+
+          done = []
+          for t, dirs, rows, expect, cell in plan:
+              staged_total = 0
+              for d in dirs:
+                  src = "s3://{}/{}/data_0.parquet".format(t, d)
+                  dst = "s3://{}-dedup-staging/{}/data_0.parquet".format(t, d)
+                  con.execute("COPY (SELECT DISTINCT * FROM read_parquet('{}')) TO '{}' "
+                              "(FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)".format(src, dst))
+                  staged_total += con.execute(
+                      "SELECT COUNT(*) FROM read_parquet('{}')".format(dst)).fetchone()[0]
+              sglob = "s3://{}-dedup-staging/h0=*/data_0.parquet".format(t)
+              scells, sfids = con.execute(
+                  "SELECT COUNT(DISTINCT ({c})), COUNT(DISTINCT _cng_fid) "
+                  "FROM read_parquet('{g}')".format(c=cell, g=sglob)).fetchone()
+              ocells, ofids = con.execute(
+                  "SELECT COUNT(DISTINCT ({c})), COUNT(DISTINCT _cng_fid) "
+                  "FROM read_parquet('s3://{t}/h0=*/data_0.parquet')".format(c=cell, t=t)).fetchone()
+              assert staged_total == expect, '{}: staged {} != expected {}'.format(t, staged_total, expect)
+              assert scells == ocells, '{}: cell count changed {} -> {}'.format(t, ocells, scells)
+              assert sfids == ofids, '{}: feature count changed {} -> {}'.format(t, ofids, sfids)
+              print('STAGED OK {}: {} rows, cells {}, features {}'.format(t, staged_total, scells, sfids), flush=True)
+              done.append((t, dirs, rows, staged_total))
+
+          with open('/tmp/flip.txt', 'w') as f:
+              for t, dirs, before, after in done:
+                  for d in dirs:
+                      f.write('{} {}\n'.format(t, d))
+                  print('READY {}: {} -> {}'.format(t, before, after), flush=True)
+          open('/tmp/ok', 'w').write('ok')
+          PY
+
+          test -f /tmp/ok || { echo 'validation failed; no live asset touched'; exit 1; }
+          echo '--- validated; swapping deduped partitions over live ---'
+          while read -r T D; do
+            rclone copyto "nrp:${T}-dedup-staging/${D}/data_0.parquet" "nrp:${T}/${D}/data_0.parquet"
+            echo "swapped ${T}/${D}"
+          done < /tmp/flip.txt
+          for T in $TARGETS; do rclone purge "nrp:${T}-dedup-staging" 2>/dev/null || true; done
+          echo '=== #509 CA-app hex dedup batch complete ==='
+        resources:
+          requests: {cpu: '8', memory: 120Gi, ephemeral-storage: 50Gi}
+          limits:   {cpu: '8', memory: 120Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-dedup.yaml
+++ b/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-dedup.yaml
@@ -1,0 +1,153 @@
+# data-workflows#509 — remove byte-identical duplicate (feature, cell) rows from the
+# conserved-areas-terrestrial-2025 hex asset.
+#
+# The vector polyfill used to emit one row per (feature, cell, geometry PART), so any
+# MultiPolygon whose parts share a cell produced identical duplicate rows. Fixed upstream
+# 2026-07-12 (boettiger-lab/datasets#150 / PR #158 — Pass 2 now writes SELECT DISTINCT *);
+# this asset was built 2026-06-18, so it is a stale artifact, not a live tool bug.
+# Confirmed by re-running :latest with this dataset's exact production parameters:
+# chunk 4 gave 26,752 rows / 0 duplicates vs 26,889 / 137 in the published data.
+#
+# A SELECT DISTINCT * rewrite is provably equivalent to a full re-hex here, because every
+# duplicate is a byte-identical FULL-ROW copy and there are no legitimate multi-row cases:
+#   rows                                  = 13,340,094
+#   COUNT(*) over SELECT DISTINCT *        = 13,269,288
+#   COUNT(DISTINCT (h10, _cng_fid))        = 13,269,288   <- identical, so nothing real is lost
+# Worst case removed: 221 copies of one unit on a single cell (Black Mountain Ranch Open
+# Space, 1,492 parts). Follows the #390 ecoregion-dedup pattern: stage, assert, then
+# overwrite each live partition in place.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: conserved-areas-2025-hex-dedup
+  namespace: geo-workflows
+  labels:
+    k8s-app: conserved-areas-2025-hex-dedup
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: conserved-areas-2025-hex-dedup
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: hex-dedup
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "=== #509 dedup: conserved-areas-terrestrial-2025 hex ==="
+          PARTS="577199624117288959 577762574070710271"
+          python3 - "$PARTS" <<'PY'
+          import os, sys, duckdb
+
+          BASE = 's3://public-ca30x30/conserved-areas-terrestrial-2025'
+          EXPECTED_ROWS     = 13269288   # == COUNT(*) over SELECT DISTINCT * on the live asset
+          EXPECTED_CELLS    = 13202628   # DISTINCT h10 — must NOT change
+          EXPECTED_FEATURES = 45811      # DISTINCT _cng_fid — must NOT change
+
+          parts = sys.argv[1].split()
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET preserve_insertion_order=false")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', ENDPOINT '{}', "
+              "URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ['AWS_S3_ENDPOINT']))
+
+          total = 0
+          for p in parts:
+              src = '{}/hex/h0={}/data_0.parquet'.format(BASE, p)
+              dst = '{}/hex-dedup-staging/h0={}/data_0.parquet'.format(BASE, p)
+              raw = con.execute("SELECT COUNT(*) FROM read_parquet('{}')".format(src)).fetchone()[0]
+              con.execute(
+                  "COPY (SELECT DISTINCT * FROM read_parquet('{}') ORDER BY h10) TO '{}' "
+                  "(FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)".format(src, dst))
+              rows, distinct_rows, dup_cf = con.execute("""
+                  SELECT COUNT(*),
+                         (SELECT COUNT(*) FROM (SELECT DISTINCT * FROM read_parquet('{d}'))),
+                         COUNT(*) - COUNT(DISTINCT (h10::VARCHAR || '-' || _cng_fid::VARCHAR))
+                  FROM read_parquet('{d}')
+              """.format(d=dst)).fetchone()
+              print('partition {}: raw={} deduped={} removed={}'.format(p, raw, rows, raw - rows),
+                    flush=True)
+              assert rows == distinct_rows, 'partition {}: staging still has duplicate rows'.format(p)
+              assert dup_cf == 0, 'partition {}: staging still has duplicate (cell, feature) rows'.format(p)
+              total += rows
+
+          staged = '{}/hex-dedup-staging/h0=*/data_0.parquet'.format(BASE)
+          rows, cells, feats = con.execute("""
+              SELECT COUNT(*), COUNT(DISTINCT h10), COUNT(DISTINCT _cng_fid)
+              FROM read_parquet('{}')
+          """.format(staged)).fetchone()
+          print('STAGED rows={} (expected {})  cells={} (expected {})  features={} (expected {})'.format(
+              rows, EXPECTED_ROWS, cells, EXPECTED_CELLS, feats, EXPECTED_FEATURES), flush=True)
+          assert total == rows == EXPECTED_ROWS, 'row count {} != expected {}'.format(rows, EXPECTED_ROWS)
+          # dedup must remove ONLY redundant rows — no cell and no feature may disappear
+          assert cells == EXPECTED_CELLS,    'DISTINCT h10 changed: {} != {}'.format(cells, EXPECTED_CELLS)
+          assert feats == EXPECTED_FEATURES, 'DISTINCT _cng_fid changed: {} != {}'.format(feats, EXPECTED_FEATURES)
+
+          # the published per-cell GAP weights (#506) already deduped, so they must be
+          # bit-for-bit reproducible from the deduped hex — proof the two agree
+          drift = con.execute("""
+              WITH recomputed AS (
+                  SELECT h0, h10,
+                         SUM(Final_g1_p)/100.0 AS r1, SUM(Final_g2_p)/100.0 AS r2,
+                         SUM(Final_g3_p)/100.0 AS r3, SUM(Final_g4_p)/100.0 AS r4
+                  FROM read_parquet('{staged}') GROUP BY h0, h10),
+              w AS (SELECT h0, h10, w1, w2, w3, w4
+                    FROM read_parquet('{base}/hex-weights/h0=*/data_0.parquet'))
+              SELECT COUNT(*) FROM recomputed r JOIN w USING (h0, h10)
+              WHERE abs(r.r1/GREATEST(r.r1+r.r2+r.r3+r.r4,1.0) - w.w1) > 1e-9
+                 OR abs(r.r4/GREATEST(r.r1+r.r2+r.r3+r.r4,1.0) - w.w4) > 1e-9
+          """.format(staged=staged, base=BASE)).fetchone()[0]
+          print('hex-weights disagreement rows: {} (expect 0)'.format(drift), flush=True)
+          assert drift == 0, 'published hex-weights do not match the deduped hex'
+
+          open('/tmp/ok', 'w').write('ok')
+          PY
+          test -f /tmp/ok || { echo 'validation failed; live asset NOT touched'; exit 1; }
+
+          echo '--- validated; overwriting each live partition in place ---'
+          for p in $PARTS; do
+            rclone copyto "nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-dedup-staging/h0=${p}/data_0.parquet" \
+                          "nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex/h0=${p}/data_0.parquet"
+            echo "swapped h0=${p}"
+          done
+          rclone purge nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex-dedup-staging || true
+          rclone lsl nrp:public-ca30x30/conserved-areas-terrestrial-2025/hex/
+          echo '=== #509 conserved-areas hex deduped ==='
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 20Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1038,6 +1038,78 @@ _NULL_JOIN_NOTE = re.compile(
     r"h3_cell_to_parent|largest features.{0,40}null", re.I)
 
 
+_MULTIROW_NOTE = re.compile(
+    r"multiple rows per \(?feature|more than one row per \(?feature|"
+    r"duplicate \(feature, cell\) rows are expected|per \(feature, cell, part\)", re.I)
+
+
+def check_hex_row_uniqueness(doc: dict, mcp: MCPClient) -> list[Finding]:
+    """One hex row must be one (feature, cell) pair — data-workflows#509.
+
+    The vector polyfill used to emit one row per (feature, cell, geometry PART), so any
+    MultiPolygon whose parts shared a cell produced byte-identical duplicate rows. Fixed
+    upstream 2026-07-12 (boettiger-lab/datasets#150 / PR #158, Pass 2 writes
+    `SELECT DISTINCT *`), but every vector hex built before that date still carries the
+    duplication, and nothing caught it: `COUNT(DISTINCT _cng_fid)` is unaffected, so the
+    documented dedup key does not rescue a consumer, and `audit-feature-dup.py` audits
+    UPSTREAM (axis-2) duplication rather than build artifacts. Confirmed live on
+    ca30x30-conserved-areas-terrestrial-2025 (70,806 dup rows, up to 221 copies of one
+    unit on a single cell) and padus-4-1/fee (160,293).
+
+    HARD, because the asset's own contract ("one row per (feature, hN) pair") is false and
+    every `COUNT(*)` / per-cell `SUM` over it is inflated. A genuine multi-row-per-
+    (feature, cell) case does not exist by construction; if one is ever legitimate,
+    document it in the asset description and this check will accept it.
+    """
+    out = []
+    coll_desc = doc.get("description", "") or ""
+    for key, asset in doc.get("assets", {}).items():
+        if not (is_parquet(asset) and is_hex_asset(key, asset)):
+            continue
+        s3 = _to_s3(asset.get("href", ""))
+        if not s3:
+            continue
+        cols = {c.get("name", "") for c in asset.get("table:columns", [])}
+        if "_cng_fid" not in cols:
+            continue  # raster reduce / per-cell aggregation — no (feature, cell) grain
+        # Key each row on its FINEST NON-NULL cell, not on h3:native_resolution.
+        # A build that caps very large features at a coarser resolution leaves the native
+        # column NULL for them (WDPA: h9 is NULL for its 1,297 biggest features, h8 is
+        # complete). COUNT(DISTINCT) drops NULL keys, so keying on the native column alone
+        # reports every NULL-native row as a duplicate — on WDPA that is a 77,991,738-row
+        # false positive against a true count of 0. H3 ids encode their resolution, so
+        # they are unique across resolutions and COALESCE is safe. The trailing literal
+        # keeps an all-NULL row countable rather than silently dropped.
+        hcols = sorted((c for c in cols if _HEX_RE.match(c)),
+                       key=lambda n: int(_HEX_RE.match(n).group(1)), reverse=True)
+        if not hcols:
+            continue
+        cell = "COALESCE(" + ", ".join(f'"{h}"::VARCHAR' for h in hcols) + ", 'none')"
+        try:
+            rows = mcp.query(
+                f"SELECT COUNT(*) AS total, COUNT(DISTINCT ({cell} || '-' || "
+                f"_cng_fid::VARCHAR)) AS pairs FROM read_parquet('{s3}')")
+            total, pairs = int(rows[0]["total"]), int(rows[0]["pairs"])
+        except (MCPError, ValueError, KeyError, IndexError) as e:
+            out.append(Finding(ADVISORY, "hex-row-uniqueness-check-failed",
+                               f"asset '{key}': could not check (feature, cell) "
+                               f"uniqueness ({e})."))
+            continue
+        if total and pairs < total:
+            desc = (asset.get("description", "") or "") + " " + coll_desc
+            if _MULTIROW_NOTE.search(desc):
+                continue
+            dup = total - pairs
+            out.append(Finding(HARD, "hex-duplicate-feature-cell-rows",
+                f"asset '{key}': {dup:,} rows ({100.0*dup/total:.3f}%) are duplicate "
+                f"(finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) "
+                f"pair, so COUNT(*) and any per-cell SUM over this asset are inflated. "
+                f"Almost certainly a vector hex built before the 2026-07-12 polyfill fix "
+                f"(boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite "
+                f"or re-hex. See data-workflows#509."))
+    return out
+
+
 def check_null_hex_index(doc: dict, mcp: MCPClient) -> list[Finding]:
     """A hex column with NULLs where a coarser column is fully populated means joining
     at that resolution silently drops the very large features that have no finer cell
@@ -1182,6 +1254,7 @@ def verify(source: str, do_data: bool = True, do_recall: bool = True,
             if do_data:
                 findings.extend(check_values_match_distinct(doc, client))
                 findings.extend(check_null_hex_index(doc, client))      # #309 §2 (hard)
+                findings.extend(check_hex_row_uniqueness(doc, client))  # #509 (hard)
                 findings.extend(check_polygon_row_dup(doc, client))     # #309 §1 (advisory)
             if do_recall:
                 findings.extend(recall_pass(doc, client))


### PR DESCRIPTION
Part of #509. Fixes the dataset that surfaced the problem and adds the gate that stops it recurring; the remaining catalog remediation stays open on the issue.

## What was wrong

The vector polyfill emitted one row per (feature, cell, **geometry part**), so any MultiPolygon whose parts shared a cell produced byte-identical duplicate rows. **Already fixed upstream** — datasets#150 / PR #158, 2026-07-12, Pass 2 now writes `SELECT DISTINCT *`. Nothing to change in `cng-datasets`; the problem is stale artifacts plus the fact that nothing in CI could see them.

## conserved-areas-terrestrial-2025 (built 2026-06-18, pre-fix)

**13,340,094 → 13,269,288 rows**, 70,806 duplicates removed. Worst case: 221 copies of one unit on a single cell (`Black Mountain Ranch Open Space`, 1,492 parts).

A `SELECT DISTINCT *` rewrite is *provably* equivalent to a full re-hex here, not merely cheaper:

```
rows                            = 13,340,094
COUNT(*) over SELECT DISTINCT * = 13,269,288
COUNT(DISTINCT (h10,_cng_fid))  = 13,269,288   <- identical => every dup is a full-row copy
```

Asserted in-job before the swap: `DISTINCT h10` (13,202,628) and `DISTINCT _cng_fid` (45,811) unchanged, and the published #506 `hex-weights` reproduce from the deduped hex with **zero** disagreeing rows.

## The gate

`verify-stac.py` gains `check_hex_row_uniqueness` (data-backed, HARD): one hex row must be one (feature, cell) pair. Nothing else caught this class — `COUNT(DISTINCT _cng_fid)` is unaffected, so the documented dedup key doesn't rescue a consumer, and `audit-feature-dup.py` audits *upstream* duplication, not build artifacts.

**A first cut of this check was wrong and would have been damaging.** Keying on `h3:native_resolution` reported **77,991,738 duplicate rows on WDPA against a true count of 0** — WDPA caps its 1,297 largest features at `h8`, leaving `h9` NULL for 37.5% of rows, and `COUNT(DISTINCT)` drops NULL keys. It now keys each row on its **finest non-NULL** cell; H3 ids encode their resolution, so the `COALESCE` is collision-free. Verified both directions: WDPA passes, `padus-4-1/fee` HARD-fails with its 160,293.

## Catalog scope (measured, for #509)

**108 of 164** vector hex assets predate the fix. Predating it is not proof of damage — only multipart features that share cells duplicate. Sampled:

| Collection | rows | duplicate rows | |
|---|---:|---:|---|
| `padus-4-1/fee` | 609,968,495 | 160,293 | 0.026% |
| `usgs-wbd hu12` | 15,191,575 | 28,106 | 0.185% |
| `calfire-2025 firep` | 11,377,557 | 1,806 | 0.016% |
| `ace-terrestrial-biodiversity-summary` | 519,971 | 57 | 0.011% |
| `cpad-holdings` | 12,562,921 | **0** | clean |
| `wdpa` | 207,833,890 | **0** | clean |

Remediation of the rest is not in this PR — the per-collection verdict is now a one-command check (`verify-stac.py --bucket X --dataset Y`), and the sweep is a scoping decision on #509.