### PR TITLE
fix: RFC 3339 temporal extents — 7 BLM MLRS collections were unloadable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,6 +541,19 @@ one version silently. Two traps, both hit in #512:
 
 - **License — REQUIRED on every collection.** Set the top-level STAC `license` field to the **SPDX identifier** of the upstream data license (e.g. `CC-BY-4.0`, `CC-BY-NC-4.0`, `CC-BY-SA-4.0`, `CDLA-Permissive-2.0`, `public-domain`). Use `"other"` **only** when no SPDX id applies, and `"various"` **only** for a meta-collection whose children genuinely differ — never as a lazy default. For `other`/`various` (and recommended for all), add a license link: `{"rel": "license", "href": "<canonical terms URL>", "type": "text/html"}`. **Exception — a meta-collection (one with `child` links) may use `various`/`other` WITHOUT a license link:** its real licenses live on the child collections (each carrying + verified for its own license), and redistribution gating (source.coop excludes, etc.) keys on those per-child licenses, not the parent. A single parent-level link would misrepresent genuinely mixed children. `verify-stac.py` enforces the link only on **leaf** collections (and always for `proprietary`). **Verify the real upstream terms — do not guess `proprietary`.** The license drives redistribution decisions (e.g. whether a dataset may be mirrored to source.coop); a wrong value is a compliance risk. NonCommercial / ShareAlike licenses are fine but MUST be recorded as such (`CC-BY-NC-*`, `CC-BY-SA-*`) so downstream users aren't misled. US federal works = `public-domain`.
 
+- **Temporal extent — RFC 3339, or the dataset vanishes from the served catalog.** Every
+  `extent.temporal.interval` endpoint must be a full RFC 3339 date-time with a timezone
+  (`"1920-05-15T00:00:00Z"`), or `null` for a genuinely open start/end. This is not
+  cosmetic: pystac parses these **eagerly** when it loads a collection, so one malformed
+  value makes the entire collection fail to load for every MCP consumer — the dataset
+  simply isn't there, with nothing but a warning in the server log. Seven BLM MLRS
+  mineral collections shipped this way and were invisible for weeks.
+  **When composing the string from a query result, slice the date part explicitly**
+  (`str(v)[:10]`): the MCP `query` tool renders a DuckDB `DATE` as
+  `"1974-03-01T00:00:00.000000"`, so appending `"T00:00:00Z"` to the raw value produces a
+  doubled time component. `verify-stac.py` HARD-fails a non-RFC-3339 endpoint, a missing
+  interval, and a start that is after its end.
+
 - **Navigation links — every collection needs all four:**
 
   ```json

--- a/catalog/blm/k8s/gen-mlrs-minerals-stac.py
+++ b/catalog/blm/k8s/gen-mlrs-minerals-stac.py
@@ -361,6 +361,13 @@ def build(name, mcp):
         f'SELECT "{c}" AS d FROM read_parquet(\'{flat}\')' for c in date_cols)
     dates = q(mcp, f"SELECT MIN(d) AS lo, MAX(d) AS hi FROM ({union}) "
                    f"WHERE d IS NOT NULL AND YEAR(d) BETWEEN 1800 AND 2100")[0]
+    # The MCP `query` tool renders a DuckDB DATE as a full timestamp with
+    # microseconds ("1974-03-01T00:00:00.000000"), NOT a bare "1974-03-01".
+    # Slice to the date part before composing the RFC 3339 instant below --
+    # appending to the raw value yields "…T00:00:00.000000T00:00:00Z", which
+    # pystac (via dateutil.isoparse) rejects with "Unused components in ISO
+    # string", making the whole collection unloadable for every MCP consumer.
+    lo, hi = str(dates["lo"])[:10], str(dates["hi"])[:10]
 
     # --- categorical values, straight from the ingested parquet ---
     values = {}
@@ -463,7 +470,7 @@ def build(name, mcp):
         "extent": {
             "spatial": {"bbox": [[float(stats["xmin"]), float(stats["ymin"]),
                                   float(stats["xmax"]), float(stats["ymax"])]]},
-            "temporal": {"interval": [[f"{dates['lo']}T00:00:00Z", f"{dates['hi']}T00:00:00Z"]]}},
+            "temporal": {"interval": [[f"{lo}T00:00:00Z", f"{hi}T00:00:00Z"]]}},
         "links": [
             {"rel": "self", "href": f"{BASE}/{name}/stac-collection.json",
              "type": "application/json"},

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -14,6 +14,9 @@ Static checks (no data; just the STAC JSON):
     license link — EXCEPT a meta-collection (has child links) may use various/other
     with no link, since the licenses live on (and are gated per) its children
   - nav links: self/root/parent present + well-formed; child (if any) well-formed
+  - extent.temporal.interval present, each endpoint RFC 3339 (or null for an open
+    end), start not after end — pystac parses these eagerly, so a malformed value
+    makes the whole collection unloadable for every MCP consumer
   - asset keys follow {last-segment}-{format}; no generic keys
     (pmtiles/geoparquet/hex/parquet/cog/h3-parquet)
   - hex asset href uses the hive glob  …/hex/h0=*/data_0.parquet  (not a bare dir)
@@ -70,6 +73,7 @@ import os
 import re
 import sys
 import urllib.request
+from datetime import datetime
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -355,6 +359,73 @@ def check_nav_links(doc: dict) -> list[Finding]:
             out.append(Finding(HARD, "nav-child-is-item",
                                 "sub-collections must use rel='child', not 'item' "
                                 "(item is for STAC Items/features)."))
+    return out
+
+
+# --- temporal extent: RFC 3339, or the collection is unloadable ------------
+# STAC requires every `extent.temporal.interval` endpoint to be an RFC 3339
+# date-time (or null for an open end). pystac parses these EAGERLY when it loads
+# a collection, via dateutil.isoparse -- so a malformed endpoint is not a
+# cosmetic defect, it makes the entire collection fail to load for every MCP
+# consumer, silently. That is exactly how the seven BLM MLRS mineral collections
+# went missing from the served catalog (mcp-data-server side: pystac raised
+# "ValueError: Unused components in ISO string" and skipped the child).
+#
+# NOTE ON THE IMPLEMENTATION: do NOT reach for datetime.fromisoformat() here.
+# On Python 3.11+ it is lenient enough to ACCEPT the very string that broke us --
+# fromisoformat("1974-03-01T00:00:00.000000T00:00:00Z") returns a datetime rather
+# than raising, so a fromisoformat-based gate would have passed these seven
+# collections too. dateutil.isoparse (what the consumer actually uses) rejects
+# it, but this verifier is deliberately stdlib-only -- CI runs it on a bare
+# setup-python with no pip install step -- so match RFC 3339 explicitly instead.
+# The pattern is stricter than either parser: it also requires a timezone
+# designator and rejects a bare date, both of which STAC mandates.
+RFC3339 = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$")
+
+
+def check_temporal_extent(doc: dict) -> list[Finding]:
+    out = []
+    extent = doc.get("extent")
+    if not isinstance(extent, dict):
+        return [Finding(HARD, "temporal-extent-missing",
+                        "collection has no `extent` object.")]
+    temporal = extent.get("temporal")
+    if not isinstance(temporal, dict) or not isinstance(temporal.get("interval"), list) \
+            or not temporal["interval"]:
+        return [Finding(HARD, "temporal-extent-missing",
+                        "collection has no `extent.temporal.interval` "
+                        "(STAC requires one, with null for an open end).")]
+
+    for pair in temporal["interval"]:
+        if not isinstance(pair, list) or len(pair) != 2:
+            out.append(Finding(HARD, "temporal-interval-malformed",
+                                f"`extent.temporal.interval` entry is not a "
+                                f"[start, end] pair: {pair!r}."))
+            continue
+        parsed = []
+        for v in pair:
+            if v is None:          # legitimate open start/end
+                parsed.append(None)
+                continue
+            if not isinstance(v, str) or not RFC3339.match(v):
+                out.append(Finding(HARD, "temporal-not-rfc3339",
+                                    f"temporal extent endpoint {v!r} is not an "
+                                    f"RFC 3339 date-time (expected e.g. "
+                                    f"'1920-05-15T00:00:00Z'). pystac refuses to "
+                                    f"load a collection with this value, so the "
+                                    f"dataset disappears from the served catalog."))
+                parsed.append(None)
+                continue
+            # Safe only because RFC3339 already gated the format above: compare as
+            # real instants so a mixed 'Z' / '+05:00' pair can't compare backwards
+            # the way a lexical string compare would.
+            parsed.append(datetime.fromisoformat(v.replace("Z", "+00:00")))
+        lo, hi = parsed
+        if lo and hi and lo > hi:
+            out.append(Finding(HARD, "temporal-interval-reversed",
+                                f"temporal extent starts after it ends: "
+                                f"{pair[0]} > {pair[1]}."))
     return out
 
 
@@ -770,6 +841,7 @@ def run_sibling_linter(mod, doc_source: str, code: str) -> list[Finding]:
 STATIC_CHECKS = [
     check_license,
     check_nav_links,
+    check_temporal_extent,
     check_asset_keys,
     check_hex_assets,
     check_vector_layers,


### PR DESCRIPTION
Found while auditing `wyoming-mcp` startup logs: seven collections have been failing to load on every MCP server (prod, dev, and the credentialed wyoming replica) with only a warning line to show for it.

```
⚠️ Child fetch failed: oil-shale-leases — ValueError: Unused components in ISO string
```

## Cause

`catalog/blm/k8s/gen-mlrs-minerals-stac.py` composed the temporal extent as:

```python
"temporal": {"interval": [[f"{dates['lo']}T00:00:00Z", f"{dates['hi']}T00:00:00Z"]]}
```

That assumes `dates['lo']` is a bare `YYYY-MM-DD`. It isn't — `dates` comes from `q(mcp, …)`, and the MCP `query` tool renders a DuckDB `DATE` as a full timestamp with microseconds:

```
| lo                         | hi                         |
| 1974-03-01T00:00:00.000000 | 2024-12-30T00:00:00.000000 |
```

So the f-string appends a **second** time component: `1974-03-01T00:00:00.000000T00:00:00Z`.

pystac parses `extent.temporal` eagerly (via `dateutil.isoparse`) when it loads a collection, so this isn't a cosmetic metadata defect — the whole collection fails to load and the dataset silently vanishes from the served catalog. Affected since #486:

`coal-cases`, `geothermal-leases`, `mineral-materials`, `non-energy-leasables`, `oil-gas-agreements`, `oil-gas-participating-areas`, `oil-shale-leases`

The other six BLM layers (`oil-gas-leases`, `mining-claims`, `locatable-operations`, `lua-*`, `acquisitions`) come from different generators and emit clean values — this is one generator's bug, and those seven are the **only** ISO-parse failures anywhere in the catalog.

## Why the gate missed it

`verify-stac.py` is 1394 lines and 11 checks, all house-convention: license, nav links, asset keys, hex assets, `table:columns`, `_cng_fid`, column-description consistency, and so on. `temporal` appeared **zero** times in the file. It loads the document as a plain dict and never asks whether it is a valid STAC Collection, so nothing in the suite could see this. These seven were iterated until the gate went green (745c8ef) and shipped unloadable anyway.

## Changes

1. **Generator** — slice the date part explicitly (`str(v)[:10]`), with a comment recording the `DATE`-rendering trap so the next author doesn't step in it.
2. **`verify-stac.py`** — new `check_temporal_extent`: HARD-fails a non-RFC-3339 endpoint, a missing/malformed interval, and a start after its end. `null` endpoints stay legal for genuinely open intervals.
3. **AGENTS.md** — documents the rule, per the repo's convention that every enforced rule is written down.

## ⚠️ Do not "simplify" the check to `datetime.fromisoformat`

The obvious implementation does not work. On Python 3.11+ `fromisoformat` is lenient enough to **accept the exact string that broke us**:

```python
>>> datetime.fromisoformat("1974-03-01T00:00:00.000000T00:00:00Z")
datetime.datetime(1974, 3, 1, 0, 0, tzinfo=datetime.timezone.utc)   # no error
```

A `fromisoformat`-based gate would have passed all seven collections. `dateutil.isoparse` — what the consumer actually uses — rejects it, but this verifier is deliberately stdlib-only (CI runs it on a bare `setup-python` with no pip install step), so the check matches RFC 3339 explicitly. The pattern is stricter than either parser: it also requires a timezone designator and rejects a bare date, both of which STAC mandates.

## Verification

- **Broken collection** → 2 HARD findings, exit 1.
- **Good sibling** (`oil-gas-leases`) → 0 temporal findings.
- **False-positive sweep over the entire published catalog**: 265 collections crawled, **exactly 7 flagged, zero false positives** — including the reversed-interval and missing-extent branches.
- **End-to-end**: the published extent raises `ValueError: Unused components in ISO string` through `pystac.Collection.from_dict`; with the generator fix applied it loads cleanly.

## Follow-up (not in this PR)

The seven published `stac-collection.json` files still carry the bad value and need regenerating before the datasets actually reappear. That is a metadata-only republish — no data reprocessing — but it writes to `public-blm`, so I left it out of the code change.

Worth considering separately: having the MCP `query` tool render a `DATE` as `YYYY-MM-DD` rather than a microsecond timestamp. That is the trap that baited this generator and it will bait the next one, but it is a visible behaviour change to the most-used tool on the server, so it wants its own scope.
