### PR TITLE
fix(#522): hex-weights res-10 sparsity, nland -> ca30x30-ecoregion, area-weighted aggregation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,10 +499,17 @@ must know to use it correctly. Spell things out — "resolution 8", not "res-8".
 does not leak as prose:
 
 ```sql
--- correct: combine cells weighted by area
-SELECT SUM((w1 + w2) * nland) / SUM(nland) FROM …
+-- correct: combine cells weighted by land area
+SELECT SUM((w1 + w2) * land_area_km2) / SUM(land_area_km2) FROM …
+-- wrong: weighting by a cell COUNT assumes equal-area cells — H3 cells are not equal-area
 -- wrong: taking the largest or any single cell's value overstates the share
 ```
+
+> The count-weighted version of that example (`… * nland) / SUM(nland`) was what this file
+> recommended until #522, and it is latitude-biased: over California (32.5N-42N) it returned a
+> 25.684% conserved share against an area-weighted 26.135%. If a rollup asset exposes only a
+> child-cell *count*, ship the child-cell *area* alongside it — the correct query should be the
+> short one, not the one requiring an `h3_cell_area()` call the consumer has to remember.
 
 The mechanical rules elsewhere in this file still apply on top of this: per-column text stays
 **identical across assets** (the mcp-data-server#303 fold), the hex per-feature-duplication note

--- a/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-weights-parents.yaml
+++ b/catalog/ca30x30/k8s/conserved-areas-terrestrial-2025/conserved-areas-terrestrial-2025-hex-weights-parents.yaml
@@ -19,6 +19,26 @@
 #
 # Row counts: every land parent gets a row, including parents with zero conserved area
 # (wN = 0) — that is what makes the asset usable as a denominator, not just a mask.
+#
+# ---------------------------------------------------------------------------------
+# #522 Part 2 UPDATE — `nland` is COMPUTED here but NO LONGER WRITTEN.
+#
+# `nland` is a property of the land grid, not of the conserved-areas layer: it is
+# exactly the res-10 `ecoregion/hex` grid redistributed into this collection, which put
+# California's land definition in two places. It now ships on ca30x30-ecoregion as
+# `ecoregion/hex-res9` and `hex-res8` (nland + land_area_km2), built by
+# catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-hex-parents.yaml — RUN THAT FIRST.
+# These assets carry only w1..w4 at all three resolutions, and every resolution composes
+# the same way: ecoregion land grid LEFT JOIN weights, COALESCE a missing weight to 0.
+#
+# `nland` is still computed in-job because it is the denominator of the parent mean and
+# the weight in #508's acceptance check — dropping it from the OUTPUT does not change a
+# single w value, and the asserts below re-prove that.
+#
+# #522 Part 3: the aggregation we document is now weighted by land AREA, not by the cell
+# COUNT `nland`. H3 cells are not equal-area and California spans 32.5N-42N, so the
+# count-weighted statewide GAP 1+2 share came out 25.684 against an area-weighted 26.135
+# (truth 26.08). Both are printed below; only the area-weighted one is documented.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -65,6 +85,7 @@ spec:
 
           W10  = 's3://public-ca30x30/conserved-areas-terrestrial-2025/hex-weights/h0=*/data_0.parquet'
           ECO  = 's3://public-ca30x30/ecoregion/hex/h0=*/data_0.parquet'
+          ECO8 = 's3://public-ca30x30/ecoregion/hex-res8/h0=*/data_0.parquet'
           BASE = 's3://public-ca30x30/conserved-areas-terrestrial-2025'
 
           con = duckdb.connect()
@@ -85,6 +106,16 @@ spec:
           assert {'h10', 'h9', 'h8', 'h0'} <= eco_cols, (
               'ecoregion hex lacks res-10 index columns {} — #507 has not landed; '
               'refusing to roll up on an unclipped stand-in grid'.format(sorted(eco_cols)))
+
+          # Guard: #522 Part 2 moves `nland` to ca30x30-ecoregion, so the res-8 land rollup
+          # must already exist. Stripping the column here before that asset is published
+          # would leave consumers with no weight at all at res 9 / res 8.
+          eco8_cols = {r[0] for r in con.execute(
+              "DESCRIBE SELECT * FROM read_parquet('{}')".format(ECO8)).fetchall()}
+          assert {'h8', 'h0', 'nland', 'land_area_km2'} <= eco8_cols, (
+              'ecoregion/hex-res8 is missing {} — run ecoregion-hex-parents.yaml first; '
+              'refusing to drop nland with no replacement published'.format(
+                  sorted({'h8', 'h0', 'nland', 'land_area_km2'} - eco8_cols)))
 
           con.execute("""
               CREATE OR REPLACE TABLE land10 AS
@@ -117,8 +148,9 @@ spec:
                          SUM(w3)/COUNT(*) AS w3, SUM(w4)/COUNT(*) AS w4
                   FROM child GROUP BY {keys}
               """.format(res=res, keys=keys))
-              cols = ('h9, h8, w1, w2, w3, w4, nland, h0' if res == 9
-                      else 'h8, w1, w2, w3, w4, nland, h0')
+              # #522 Part 2: nland stays out of the OUTPUT — it lives on ca30x30-ecoregion.
+              cols = ('h9, h8, w1, w2, w3, w4, h0' if res == 9
+                      else 'h8, w1, w2, w3, w4, h0')
               order = 'h9' if res == 9 else 'h8'
               staging = '{}/hex-weights-res{}-staging'.format(BASE, res)
               parts = [r[0] for r in con.execute(
@@ -130,11 +162,21 @@ spec:
                       "TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)".format(
                           cols=cols, res=res, h0=h0, order=order, out=out))
                   print('wrote {}'.format(out))
-              (rows, cells, mx_nland, mn_nland, mx_tot, mn_w) = con.execute("""
-                  SELECT COUNT(*), COUNT(DISTINCT {order}), MAX(nland), MIN(nland),
+              # Written schema check: nland must NOT be in the staged files (#522 Part 2).
+              staged_cols = [r[0] for r in con.execute(
+                  "DESCRIBE SELECT * FROM read_parquet('{s}/h0=*/data_0.parquet')".format(
+                      s=staging)).fetchall()]
+              print('RES{} STAGED_COLUMNS={}'.format(res, staged_cols))
+              assert 'nland' not in staged_cols, \
+                  'res{} still writes nland — it belongs on ca30x30-ecoregion'.format(res)
+
+              (rows, cells, mx_tot, mn_w) = con.execute("""
+                  SELECT COUNT(*), COUNT(DISTINCT {order}),
                          MAX(w1+w2+w3+w4), MIN(LEAST(w1,w2,w3,w4))
                   FROM read_parquet('{s}/h0=*/data_0.parquet')
               """.format(order=order, s=staging)).fetchone()
+              mn_nland, mx_nland = con.execute(
+                  "SELECT MIN(nland), MAX(nland) FROM parent{}".format(res)).fetchone()
               print('RES{} ROWS={} CELLS={} NLAND=[{},{}] MAX_TOTAL_W={:.9f} MIN_W={:.9f}'.format(
                   res, rows, cells, mn_nland, mx_nland, mx_tot, mn_w))
               assert rows == cells, 'res{} not one row per cell'.format(res)
@@ -167,6 +209,23 @@ spec:
                 'non_conserved={} (report 49.81)'.format(gap12, gap34, nonc))
           assert abs(float(gap12) - 21.05) <= 1.0, 'res8 gap12 outside +/-1.0pp of 21.05'
           assert abs(float(gap34) - 29.54) <= 1.0, 'res8 gap34 outside +/-1.0pp of 29.54'
+
+          # --- #522 Part 3: the aggregation we now DOCUMENT is the ecoregion land rollup
+          # LEFT JOIN the weights, weighted by land AREA. It must return the statewide
+          # figure (26.135), not the count-weighted 25.684 the old wording produced.
+          count_wtd, area_wtd = con.execute("""
+              SELECT ROUND(100*SUM((p.w1+p.w2)*p.nland)/SUM(p.nland), 3),
+                     ROUND(100*SUM(COALESCE(w.w1+w.w2, 0)*e.land_area_km2)
+                             /SUM(e.land_area_km2), 3)
+              FROM read_parquet('{}') e
+              LEFT JOIN read_parquet('{}/hex-weights-res8-staging/h0=*/data_0.parquet') w
+                     USING (h0, h8)
+              JOIN parent8 p USING (h0, h8)
+          """.format(ECO8, BASE)).fetchone()
+          print('PART3 statewide GAP1+2: count-weighted={} (old wording) '
+                'area-weighted={} (documented, target 26.135)'.format(count_wtd, area_wtd))
+          assert abs(float(area_wtd) - 26.135) <= 0.01, \
+              'documented res-8 aggregation returns {}, expected 26.135'.format(area_wtd)
 
           open('/tmp/ok', 'w').write('ok')
           PYEOF

--- a/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-hex-parents.yaml
+++ b/catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-hex-parents.yaml
@@ -1,0 +1,197 @@
+# data-workflows#522 Part 2 — res-9 / res-8 land rollups of the California land grid.
+#
+# WHY THIS EXISTS. #506 published `conserved-areas-terrestrial-2025/hex-weights-res9`
+# and `-res8` carrying an `nland` column: the count of res-10 California land cells
+# inside each parent, used as the weight when averaging w1..w4 across cells. But `nland`
+# is a property of the LAND GRID, not of the conserved-areas layer — it is exactly the
+# res-10 `ecoregion/hex` grid (#507) redistributed into another collection. That put
+# California's land definition in two places: revisiting #507's open land/water-agnostic
+# vs. strictly-terrestrial question would silently stale every conserved-areas res-9/res-8
+# asset. #522 Part 2 moves it here, where the definition lives, and drops `nland` from the
+# weights assets (see conserved-areas-terrestrial-2025-hex-weights-parents.yaml).
+#
+#   land10        = DISTINCT (h0,h9,h8,h10) from ecoregion/hex   -- res-10 CA land grid
+#   nland         = COUNT(*) of res-10 land children in the parent
+#   land_area_km2 = SUM(h3_cell_area(h10,'km^2')) over those children
+#
+# `land_area_km2` is the second half of #522. The res-9/res-8 descriptions used to
+# recommend SUM((w1+w2)*nland)/SUM(nland), which weights by a CELL COUNT and so assumes
+# equal-area cells. H3 cells are not equal-area and California spans 32.5N-42N, so that
+# understated statewide GAP 1+2 by 0.45pp (25.684 vs 26.135, truth 26.08). Shipping the
+# land area alongside the count gives consumers the correct weight without an
+# h3_cell_area() call, and makes the right query the short one.
+#
+# Row counts: every land parent gets a row. The 25,596,931 res-10 land cells roll up to
+# res-9 and res-8 parents; the assertion below is that SUM(nland) is conserved at both
+# levels against the live grid, not a hardcoded expected count.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ecoregion-hex-parents
+  namespace: geo-workflows
+  labels:
+    k8s-app: ecoregion-hex-parents
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: ecoregion-hex-parents
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: ecoregion-hex-parents
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS, value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: PYTHONPATH, value: /usr/lib/python3/dist-packages}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "=== #522 Part 2: ca30x30-ecoregion res-9 / res-8 land rollups ==="
+          python3 - <<'PYEOF'
+          import duckdb, os
+
+          ECO  = 's3://public-ca30x30/ecoregion/hex/h0=*/data_0.parquet'
+          W8   = ('s3://public-ca30x30/conserved-areas-terrestrial-2025/'
+                  'hex-weights-res8/h0=*/data_0.parquet')
+          BASE = 's3://public-ca30x30/ecoregion'
+
+          con = duckdb.connect()
+          con.execute("INSTALL httpfs; LOAD httpfs")
+          con.execute("INSTALL h3 FROM community; LOAD h3")
+          con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
+          con.execute("SET preserve_insertion_order=false")
+          con.execute("SET temp_directory='/tmp/duckdb-spill'")
+          con.execute("SET memory_limit='100GiB'")
+          con.execute(
+              "CREATE SECRET s3_secret (TYPE S3, KEY_ID '{}', SECRET '{}', "
+              "ENDPOINT '{}', URL_STYLE 'path', USE_SSL false)".format(
+                  os.environ['AWS_ACCESS_KEY_ID'], os.environ['AWS_SECRET_ACCESS_KEY'],
+                  os.environ.get('AWS_S3_ENDPOINT', 'rook-ceph-rgw-nautiluss3.rook')))
+
+          # Guard: #507 must have landed — the ecoregion hex must actually carry h10.
+          eco_cols = {r[0] for r in con.execute(
+              "DESCRIBE SELECT * FROM read_parquet('{}')".format(ECO)).fetchall()}
+          assert {'h10', 'h9', 'h8', 'h0'} <= eco_cols, (
+              'ecoregion hex lacks res-10 index columns {} — #507 has not landed'.format(
+                  sorted(eco_cols)))
+
+          # One row per res-10 land cell. The ecoregion hex is a per-(feature, cell)
+          # conversion, so a cell straddling two ecoregions appears more than once —
+          # DISTINCT is what makes this a grid rather than a feature table.
+          con.execute("""
+              CREATE OR REPLACE TABLE land10 AS
+              SELECT DISTINCT h0, h9, h8, h10 FROM read_parquet('{}')
+          """.format(ECO))
+          n_land10 = con.execute("SELECT COUNT(*) FROM land10").fetchone()[0]
+          n_h10    = con.execute(
+              "SELECT COUNT(DISTINCT h10) FROM read_parquet('{}')".format(ECO)).fetchone()[0]
+          print('LAND10_CELLS={} DISTINCT_H10={}'.format(n_land10, n_h10))
+          assert n_land10 == n_h10, 'h10 is not unique within (h0,h9,h8) — grid is malformed'
+
+          for res, keys, order in ((9, 'h0, h9, h8', 'h9'), (8, 'h0, h8', 'h8')):
+              con.execute("""
+                  CREATE OR REPLACE TABLE parent{res} AS
+                  SELECT {keys},
+                         COUNT(*)::INTEGER              AS nland,
+                         SUM(h3_cell_area(h10, 'km^2')) AS land_area_km2
+                  FROM land10 GROUP BY {keys}
+              """.format(res=res, keys=keys))
+
+              cols = ('h9, h8, nland, land_area_km2, h0' if res == 9
+                      else 'h8, nland, land_area_km2, h0')
+              staging = '{}/hex-res{}-staging'.format(BASE, res)
+              parts = [r[0] for r in con.execute(
+                  "SELECT DISTINCT h0 FROM parent{} ORDER BY h0".format(res)).fetchall()]
+              for h0 in parts:
+                  out = '{}/h0={}/data_0.parquet'.format(staging, h0)
+                  con.execute(
+                      "COPY (SELECT {cols} FROM parent{res} WHERE h0 = {h0} ORDER BY {order}) "
+                      "TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)".format(
+                          cols=cols, res=res, h0=h0, order=order, out=out))
+                  print('wrote {}'.format(out))
+
+              rows, cells, tot_nland, mn, mx, mn_area = con.execute("""
+                  SELECT COUNT(*), COUNT(DISTINCT {order}), SUM(nland),
+                         MIN(nland), MAX(nland), MIN(land_area_km2)
+                  FROM read_parquet('{s}/h0=*/data_0.parquet')
+              """.format(order=order, s=staging)).fetchone()
+              cap = 7 if res == 9 else 49
+              print('RES{} ROWS={} CELLS={} SUM_NLAND={} NLAND=[{},{}] MIN_AREA={:.9f}'.format(
+                  res, rows, cells, tot_nland, mn, mx, mn_area))
+              assert rows == cells, 'res{} not one row per cell'.format(res)
+              assert tot_nland == n_land10, (
+                  'res{} rollup loses land cells: SUM(nland)={} != {}'.format(
+                      res, tot_nland, n_land10))
+              assert 1 <= mn and mx <= cap, 'res{} nland outside [1,{}]'.format(res, cap)
+              assert mn_area > 0, 'res{} has a zero-area parent'.format(res)
+
+          # --- equivalence: the new nland must match the nland #506 stored on the weights
+          # asset we are about to strip it from. Non-negotiable — this is the whole basis
+          # for calling the ecoregion rollup a faithful replacement rather than a variant.
+          n_w8, mismatch = con.execute("""
+              SELECT COUNT(*), SUM(CASE WHEN w.nland <> p.nland THEN 1 ELSE 0 END)
+              FROM read_parquet('{}') w JOIN parent8 p USING (h0, h8)
+          """.format(W8)).fetchone()
+          n_w8_rows = con.execute(
+              "SELECT COUNT(*) FROM read_parquet('{}')".format(W8)).fetchone()[0]
+          print('NLAND_EQUIV res8: joined={} of {} weights rows, mismatches={}'.format(
+              n_w8, n_w8_rows, mismatch))
+          assert n_w8 == n_w8_rows, 'res-8 weights cells are not all in the land rollup'
+          assert mismatch == 0, '{} cells disagree on nland'.format(mismatch)
+
+          # --- #522 Part 3: the area weight must reproduce the true statewide share.
+          documented, area_wtd = con.execute("""
+              SELECT ROUND(100*SUM((w.w1+w.w2)*p.nland)/SUM(p.nland), 3),
+                     ROUND(100*SUM((w.w1+w.w2)*p.land_area_km2)/SUM(p.land_area_km2), 3)
+              FROM read_parquet('{}') w JOIN parent8 p USING (h0, h8)
+          """.format(W8)).fetchone()
+          print('PART3 res8 GAP1+2: count-weighted={} (old, biased) '
+                'area-weighted={} (target 26.135)'.format(documented, area_wtd))
+          assert abs(float(area_wtd) - 26.135) <= 0.01, 'area-weighted share moved'
+
+          open('/tmp/ok', 'w').write('ok')
+          PYEOF
+          test -f /tmp/ok || { echo 'staging validation failed; NOT flipping'; exit 1; }
+
+          for RES in 9 8; do
+            echo "--- flipping ecoregion/hex-res${RES} ---"
+            rclone purge nrp:public-ca30x30/ecoregion/hex-res${RES}/ 2>/dev/null || true
+            REMAIN=$(rclone lsf -R nrp:public-ca30x30/ecoregion/hex-res${RES}/ 2>/dev/null | wc -l)
+            test "$REMAIN" -eq 0 || { echo "target res${RES} not empty after purge ($REMAIN); refusing to flip"; exit 1; }
+            rclone move nrp:public-ca30x30/ecoregion/hex-res${RES}-staging/ \
+                        nrp:public-ca30x30/ecoregion/hex-res${RES}/
+            rclone lsf -R --format sp nrp:public-ca30x30/ecoregion/hex-res${RES}/ | head -5
+          done
+          echo '=== #522 Part 2: ecoregion res-9 / res-8 land rollups published ==='
+        resources:
+          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 50Gi}
+          limits:   {cpu: '8', memory: 64Gi, ephemeral-storage: 50Gi}
+      volumes:
+      - name: rclone-config
+        secret: {secretName: rclone-config}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values: ['true']

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -658,7 +658,7 @@ def _is_percell_aggregation(doc: dict, asset: dict) -> bool:
     A cng-datasets vector hex always carries the source feature attributes forward, so it
     necessarily shares attribute names with the flat GeoParquet. A derived aggregation
     shares NONE: every non-index column is newly computed (data-workflows#506
-    `…-hex-weights`: h-indexes + w1…w4 + nland + n_units). Such an asset has collapsed the
+    `…-hex-weights`: h-indexes + w1…w4 + n_units). Such an asset has collapsed the
     feature dimension away, so there is no per-feature identity left to carry and
     `_cng_fid` is as meaningless on it as on a raster reduce — where a row-unique id would
     in fact be actively misleading, since `COUNT(DISTINCT _cng_fid)` would then equal the


### PR DESCRIPTION
Closes #522.

All three parts are done and live on NRP S3. Every claim in the issue reproduced exactly
before any change was made, and every "Done when" bullet is checked below with the query
that proves it.

## Part 1 — res-10 `hex-weights` is sparse (docs only)

Reproduced: 13,202,628 cells / 52,533,300 acres covered / 52,533,300 acres in units, and
`MIN(w1+w2+w3+w4) = MAX(…) = 1` — every present cell is saturated. Also measured: **794 of
13,202,628** cells (0.006 %) fall *outside* the `ca30x30-ecoregion` land grid (state-boundary
overhang / water), so the res-10 weights asset is not a strict subset of the land grid. That
is why the documented composition is a `LEFT JOIN` **from** the land grid — it drops those
794 and is what makes the pinned 101,472,000 ac denominator hold.

The res-10 asset description now states it covers only the inventory footprint, that
`w1+w2+w3+w4` is 1 on every row so unconserved California cannot be read from it alone, and
gives the `LEFT JOIN` + `COALESCE(…, 0)` composition against `ecoregion-hex`. The
parent-collection sentence now says the three assets differ in coverage instead of implying
all three are dense.

## Part 2 — `nland` moved to `ca30x30-ecoregion` (implemented, per maintainer decision)

New recipe `catalog/ecoregion/k8s/ca-30x30-ecoregion/ecoregion-hex-parents.yaml` publishes:

| asset | path | columns |
|---|---|---|
| `ecoregion-hex-res9` | `…/ecoregion/hex-res9/h0=*/data_0.parquet` | `h9, h8, nland, land_area_km2, h0` |
| `ecoregion-hex-res8` | `…/ecoregion/hex-res8/h0=*/data_0.parquet` | `h8, nland, land_area_km2, h0` |

`hex-weights-parents` no longer writes `nland`; it still computes it, because it is the
denominator of the parent mean and the weight in #508's acceptance check — so dropping it
from the output provably does not move a single `w` value.

The job asserts the equivalence rather than assuming it, and refuses to run if the ecoregion
rollups are not published yet (no window where `nland` is gone with no replacement):

```
LAND10_CELLS=25596931 DISTINCT_H10=25596931
RES9 ROWS=3662101 CELLS=3662101 SUM_NLAND=25596931 NLAND=[1,7]
RES8 ROWS=525034  CELLS=525034  SUM_NLAND=25596931 NLAND=[1,49]
NLAND_EQUIV res8: joined=525034 of 525034 weights rows, mismatches=0
```

Rebuild of the weights assets, `w` values untouched:

```
RES9 STAGED_COLUMNS=['h9','h8','w1','w2','w3','w4','h0']
RES8 STAGED_COLUMNS=['h8','w1','w2','w3','w4','h0']
CELL_EQUIV_GAP12 res10=6574294.5604 res9=6574294.5604 res8=6574294.5604
CELL_EQUIV_GAP34 res10=6627539.3665 res9=6627539.3665 res8=6627539.3665
ACCEPTANCE res8 join, BioRankSW=5: gap12=21.04 (target 21.05) gap34=29.62 (target 29.54)
```

**Deliberately out of scope:** the res-9/res-8 row sets stay **dense** (one row per California
land cell, `w = 0` included). The issue scopes Part 2 as "remove one column from three
`hex-weights` assets", and making them sparse would introduce at res-9/res-8 exactly the
silent inner-join failure Part 1 is fixing at res-10. The documented composition is written
as `LEFT JOIN` + `COALESCE` at all three resolutions, so "every resolution composes
identically" holds either way. Say the word if you want the row sets collapsed too — separable
follow-up.

## Part 3 — the documented aggregation is area-weighted

`land_area_km2` ships the correct weight as a column, so the right query is now the short
one and needs no `h3_cell_area` call. Verified against the live published assets:

```sql
SELECT ROUND(100*SUM(COALESCE(w.w1+w.w2,0)*e.land_area_km2)/SUM(e.land_area_km2),3)
FROM read_parquet('s3://public-ca30x30/ecoregion/hex-res8/h0=*/data_0.parquet') e
LEFT JOIN read_parquet('s3://…/hex-weights-res8/h0=*/data_0.parquet') w USING (h0, h8);
-- 26.135        (was 25.684; truth 26.47M/101.498M ac = 26.08)
```

res-9 returns **26.135** as well, on 3,662,101 rows, and its `SUM(land_area_km2)` reproduces
the pinned extent at **101,472,000 acres**. `nland` is confirmed gone from the res-9 schema:
`['h9','h8','w1','w2','w3','w4','h0']`.

## Done when — all four met

- [x] res-10 description states it is sparse, names `LEFT JOIN` + `COALESCE`, points at `ca30x30-ecoregion`
- [x] parent-collection sentence no longer implies all three assets are dense
- [x] documented res-9/res-8 aggregation returns **26.135**, not 25.684
- [x] Part 2 implemented (decision + reasoning recorded in the [scoping comment](https://github.com/boettiger-lab/data-workflows/issues/522#issuecomment-5222381416))

## Published artifacts (NRP S3, not in this repo)

`ecoregion/{stac-collection.json,README.md}` and
`conserved-areas-terrestrial-2025/{stac-collection.json,README.md}`. Both collections pass
the full data-backed gate:

```
scripts/verify-stac.py --bucket public-ca30x30 --dataset ecoregion                        -> PASS
scripts/verify-stac.py --bucket public-ca30x30 --dataset conserved-areas-terrestrial-2025 -> PASS
```

Two findings from the pre-publish gate were real and shaped the copy: the res-10 example
originally inlined `h3_cell_area()` (blocked by the #389 rule), so it now shows the per-cell
`LEFT JOIN` and points at the res-9/res-8 rollups where the weight is a published column; and
`land_area_km2` needed an explicit per-cell-grain note, which it now carries.

Descriptions follow the #512 user-facing-copy rule — no issue numbers, no defect magnitudes,
constraints expressed as `-- correct:` / `-- wrong:` SQL rather than imperatives. Note the
mcp-data-server STAC cache refreshes on a ~15-minute cycle, so the app will quote the old
text briefly.

Related: boettiger-lab/mcp-data-server#356 fixes the mirror-image `h3_cell_area` omission in
the h3-guide's worked example.
