### PR TITLE
docs(#512): STAC descriptions are user-facing copy, not engineering notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,45 @@ auto-refresh from S3, so **after your cluster jobs finish, re-fire the check** (
 - A MapLibre GL JS example with the correct `source-layer` (= last segment of `--dataset`), documented prominently
 - A DuckDB example with the full public parquet URL
 
+#### ✍️ Descriptions are USER-FACING COPY — agents quote them to end users
+
+Asset, column and collection `description` fields are not internal documentation. The geo-agent
+reads them and **quotes them, nearly verbatim, into answers for end users** — for ca-30x30 that is
+state-agency staff and conservation partners, often non-spatial. Write them as product copy, not as
+notes to the next engineer (data-workflows#512, where issue prose reached a user as
+"joining at res-8 avoids the ~11 pp overstatement that a coarse `GROUP BY` would introduce").
+
+**Say:** what the asset is, what it is for, what resolution it is at, and the one thing a consumer
+must know to use it correctly. Spell things out — "resolution 8", not "res-8".
+
+**Do NOT put in a description:**
+- issue or PR numbers, repo names (`data-workflows#506`) — those belong in the issue and the commit;
+- defect magnitudes or what a previous consumer got wrong ("overstates conserved share by ~11pp");
+- unexplained abbreviations (`pp`), bare column/asset keys as the subject of a sentence;
+- shouted imperatives (`ALREADY A MEAN`, `do NOT re-aggregate`, `NEVER SUM`) — they read as
+  scolding when quoted, and prose imperatives are exactly what leaks into an answer.
+
+**Express a real constraint as a short SQL example instead** — it is clearer than an imperative and
+does not leak as prose:
+
+```sql
+-- correct: combine cells weighted by area
+SELECT SUM((w1 + w2) * nland) / SUM(nland) FROM …
+-- wrong: taking the largest or any single cell's value overstates the share
+```
+
+The mechanical rules elsewhere in this file still apply on top of this: per-column text stays
+**identical across assets** (the mcp-data-server#303 fold), the hex per-feature-duplication note
+still has to be present and still has to match what `verify-stac.py` looks for (phrases like
+"repeated on every … cell"), and the H3 area recipe still must not be inlined (#389). Plain register,
+same guarantees.
+
+**Publishing is not instantly visible.** `mcp-data-server` caches STAC collections, so after
+`rclone copyto` the agent (and the app) keep reading the previous text for a while — verified during
+#512, where `verify-stac.py` (which fetches S3 directly) saw the new copy while
+`get_stac_details` still returned the old. Verify prose changes against the S3 URL, not the MCP,
+and expect app-visible wording to lag.
+
 **stac-collection.json MUST include:**
 
 - **License — REQUIRED on every collection.** Set the top-level STAC `license` field to the **SPDX identifier** of the upstream data license (e.g. `CC-BY-4.0`, `CC-BY-NC-4.0`, `CC-BY-SA-4.0`, `CDLA-Permissive-2.0`, `public-domain`). Use `"other"` **only** when no SPDX id applies, and `"various"` **only** for a meta-collection whose children genuinely differ — never as a lazy default. For `other`/`various` (and recommended for all), add a license link: `{"rel": "license", "href": "<canonical terms URL>", "type": "text/html"}`. **Exception — a meta-collection (one with `child` links) may use `various`/`other` WITHOUT a license link:** its real licenses live on the child collections (each carrying + verified for its own license), and redistribution gating (source.coop excludes, etc.) keys on those per-child licenses, not the parent. A single parent-level link would misrepresent genuinely mixed children. `verify-stac.py` enforces the link only on **leaf** collections (and always for `proprietary`). **Verify the real upstream terms — do not guess `proprietary`.** The license drives redistribution decisions (e.g. whether a dataset may be mirrored to source.coop); a wrong value is a compliance risk. NonCommercial / ShareAlike licenses are fine but MUST be recorded as such (`CC-BY-NC-*`, `CC-BY-SA-*`) so downstream users aren't misled. US federal works = `public-domain`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,11 +510,24 @@ still has to be present and still has to match what `verify-stac.py` looks for (
 "repeated on every … cell"), and the H3 area recipe still must not be inlined (#389). Plain register,
 same guarantees.
 
-**Publishing is not instantly visible.** `mcp-data-server` caches STAC collections, so after
-`rclone copyto` the agent (and the app) keep reading the previous text for a while — verified during
-#512, where `verify-stac.py` (which fetches S3 directly) saw the new copy while
-`get_stac_details` still returned the old. Verify prose changes against the S3 URL, not the MCP,
-and expect app-visible wording to lag.
+**Publishing lags by ~15 minutes.** `mcp-data-server` refreshes its STAC cache on a **~15-minute**
+cycle, so right after `rclone copyto` the agent (and the app) still read the previous text — verified
+during #512, where `verify-stac.py` (which fetches S3 directly) saw the new copy while
+`get_stac_details` returned the old, then agreed after the refresh. So: verify prose against the S3
+URL for correctness, and wait out the cycle before judging what an agent or the app will quote. **No
+cache-invalidation or restart is needed** — do not go reaching into the MCP's namespace for one.
+
+**One text per column NAME per collection.** The `#303` fold is per column *name* across every asset
+in the collection, and **first-seen wins**, so a column documented differently on two assets loses
+one version silently. Two traps, both hit in #512:
+- Adding a new hex-like asset with its own wording for `h10`/`h9`/`h8`/`h0` meant the older asset's
+  text won — and that text said "one row per (feature, h10) pair", which was true there and **false**
+  for the new per-cell assets. Keep shared H3 columns grain-neutral and identical; state grain in the
+  asset `description`, which is always rendered.
+- Appending a hex-only clause to a column that also exists on the flat GeoParquet (e.g. "…repeated on
+  every hex cell — dedup first") makes the two differ, so the clause is dropped. Put that note in the
+  hex asset's `description` instead. After editing, check no column name carries two different texts
+  within the collection.
 
 **stac-collection.json MUST include:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,7 +527,8 @@ one version silently. Two traps, both hit in #512:
 - Appending a hex-only clause to a column that also exists on the flat GeoParquet (e.g. "…repeated on
   every hex cell — dedup first") makes the two differ, so the clause is dropped. Put that note in the
   hex asset's `description` instead. After editing, check no column name carries two different texts
-  within the collection.
+  within the collection — `verify-stac.py` reports this as `column-description-divergent`
+  (ADVISORY today; it becomes HARD once the pre-gate catalog is fold-clean, #509).
 
 **stac-collection.json MUST include:**
 

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -435,6 +435,51 @@ def check_table_columns_placement(doc: dict) -> list[Finding]:
     return out
 
 
+def check_column_description_consistency(doc: dict) -> list[Finding]:
+    """One text per column NAME per collection — the mcp-data-server#303 fold.
+
+    `get_stac_details` folds per-column descriptions across every asset in the collection
+    and **first-seen wins**, so a column documented two ways loses one version silently.
+    That is not merely redundant text: whichever asset happens to be listed first decides
+    what every consumer reads about that column on *all* assets.
+
+    Two ways this bites, both observed on ca30x30-conserved-areas-terrestrial-2025
+    (data-workflows#512):
+
+      * A hex-only clause appended to a column that also exists on the flat GeoParquet
+        ("…repeated on every hex cell — dedup by _cng_fid first") is dropped, because the
+        flat is listed first. Eight duplication warnings were invisible this way. Such a
+        note belongs in the hex asset's own `description`, which is always rendered.
+      * A newly added asset that words a shared column differently loses to the older
+        asset — and the older text may be *false* for the new asset. Here the surviving
+        h10 text said "one row per (feature, h10) pair", true for the hex asset and wrong
+        for the per-cell hex-weights assets.
+
+    ADVISORY rather than HARD for now: pre-gate collections have not been swept yet
+    (data-workflows#509), so a hard failure would block unrelated PRs. Promote to HARD
+    once the catalog is fold-clean. Columns with no description (a lean PMTiles asset,
+    per the PMTiles standard) are skipped — omitting text is not disagreeing about it.
+    """
+    out = []
+    seen: dict[str, tuple[str, str]] = {}
+    clashes: dict[str, set[str]] = {}
+    for key, asset in doc.get("assets", {}).items():
+        for col in asset.get("table:columns", []):
+            name, text = col.get("name", ""), col.get("description", "")
+            if not name or not text:
+                continue
+            if name in seen and seen[name][1] != text:
+                clashes.setdefault(name, {seen[name][0]}).add(key)
+            seen.setdefault(name, (key, text))
+    for name, assets in sorted(clashes.items()):
+        winner = seen[name][0]
+        out.append(Finding(ADVISORY, "column-description-divergent",
+            f"column '{name}' is documented differently on {sorted(assets)} — the #303 fold "
+            f"keeps the first-seen text (from '{winner}') and silently drops the others. Use "
+            f"one text everywhere; put asset-specific notes in that asset's `description`."))
+    return out
+
+
 def check_hex_dup_warning(doc: dict) -> list[Finding]:
     """Any aggregatable per-feature column on a hex asset must warn that it is repeated
     per (feature, cell) and give a dedup recipe."""
@@ -731,6 +776,7 @@ STATIC_CHECKS = [
     check_table_columns_placement,
     check_cng_fid,
     check_hex_dup_warning,
+    check_column_description_consistency,
     check_point_note,
     check_inline_area_formula,
 ]


### PR DESCRIPTION
Closes #512.

You were right, and the diagnosis was exact — that prose is my #506 issue text with the serial numbers filed off. Rewritten as product copy, and the rule added to AGENTS.md so it applies to every future dataset rather than depending on whoever writes the next one.

## Before / after

| | |
|---|---|
| **was** | `ALREADY A MEAN at res 9 / res 8 - do NOT re-aggregate with MIN / MAX / ANY / a presence test; to roll up further use SUM(w1 * nland) / SUM(nland).` |
| **now** | "Share of the cell's California land area in GAP status 1 — permanently protected, with natural processes left to run their course. A value of 0.4 means 40 percent of the cell. … On the resolution-9 and resolution-8 grids this share is already averaged over the finer resolution-10 cells inside each one — see the asset description for how to combine cells." |

The constraint that had to survive is now a SQL example on the asset, per your suggestion:

```sql
-- correct: share of a group of cells conserved under GAP 1+2
SELECT SUM((w1 + w2) * nland) / SUM(nland) FROM …
-- wrong: taking the largest or any single cell's value overstates the share
```

## Scope covered

- **`ca30x30-conserved-areas-terrestrial-2025`** — collection paragraph, all three `hex-weights*` asset descriptions, `w1`–`w4`, `nland`, `n_units`, and the `h*` columns.
- **`ca30x30-ecoregion`** — it had picked up the same register in #507 ("THE CANONICAL RES-10 CALIFORNIA LAND GRID", "Do NOT use cwhr13 … 1.36M acres … lie in Nevada", two issue references). Rewritten, and while on that asset I also fixed three **pre-existing** column descriptions carrying the same shouted pattern (`Shape_Area`, `Shape_Leng`, `ratio`: "never SUM(Shape_Area) on hex data" → plain text plus the `SELECT DISTINCT` example).
- `n_units` kept the wording you called out as the good pattern, minus a now-stale clause about deduplicating source rows (that duplication was fixed in #509).

Checked with a scripted register lint over every field in scope — issue numbers, `pp`, `GROUP BY`/`NEVER`/`do NOT`, `res-N`, `canonical`/`stand-in`, `_cng_fid` — **0 violations**, excluding fenced SQL where technical detail is allowed. Both collections still pass `verify-stac.py` full data-backed with zero findings.

## Two things to know

**1. The app will lag.** `mcp-data-server` caches STAC collections. Immediately after publishing, `verify-stac.py` (which fetches S3 directly) saw the new copy while `get_stac_details` still returned the old prose verbatim — including the `~11pp` sentence. So **your third "done when" — the app's method note no longer containing an asset key, a column name, or `pp` — cannot be confirmed until that cache turns over**, independent of #109. The MCP and app run in `biodiversity`, outside the namespace this repo's agent is confined to, so invalidating it is an ops action, not one I should take. Flagging rather than reaching.

**2. Out of scope, deliberately left alone.** The pre-existing `GAP-STATUS AGGREGATION NOTE` paragraph in the conserved-areas collection description has the same register (`_cng_fid`, `must NOT be multiplied`, caps) and is *long*. It also carries carefully verified acreage semantics (the `Acres` vs `Total_Acre` trap) that I did not want to reword in a copy-editing pass. Worth a follow-up if you want the whole collection description brought into register.

## Prevention

AGENTS.md gains a `✍️ Descriptions are USER-FACING COPY` subsection: what to say, the explicit do-not list, the SQL-example pattern, a note that the existing mechanical rules (identical per-column text across assets for the #303 fold, the duplication note `verify-stac.py` greps for, no inlined H3 area formula) still hold on top of plain register, and the caching behaviour above.