### PR TITLE
fix(#528): nhdplus-hr flowline is 13 whole hydrologic units, not California

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,6 +537,26 @@ one version silently. Two traps, both hit in #512:
   within the collection — `verify-stac.py` reports this as `column-description-divergent`
   (ADVISORY today; it becomes HARD once the pre-gate catalog is fold-clean, #509).
 
+**The title and description state the FOOTPRINT, not which tranche you ingested.** A set of
+whole administrative or hydrologic units is **never** a state extent, and a consumer — human or
+model — trusts the title over the geometry. `usgs-nhdplus-hr-flowline` was titled *"(California)"*
+and said *"COVERAGE IS CALIFORNIA ONLY"*, both true about which VPUs had been ingested and both
+read as claims about the footprint, which is 13 whole HU4 units with **30.3% of its stream length
+in Nevada, Utah, Oregon and Arizona**. A model skipped the California mask and its headline number
+was 8.5 points wrong — the same mechanism as the pinyon-juniper defect (#505). So:
+
+- **Title the unit set** — "…(13 California hydrologic units)", not "…(California)". Same for
+  counties, ecoregions, watersheds, and every later tranche of a national build.
+- **State the footprint near the top of the description**: what the units are, that they are not
+  clipped to the region, how much lies outside, and the mask a region-level statistic needs
+  (for California, join `h8` + `h0` against the `ca30x30-ecoregion` hex). Give the mask as a short
+  SQL example, per the register rules above.
+- **Never write "X ONLY" for "only the X tranche is ingested so far"** — say the ingest scope and
+  the footprint as two separate facts.
+- The `bbox` is usually already correct; it is the prose that lies. `verify-stac.py` flags a title
+  naming one US state whose bbox reaches >1° outside it with no footprint sentence
+  (`title-names-state-but-bbox-exceeds-it`, ADVISORY) — the fix is the sentence, not a narrower bbox.
+
 **stac-collection.json MUST include:**
 
 - **License — REQUIRED on every collection.** Set the top-level STAC `license` field to the **SPDX identifier** of the upstream data license (e.g. `CC-BY-4.0`, `CC-BY-NC-4.0`, `CC-BY-SA-4.0`, `CDLA-Permissive-2.0`, `public-domain`). Use `"other"` **only** when no SPDX id applies, and `"various"` **only** for a meta-collection whose children genuinely differ — never as a lazy default. For `other`/`various` (and recommended for all), add a license link: `{"rel": "license", "href": "<canonical terms URL>", "type": "text/html"}`. **Exception — a meta-collection (one with `child` links) may use `various`/`other` WITHOUT a license link:** its real licenses live on the child collections (each carrying + verified for its own license), and redistribution gating (source.coop excludes, etc.) keys on those per-child licenses, not the parent. A single parent-level link would misrepresent genuinely mixed children. `verify-stac.py` enforces the link only on **leaf** collections (and always for `proprietary`). **Verify the real upstream terms — do not guess `proprietary`.** The license drives redistribution decisions (e.g. whether a dataset may be mirrored to source.coop); a wrong value is a compliance risk. NonCommercial / ShareAlike licenses are fine but MUST be recorded as such (`CC-BY-NC-*`, `CC-BY-SA-*`) so downstream users aren't misled. US federal works = `public-domain`.

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -33,6 +33,9 @@ Static checks (no data; just the STAC JSON):
   - point datasets: a processing-resolution note in description/processing:notes
   - categorical column completeness (values + inline CODE=Name)  [reuses lint-stac-categorical]
   - PMTiles tile-accurate table:columns                          [reuses lint-stac-pmtiles-fields]
+  - ADVISORY: a title naming one US state whose bbox reaches well outside it, with no
+    footprint sentence in the description — a set of whole units is not a state extent
+    and a state-shaped title is what a consumer trusts instead of masking (#528)
 
 Data-backed checks (delegated to the duckdb-geo MCP server, --no-data to skip):
   - every coded column's `values` array == the ingested DISTINCT set (automates the
@@ -675,6 +678,90 @@ def check_inline_area_formula(doc: dict) -> list[Finding]:
     return out
 
 
+# --- #528 — a title that names a state must not misstate the footprint ------
+# The nhdplus-hr flowline collection was titled "(California)" and said "COVERAGE IS
+# CALIFORNIA ONLY", because only the California HU4 units had been ingested. Both read
+# as statements about the FOOTPRINT, which was 13 whole hydrologic units — 30.3% of its
+# stream length lies in NV/UT/OR/AZ. A model trusted the title, skipped the California
+# mask, and reported a headline number 8.5 points wrong (data-workflows#528; same
+# mechanism as the pinyon-juniper defect, #505).
+#
+# The mechanical signal: the title names exactly one US state, but the declared bbox
+# reaches well outside that state. ADVISORY, and suppressed once the description
+# actually explains the footprint — the point is to prompt that sentence, not to ban
+# region names in titles.
+_STATE_BBOX = {  # (west, south, east, north), approximate — paired with a 1° tolerance
+    "alabama": (-88.5, 30.2, -84.9, 35.0), "alaska": (-179.2, 51.2, 179.8, 71.4),
+    "arizona": (-114.8, 31.3, -109.0, 37.0), "arkansas": (-94.6, 33.0, -89.6, 36.5),
+    "california": (-124.5, 32.5, -114.1, 42.0), "colorado": (-109.1, 37.0, -102.0, 41.0),
+    "connecticut": (-73.7, 40.9, -71.8, 42.1), "delaware": (-75.8, 38.4, -75.0, 39.8),
+    "florida": (-87.6, 24.4, -80.0, 31.0), "georgia": (-85.6, 30.3, -80.8, 35.0),
+    "hawaii": (-178.4, 18.9, -154.8, 28.4), "idaho": (-117.3, 42.0, -111.0, 49.0),
+    "illinois": (-91.5, 36.9, -87.0, 42.5), "indiana": (-88.1, 37.8, -84.8, 41.8),
+    "iowa": (-96.6, 40.4, -90.1, 43.5), "kansas": (-102.1, 37.0, -94.6, 40.0),
+    "kentucky": (-89.6, 36.5, -81.9, 39.1), "louisiana": (-94.1, 28.9, -88.8, 33.0),
+    "maine": (-71.1, 43.0, -66.9, 47.5), "maryland": (-79.5, 37.9, -75.0, 39.7),
+    "massachusetts": (-73.5, 41.2, -69.9, 42.9), "michigan": (-90.4, 41.7, -82.1, 48.3),
+    "minnesota": (-97.2, 43.5, -89.5, 49.4), "mississippi": (-91.7, 30.1, -88.1, 35.0),
+    "missouri": (-95.8, 36.0, -89.1, 40.6), "montana": (-116.1, 44.4, -104.0, 49.0),
+    "nebraska": (-104.1, 40.0, -95.3, 43.0), "nevada": (-120.0, 35.0, -114.0, 42.0),
+    "new hampshire": (-72.6, 42.7, -70.6, 45.3), "new jersey": (-75.6, 38.9, -73.9, 41.4),
+    "new mexico": (-109.1, 31.3, -103.0, 37.0), "new york": (-79.8, 40.5, -71.8, 45.0),
+    "north carolina": (-84.3, 33.8, -75.5, 36.6), "north dakota": (-104.1, 45.9, -96.6, 49.0),
+    "ohio": (-84.8, 38.4, -80.5, 42.0), "oklahoma": (-103.0, 33.6, -94.4, 37.0),
+    "oregon": (-124.6, 41.9, -116.5, 46.3), "pennsylvania": (-80.5, 39.7, -74.7, 42.3),
+    "rhode island": (-71.9, 41.1, -71.1, 42.0), "south carolina": (-83.4, 32.0, -78.5, 35.2),
+    "south dakota": (-104.1, 42.5, -96.4, 46.0), "tennessee": (-90.3, 35.0, -81.6, 36.7),
+    "texas": (-106.7, 25.8, -93.5, 36.5), "utah": (-114.1, 37.0, -109.0, 42.0),
+    "vermont": (-73.5, 42.7, -71.5, 45.0), "virginia": (-83.7, 36.5, -75.2, 39.5),
+    "washington": (-124.9, 45.5, -116.9, 49.0), "west virginia": (-82.7, 37.2, -77.7, 40.6),
+    "wisconsin": (-92.9, 42.5, -86.8, 47.1), "wyoming": (-111.1, 41.0, -104.0, 45.0),
+}
+_FOOTPRINT_TOLERANCE_DEG = 1.0
+# Phrases that contain a state name but do not name that state — "Sierra Nevada" is a
+# California mountain range, "Washington, D.C." is not Washington state.
+_NOT_A_STATE = re.compile(r"sierra nevada|washington,?\s*d\.?c\.?|kansas city", re.I)
+# Prose that shows the footprint is already explained — the collection has done the work.
+_FOOTPRINT_EXPLAINED = re.compile(
+    r"not clipped|no[nt]e is clipped|whole (hydrologic|watershed|hu4|unit|basin)|"
+    r"extends? (past|beyond|outside)|outside (the state|california|nevada|oregon)|"
+    r"footprint:", re.I)
+
+
+def check_region_title_vs_bbox(doc: dict) -> list[Finding]:
+    """ADVISORY when a title names one US state but the bbox reaches well outside it.
+
+    A collection ingested as whole administrative/hydrologic units is not a state
+    extent, and a title that says otherwise is what a consumer (human or model) trusts
+    instead of applying the mask (#528). Silent once the description states the real
+    footprint.
+    """
+    title = _NOT_A_STATE.sub(" ", doc.get("title", "") or "")
+    named = [s for s in _STATE_BBOX if re.search(rf"\b{re.escape(s)}\b", title, re.I)]
+    # "West Virginia" also matches "virginia"; the longest name is the one being claimed.
+    named = [s for s in named if not any(s != o and s in o for o in named)]
+    if len(named) != 1:
+        return []          # zero states named, or a multi-state title that isn't a claim
+    state = named[0]
+    try:
+        west, south, east, north = doc["extent"]["spatial"]["bbox"][0][:4]
+    except (KeyError, IndexError, TypeError, ValueError):
+        return []
+    sw, ss, se, sn = _STATE_BBOX[state]
+    t = _FOOTPRINT_TOLERANCE_DEG
+    over = [f"{d} by {v:.1f}°" for d, v in (
+        ("west", sw - west), ("south", ss - south), ("east", east - se), ("north", north - sn))
+        if v > t]
+    if not over:
+        return []
+    if _FOOTPRINT_EXPLAINED.search(doc.get("description", "") or ""):
+        return []
+    return [Finding(ADVISORY, "title-names-state-but-bbox-exceeds-it",
+                    f"title names '{state.title()}' but the declared bbox reaches outside "
+                    f"it ({', '.join(over)}). If this was ingested as whole units that "
+                    f"cross the state line, say so in the description — state the real "
+                    f"footprint, how much lies outside, and the mask a state-level "
+                    f"statistic needs. A unit set is not a state extent (#528).")]
 
 
 def _asset_has_geom(asset: dict) -> bool:
@@ -851,6 +938,7 @@ STATIC_CHECKS = [
     check_column_description_consistency,
     check_point_note,
     check_inline_area_formula,
+    check_region_title_vs_bbox,
 ]
 
 


### PR DESCRIPTION
Closes #528.

`usgs-nhdplus-hr-flowline` was titled **"(California)"** and said **"COVERAGE IS CALIFORNIA ONLY"**. Both were true about *which VPUs had been ingested*; both read as claims about the **footprint**, which is 13 whole HU4 units — **30.3% of its in-network stream length is outside California**, in NV/UT/OR/AZ. A model trusted the title, skipped the mask, and was 8.5 points off.

Reproduced the issue's numbers against live data before editing (duckdb-geo MCP):

| | length | GAP 1+2 |
|---|---|---|
| unmasked | 924,634 km | 19.0% |
| masked to `ca30x30-ecoregion` (h8) | 641,393 km | 27.4% |

Per-unit out-of-state totals matched the issue to a fraction of a point (small deltas because the issue's per-unit figures exclude coastline; the collection's own manifest counts in-network including it, so the published table uses that basis: 1,175,296 km total, 818,884 km in CA, 30.3% outside).

## Published to S3 (canonical — not in this repo)

`public-usgs-nhd/nhdplus-hr/flowline/stac-collection.json`
- title → **"USGS NHDPlus High Resolution — Flowlines + network VAA (13 California hydrologic units)"**
- a **Footprint** paragraph second in the description: whole HU4s, not clipped to the state, 30.3% outside, per-unit shares, the masked-vs-unmasked headwater numbers, and the masking SQL
- "COVERAGE IS CALIFORNIA ONLY at present" → "Only the 13 California hydrologic units are ingested so far … those units extend past the state line and the data is not clipped to it"
- asset titles no longer say "California flowlines"; each asset description carries a one-line footprint pointer; keywords no longer imply a CA-only extent

`public-usgs-nhd/stac-collection.json` — the parent's "(California so far)" clause restated the same way.

`public-usgs-nhd/README.md` — layer table, extent row, and the comparison section corrected; a new **"Footprint: 13 whole hydrologic units, not California"** section with the per-unit table and mask recipe; the `-- California stream length by Strahler order` example was itself the trap in prose form and is now labelled as the whole-unit total.

`scripts/verify-stac.py --bucket public-usgs-nhd --dataset nhdplus-hr/flowline` → PASS.

## In this repo (issue item 4 — so the next tranche gets the same treatment)

- **AGENTS.md**: titles/descriptions state the footprint, not the ingested tranche; a unit set is never a state extent; never write "X ONLY" for "only the X tranche so far".
- **verify-stac.py**: new static ADVISORY `title-names-state-but-bbox-exceeds-it` — title names exactly one US state, declared bbox reaches >1° outside it, and no footprint sentence in the description. Silent once the footprint is stated (so the fixed collection passes).

Swept 266 catalog collections with the new check: 0 false positives after excluding compound names ("Sierra Nevada" is a California range), and 2 genuine candidates for a human look — `california-swap` (1.1° north) and `missouri-swap` (1.0° south). Advisory only, so neither blocks.