### PR TITLE
docs(#518): streams-by-order stream-order gap is geographic, not topological

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -745,6 +745,23 @@ was 8.5 points wrong — the same mechanism as the pinyon-juniper defect (#505).
   - **NULL finest-parent cells.** If the hex build caps very large features at a coarser native resolution (WDPA: `h9` is NULL for the 1,297 biggest features, `h8` is complete), the hex asset description MUST name the complete column and say joins should use the coarsest shared resolution (or `h3_cell_to_parent()`), not the finest. `verify-stac.py` **HARD**-flags an undocumented NULL finest hex column.
   - **No-data sentinels.** Document sentinel/fill codes (e.g. land-cover `0`/`200`) so consumers `WHERE col NOT IN (...)` before `SUM`/`AVG` — an undocumented sentinel poisons aggregates to `NaN`.
 
+  ⛔ **MEASURE every added column's range and sentinels — never document one from upstream docs or
+  memory.** When a build introduces columns new to this catalog, run one query per new column
+  (`MIN`/`MAX`, `COUNT(*) FILTER (WHERE col < 0)`, distinct count) *before* writing STAC. This is
+  the #518 lesson generalised, and it recurred three times in one session while fixing #518
+  (data-workflows #205/#525):
+  - `-9999` on four NHDPlus VAA columns (and `-9` on a fifth) — **the same 2,745 rows** — was
+    documented nowhere in the first draft; an unfiltered `AVG(slope)`/`MIN(totdasqkm)` is poisoned.
+  - Worse than omission: a sentinel note copied from upstream documentation said "check for
+    negative values", which would have told consumers to discard **real** below-sea-level
+    elevations (10,349 rows, min −85.61 m in Death Valley). **A negative value is not automatically
+    a sentinel** — filter the exact sentinel (`<> -9998`), never a sign test, unless you have
+    measured that no legitimate negatives exist.
+  - A `values` array copied from a sibling collection missed 13 codes actually present. Coded
+    domains come from the authoritative source table (#294), and `values` from the ingest.
+  Record the measured ranges in the dataset's `BUILD.md` so the next reader inherits evidence
+  rather than assumption — see `catalog/usgs-nhd/k8s/nhdplus-hr/BUILD.md` for the pattern.
+
 - **Point datasets:** `description` or `"processing:notes"` MUST state each point resolved to one H3 cell at the processing resolution, and name the resolution. Example: *"Point observations were hexed to H3 resolution 10 (each point → one ~15 000 m² cell). Multiple points within the same cell are not deduplicated."*
 
 ### Step 6: Register in the parent sub-catalog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,31 @@ ogrinfo /vsicurl/<source-url>                                # multi-layer file
 
 Common patterns: Census TIGER = per-state (`tl_2024_{STATEFP}_tract.zip`); protected areas = per-region or national; rasters may be tiled.
 
+#### 💡 Read one small table out of a HUGE remote zip — range reads, no localize (#518)
+
+To inspect a schema, a lookup/domain table, or one layer's coverage inside a multi-GB zipped
+GDB, do **not** localize the archive (a PVC + 30 GB download for a 126-row table). GDAL's
+`/vsizip//vsicurl/` reads the zip central directory plus only the bytes it needs over HTTP
+range requests — a small cluster job, seconds to a couple of minutes:
+
+```bash
+# authoritative coded domain out of the archived 30 GB national GDB (internal endpoint)
+SRC="/vsizip//vsicurl/http://rook-ceph-rgw-nautiluss3.rook/public-usgs-nhd/raw/NHD_H_National_GDB.zip/NHD_H_National_GDB.gdb"
+ogr2ogr -f CSV /vsistdout/ "$SRC" NHDFCode          # 126 rows, ~25 s, no PVC
+ogrinfo -ro -q "$SRC" -dialect SQLITE \
+  -sql "SELECT COUNT(*), SUM(StreamOrde > 0) FROM NHDPlusFlowlineVAA"
+```
+
+- Works on a **public** source URL too (`/vsizip//vsicurl/https://prd-tnm.s3.amazonaws.com/...`) —
+  ideal for pre-flighting a candidate import before committing to a build.
+- Use `-dialect SQLITE`: **OGR SQL has no `CASE`**, and keep the SQL on **one line** (a folded
+  YAML block mangles multi-line SQL). `SUM(cond)` works in the SQLITE dialect.
+- Full-table `COUNT(*)` over range reads is slow (minutes) because it decodes every feature;
+  schema reads and small tables are fast. Aggregate on the small table, not the geometry layer.
+- Working manifests: `catalog/usgs-nhd/k8s/extract-fcode-domain.yaml`,
+  `catalog/usgs-nhd/k8s/preflight-nhdplus-hr-vaa.yaml`.
+- ⛔ Never hand-write a coded domain from memory (#294) — this is how you get the real one.
+
 ### Step 1b: Copy raw to `s3://<bucket>/raw/` FIRST
 
 External downloads are slow/rate-limited; restart from S3 if conversion fails. Subsequent jobs read `s3://<bucket>/raw/<file>` (or `/vsicurl/https://s3-west.nrp-nautilus.io/<bucket>/raw/<file>` for GDAL).

--- a/catalog/usgs-nhd/k8s/BUILD.md
+++ b/catalog/usgs-nhd/k8s/BUILD.md
@@ -7,13 +7,71 @@ New bucket `public-usgs-nhd`. Two datasets from the **same** source file
   (`STREAMORDER`) + `STREAMLEVEL` joined from the bundled non-spatial table `NHDFlowlineVAA`
   on `PERMANENT_IDENTIFIER`. **Stream order is NOT a native NHDFlowline attribute** — it lives in
   the VAA table, so a join step is required (this is why the build is custom, not a plain
-  `cng-datasets workflow`). NHD only populates order for the connected network (~4.6M of 30.2M
-  flowlines); the rest are NULL.
+  `cng-datasets workflow`). ⚠️ **`STREAMORDER` is sparse in the source VAA table and its coverage
+  is GEOGRAPHIC, not topological — see "Stream-order coverage" below (#518).**
 - **`perennial-streams`** — the 6,799,617 flowlines with `FCODE = 46006`
   (Stream/River: Hydrographic Category = Perennial), confirmed against the `NHDFCode` domain.
 
 Geometry reprojected NAD83 (EPSG:4269) → **OGC:CRS84**; hexed to **H3 resolution 8**
 (lines buffered by the H3 cell circumradius before polyfill).
+
+## ⚠️ Stream-order coverage — sparse in the SOURCE, and geographic (#518)
+
+**The import is faithful — do not re-run it to "fix" the NULLs.** `convert.yaml` extracts
+`NHDFlowlineVAA` with no filter and `derive.yaml` LEFT JOINs it on `PERMANENT_IDENTIFIER`; both
+are exact. The archived intermediate proves the hole is upstream, in USGS's own VAA table:
+
+| `s3://public-usgs-nhd/raw/vaa.parquet` | |
+|---|---|
+| rows | 30,772,890 — all `PERMANENT_IDENTIFIER` distinct, a superset of the 30,221,659 flowlines |
+| `STREAMORDER` non-null | 5,153,385 (16.7%) |
+| `STREAMORDER > 0` — **actually usable** | 3,500,768 (**11.4%**) |
+| `STREAMLEVEL` non-null | 12,247,542 (39.8%) |
+
+Published: 4,589,297 non-null / 3,355,035 usable of 30,221,659 flowlines (11.1%); the difference
+from the VAA counts is the 564,088 VAA ids with no matching `NHDFlowline` row. No rows lost, no
+fan-out — the join is exact.
+
+**The earlier note in this file and in STAC ("NHD computes order only for networked reaches") was
+FALSE.** `INNETWORK = 1` is **29,184,336** of 30,221,659 flowlines (96.6%) — the network is
+essentially the whole dataset, and ~25.8 M networked flowlines have no usable order. The real
+pattern is per-subbasin refresh history:
+
+- **15 of the 22 HUC2 regions are at exactly 0.0% usable coverage.** Best is HUC2 17 at 66.1%;
+  then 02 (28.2), 11 (18.2), 18 (12.4), 01 (11.1), 16 (4.0), 04 (3.3). **No region is complete.**
+- Coverage varies *inside* a single HUC4 — California's 1801 Klamath is 73.4%, the adjacent
+  1802 Sacramento 0.7%.
+- `STREAMORDER` and `STREAMLEVEL` coverage are **uncorrelated** by region (HUC2 17 = 66.1% order /
+  6.4% level; HUC2 14 = 0.0% / 83.6%) — USGS populated one attribute *or* the other per subbasin.
+  A truncated extract or bad join key would null both columns on the same rows.
+- The two are not interchangeable: on rows carrying both with order > 0 they are equal on only
+  4.3%, correlation **−0.116** (means 3.51 vs 5.64; maxima 191 vs 25).
+
+⛔ **Consequence for consumers: `STREAMORDER` cannot select a stream class over any area larger
+than a verified subbasin.** The predicate looks like an attribute filter and acts as a geographic
+one — in California it selects 94,505 km of 1,083,964 km of in-network flowline (8.7%), and
+**92,393 km of that (97.8%) is HUC4 1801 alone**. That is how `ca-30x30` reported Klamath-basin
+stream numbers as statewide (ca-30x30#111). Where order *is* computed it is not selective by
+feature type (in 1801 it covers 87.3% of perennial, 86.1% of intermittent, 65.6% of ephemeral
+length), so the populated subset is *not* "the real streams".
+
+**`STREAMORDER = 0` is a source sentinel, not an order** — 1,652,617 VAA rows / 1,234,262
+published rows. Valid Strahler range is **1–10** (a few thousand records carry out-of-range
+values up to 191). **Always filter `STREAMORDER > 0`; `IS NOT NULL` admits the sentinel** and
+certifies regions that have nothing usable — HUC2 12 looks 96.7% covered by `IS NOT NULL` and is
+0.0% usable; HUC2 13 goes 17.5% → 0.0%. It is documented rather than normalised to NULL in the
+published files because normalising would mean re-running a correct 30 M-feature build; **fold
+the normalisation into the #205 rebuild** (below) and keep `> 0` as the documented filter until
+then.
+
+**The real fix is #205, not a re-run** — the values are not in this source. Network VAAs are
+computed nationally in **NHDPlus High Resolution** (`NHDPlusFlowlineVAA`), tracked as
+data-workflows#205. When it lands, **audit coverage by HUC2 with `> 0`, never `IS NOT NULL`.**
+
+Convention this build missed: when a dataset is *named* for a joined attribute, record that
+attribute's **non-null and in-valid-range counts plus its distribution across a partition key** —
+not just the join's row count. Run one `COUNT(col) FILTER (WHERE col > 0)` + per-HUC2 breakdown
+before writing STAC.
 
 ## Actual build sequence (run manually, in order)
 

--- a/catalog/usgs-nhd/k8s/extract-fcode-domain.yaml
+++ b/catalog/usgs-nhd/k8s/extract-fcode-domain.yaml
@@ -1,0 +1,59 @@
+# Extract the authoritative NHDFCode domain table from the archived national GDB.
+# One-shot metadata job (data-workflows#518): the published STAC declared an incomplete
+# FCODE `values` array ("428xx=Pipeline variants" shorthand), which verify-stac.py HARD-fails
+# against the 37 codes actually ingested. Never hand-write a coded domain (#294) — read it
+# from the source GDB's own NHDFCode table and print it as CSV for the STAC edit.
+#
+# Reads the small NHDFCode table out of the 30 GB zip with HTTP range requests over the
+# INTERNAL endpoint (no localize, no PVC). Falls back to a small state GDB of the same
+# product if the range read is refused.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nhd-extract-fcode-domain
+  labels:
+    k8s-app: nhd-extract-fcode-domain
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nhd-extract-fcode-domain
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: extract
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: CPL_VSIL_CURL_ALLOWED_EXTENSIONS
+          value: .zip,.gdb
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        - name: GDAL_HTTP_RETRY_DELAY
+          value: '3'
+        command: [bash, -c]
+        args:
+        - |
+          set -o pipefail
+          NAT="/vsizip//vsicurl/http://rook-ceph-rgw-nautiluss3.rook/public-usgs-nhd/raw/NHD_H_National_GDB.zip/NHD_H_National_GDB.gdb"
+          echo "=== attempt 1: national GDB via range reads ==="
+          if ogrinfo -ro -q "$NAT" NHDFCode >/dev/null 2>&1; then
+            SRC="$NAT"
+          else
+            echo "range read failed; falling back to a state GDB of the same product"
+            curl -L --retry 5 -o /tmp/state.zip \
+              "https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHD/State/GDB/NHD_H_Delaware_State_GDB.zip"
+            unzip -q -o /tmp/state.zip -d /tmp/state
+            SRC="$(find /tmp/state -maxdepth 2 -name '*.gdb' | head -1)"
+          fi
+          echo "=== source: $SRC ==="
+          ogrinfo -ro -q "$SRC" NHDFCode -al | head -20
+          echo "=== NHDFCode as CSV ==="
+          ogr2ogr -f CSV /vsistdout/ "$SRC" NHDFCode
+        resources:
+          requests: {memory: 4Gi, cpu: '1', ephemeral-storage: 8Gi}
+          limits:  {memory: 8Gi, cpu: '2', ephemeral-storage: 10Gi}

--- a/catalog/usgs-nhd/k8s/preflight-nhdplus-hr-vaa.yaml
+++ b/catalog/usgs-nhd/k8s/preflight-nhdplus-hr-vaa.yaml
@@ -1,0 +1,57 @@
+# Pre-flight for the NHDPlus HR import (#205), run while scoping #518.
+# Question: does NHDPlusFlowlineVAA actually ship a usable stream order in the subbasins where
+# the plain NHD NHDFlowlineVAA does not? (#518 measured NHD: HUC4 1801 = 73.4% usable,
+# 1802 = 0.7%, and all of HUC2 12 = 0.0%.) If NHDPlus HR is complete there, #205 is the fix;
+# if it is equally sparse, #205 must be declined as a remedy.
+#
+# Reads three HU4 units straight out of their published zips with HTTP range requests
+# (no localize, no PVC) and prints the VAA schema + order coverage per unit.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nhdplus-hr-vaa-preflight
+  labels:
+    k8s-app: nhdplus-hr-vaa-preflight
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: nhdplus-hr-vaa-preflight
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: preflight
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        - name: GDAL_HTTP_RETRY_DELAY
+          value: '3'
+        command: [bash, -c]
+        args:
+        - |
+          set -o pipefail
+          BASE="https://prd-tnm.s3.amazonaws.com/StagedProducts/Hydrography/NHDPlusHR/VPU/Current/GDB"
+          # 1801 Klamath (NHD 73.4% usable), 1802 Sacramento (0.7%), 1206 (HUC2 12 = 0.0%)
+          for U in 1801 1802 1206; do
+            Z="$BASE/NHDPLUS_H_${U}_HU4_GDB.zip"
+            SRC="/vsizip//vsicurl/${Z}/NHDPLUS_H_${U}_HU4_GDB.gdb"
+            echo "############ HU4 $U ############"
+            echo "--- layers ---"
+            ogrinfo -ro -q "$SRC" 2>&1 | grep -i -E "vaa|flowline" || true
+            echo "--- NHDPlusFlowlineVAA schema (order/level fields) ---"
+            ogrinfo -ro -so "$SRC" NHDPlusFlowlineVAA 2>&1 \
+              | grep -i -E "streamorde|streamleve|streamcalc|nhdplusid|hydroseq" || true
+            echo "--- coverage (SQLITE dialect: OGR SQL has no CASE) ---"
+            ogrinfo -ro -q "$SRC" -dialect SQLITE -sql "SELECT COUNT(*) AS vaa_rows, SUM(StreamOrde IS NOT NULL) AS order_notnull, SUM(StreamOrde > 0) AS order_usable, MIN(StreamOrde) AS order_min, MAX(StreamOrde) AS order_max, SUM(StreamLeve > 0) AS level_usable, COUNT(DISTINCT NHDPlusID) AS distinct_ids FROM NHDPlusFlowlineVAA" 2>&1 | head -20
+            echo "--- flowline count (join denominator) ---"
+            ogrinfo -ro -q "$SRC" -dialect SQLITE -sql "SELECT COUNT(*) AS flowlines, SUM(NHDPlusID IS NOT NULL) AS with_nhdplusid FROM NHDFlowline" 2>&1 | head -8
+          done
+        resources:
+          requests: {memory: 6Gi, cpu: '1', ephemeral-storage: 10Gi}
+          limits:  {memory: 7Gi, cpu: '1', ephemeral-storage: 12Gi}


### PR DESCRIPTION
Closes #518. **Scope: documentation only** — the #205 NHDPlus HR build that this issue's third deliverable called for has been split into #530 so this PR stays a small, reviewable doc fix.

**The import is correct and was not re-run.** `convert.yaml` extracts `NHDFlowlineVAA` unfiltered, `derive.yaml` LEFT JOINs on `PERMANENT_IDENTIFIER`, and the archived intermediate shows the sparsity is USGS's own: 3,500,768 of 30,772,890 VAA rows (11.4%) carry `STREAMORDER > 0`. What shipped wrong was the metadata.

## 1. The false cause — the piece causing wrong answers downstream

Both the STAC and `BUILD.md` said order is NULL because "NHD computes order only for networked reaches". `INNETWORK = 1` is **29,184,336 of 30,221,659 flowlines (96.6%)** — the network is essentially the whole dataset, and ~25.8 M networked flowlines have no usable order. Agents quote the note verbatim, which is how ca-30x30 presented Klamath-basin stream numbers as statewide (ca-30x30#111).

Replaced with the measured truth in `BUILD.md` and in the published STAC (collection description, `STREAMORDER`/`STREAMLEVEL` columns on all three assets, hex + PMTiles asset notes):

- coverage is per-subbasin — **15 of 22 HUC2 regions at exactly 0.0% usable**, best region 66.1%, none complete, and it varies inside one HUC4 (1801 = 73.4%, 1802 = 0.7%);
- **the column cannot select a stream class over any area larger than a verified subbasin**;
- where order *is* computed it is not selective by feature type, so the populated subset is not "the real streams".

The bucket `README.md` repeated the same false claim and was rewritten too (it is the STAC `describedby` target), and the parent collection carries a one-clause caveat.

## 2. The `STREAMORDER = 0` sentinel

Documented prominently (STAC ×3 assets, README, `BUILD.md`) with the valid range stated as **1–10** and the out-of-range tail to 191 flagged: **filter `> 0`, never `IS NOT NULL`** — by `IS NOT NULL`, HUC2 12 looks 96.7% covered and is 0.0% usable, HUC2 13 goes 17.5% → 0.0%.

Documented rather than normalised, because normalising means rebuilding a correct 30 M-feature dataset for a cosmetic write. **The normalisation is applied at build time in #530 instead**, where it comes free with the build that supplies usable order.

## 3. #205 scoped, not declined

Scope pinned in the #205 body with a measured pre-flight rather than an assumption — `catalog/usgs-nhd/k8s/preflight-nhdplus-hr-vaa.yaml` range-reads the published per-HU4 zips:

| HU4 | NHD-H usable order | NHDPlus HR `StreamOrde > 0` | range |
|---|---|---|---|
| 1802 Sacramento | 0.7% | **100.00%** (459,285/459,285) | 1–10 |
| 1206 (HUC2 12) | 0.0% | **100.00%** (132,565/132,565) | 1–9 |
| 1801 Klamath | 73.4% | **99.88%** (332,874/333,283) | −9 … 9 |

That tranche is now built and published — see #530.

## Incidental: a pre-existing HARD gate failure in the same collection

`verify-stac.py --bucket public-usgs-nhd --dataset streams-by-order` was already RED before this PR — `FCODE` declared 12 values (the `428xx=Pipeline variants` shorthand) against **37 actually ingested**, plus two codes that never appear. Fixed from the authoritative source rather than by hand (#294): `catalog/usgs-nhd/k8s/extract-fcode-domain.yaml` reads the `NHDFCode` domain table out of the archived national GDB with HTTP range requests (no localize, no PVC, ~25 s). The gate now exits **0**.

`AGENTS.md` gains that range-read technique plus the two gotchas it cost (OGR SQL has no `CASE` — use `-dialect SQLITE`; folded YAML mangles multi-line SQL).

## Published / verified

- `nrp:public-usgs-nhd/streams-by-order/stac-collection.json`, `nrp:public-usgs-nhd/stac-collection.json`, `nrp:public-usgs-nhd/README.md`
- `verify-stac.py` exits **0** on `streams-by-order`, and `perennial-streams` has 0 hard findings.

No data was rebuilt by this PR.