### PR TITLE
fix(#511): verify-stac keeps a declared null/nan/none as a real category

### DIFF
--- a/catalog/wdpa/k8s/check-no-take-upstream.yaml
+++ b/catalog/wdpa/k8s/check-no-take-upstream.yaml
@@ -1,0 +1,56 @@
+# One-shot investigation (data-workflows#511): is NO_TAKE='All ' (trailing space, 857 rows
+# in wdpa.parquet) present UPSTREAM in the WDPA GDB, or introduced by our conversion?
+# Reads DISTINCT NO_TAKE with lengths straight from the staged source GDB over the INTERNAL
+# endpoint via /vsicurl/ range reads — no localize. Attribute-only scan (no geometry).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wdpa-check-no-take-upstream
+  labels:
+    k8s-app: wdpa-check-no-take-upstream
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        k8s-app: wdpa-check-no-take-upstream
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: check
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: GDAL_DISABLE_READDIR_ON_OPEN
+          value: EMPTY_DIR
+        - name: GDAL_HTTP_MAX_RETRY
+          value: '5'
+        - name: GDAL_HTTP_RETRY_DELAY
+          value: '3'
+        command: [bash, -c]
+        args:
+        - |
+          set -o pipefail
+          SRC="/vsicurl/http://rook-ceph-rgw-nautiluss3.rook/public-wdpa/wdpa-june-2026/raw/WDPA_Jun2026_Public.gdb"
+          echo "=== source: $SRC ==="
+          ogrinfo -ro -q "$SRC" WDPA_poly_Jun2026 -dialect SQLITE \
+            -sql "SELECT '[' || NO_TAKE || ']' AS bracketed, length(NO_TAKE) AS len, COUNT(*) AS n FROM WDPA_poly_Jun2026 GROUP BY NO_TAKE ORDER BY n DESC"
+          echo "=== rows where NO_TAKE LIKE 'All%' (any trailing chars) ==="
+          ogrinfo -ro -q "$SRC" WDPA_poly_Jun2026 -dialect SQLITE \
+            -sql "SELECT DISTINCT '[' || NO_TAKE || ']' AS bracketed, length(NO_TAKE) AS len FROM WDPA_poly_Jun2026 WHERE NO_TAKE LIKE 'All%'"
+        resources:
+          requests: {memory: 4Gi, cpu: '1', ephemeral-storage: 8Gi}
+          limits:  {memory: 8Gi, cpu: '2', ephemeral-storage: 10Gi}
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1141,11 +1141,23 @@ def check_values_match_distinct(doc: dict, mcp: MCPClient) -> list[Finding]:
         # array pollutes the schema and breaks the self-describing fold — so exclude them
         # from the ingested DISTINCT set, the same way SQL NULL is already excluded.
         # Real "unknown" categories (UNK, Unknown, N/A) are intentional codes and stay.
+        #
+        # EXCEPTION (#511): only filter a token the schema does NOT itself declare. WDPA's
+        # NO_TAKE really has a 'None' class ("no no-take zone", 1,545 rows); unconditionally
+        # dropping it made the linter both hide a populated category AND report it as
+        # declared-but-absent — an asymmetric, self-contradictory finding. A token that is an
+        # explicit declared value is a genuine category, so keep it on the ingested side too.
+        declared_norm = {str(d).strip().lower() for d in declared}
+        artifact_tokens = [t for t in ("null", "nan", "none") if t not in declared_norm]
+        excl = ""
+        if artifact_tokens:
+            toks = ", ".join("'" + t + "'" for t in artifact_tokens)
+            excl = f"AND lower(trim(CAST(\"{col}\" AS VARCHAR))) NOT IN ({toks}) "
         sql = (
             f'WITH ingested AS (SELECT DISTINCT {norm(chr(34)+col+chr(34))} AS v '
             f"  FROM read_parquet('{s3}') WHERE \"{col}\" IS NOT NULL "
             f"    AND trim(CAST(\"{col}\" AS VARCHAR)) <> '' "
-            f"    AND lower(trim(CAST(\"{col}\" AS VARCHAR))) NOT IN ('null','nan','none')), "
+            f"    {excl}), "
             f"declared AS (SELECT {norm('v')} AS v FROM (VALUES {decl_rows}) t(v)) "
             f"SELECT 'missing' AS kind, v FROM ingested WHERE v NOT IN (SELECT v FROM declared) "
             f"UNION ALL "

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -373,5 +373,42 @@ class HexHoldsAllFeatures(unittest.TestCase):
         self.assertIn("104 of 105", f[0].message)
 
 
+class ValuesMatchDistinctArtifactTokens(unittest.TestCase):
+    """A declared null/nan/none is a real category, not a missing-value artifact (#511).
+
+    The filter that drops pandas/str(None) leakage from the ingested DISTINCT set must not
+    fire on a token the schema itself declares — otherwise a genuine, populated category
+    (WDPA NO_TAKE='None', 1,545 rows) is both hidden and reported as declared-but-absent.
+    The decision is made in Python before the query, so assert on the generated SQL."""
+
+    def _sql_for(self, values):
+        asset = {"href": "https://s3-west.nrp-nautilus.io/public-x/d.parquet",
+                 "type": PARQUET,
+                 "table:columns": [{"name": "NO_TAKE", "type": "string",
+                                    "values": values}]}
+        doc = {"assets": {"d-parquet": asset}}
+        mcp = StubMCP(rows=[])
+        vs.check_values_match_distinct(doc, mcp)
+        self.assertEqual(len(mcp.sql), 1)
+        return mcp.sql[0]
+
+    def test_undeclared_tokens_are_filtered(self):
+        sql = self._sql_for(["All", "Part"]).lower()
+        self.assertIn("not in ('null', 'nan', 'none')", sql)
+
+    def test_declared_none_is_kept_on_ingested_side(self):
+        sql = self._sql_for(["All", "Part", "None"]).lower()
+        # 'none' must drop out of the exclusion so the ingested 'None' survives to match.
+        self.assertIn("not in ('null', 'nan')", sql)
+        self.assertNotIn("'none'", sql.split(") t(v)")[0].split("declared")[0])
+
+    def test_all_artifact_tokens_declared_removes_exclusion(self):
+        sql = self._sql_for(["Null", "NaN", "None", "Real"]).lower()
+        # nothing left to exclude → no NOT IN artifact clause at all
+        self.assertNotIn("not in ('null'", sql)
+        self.assertNotIn("not in ('nan'", sql)
+        self.assertNotIn("not in ('none'", sql)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses the **linter half** of #511, plus establishes the cause of the sibling data defect.

## Linter bug (fixed here)
`check_values_match_distinct` excluded the tokens `null`/`nan`/`none` from the *ingested* DISTINCT set (to filter pandas/`str(None)` leakage) but never from the *declared* side. On WDPA `NO_TAKE`, where `None` is a **genuine documented category** ("no no-take zone", 1,545 rows), this:
- **hid** the populated `None` category, and
- reported `None` as **declared-but-absent** —

an asymmetric, self-contradictory finding that made the whole result look like a linter artifact (and risked a reviewer dismissing the *real* `All ` defect along with it).

**Fix:** only filter an artifact token the schema does **not** itself declare. An explicitly declared `None`/`Null`/`NaN` is a real category and stays on both sides. Adds a `ValuesMatchDistinctArtifactTokens` test class (31 tests pass).

## Data defect (investigated here, remediated on S3)
`NO_TAKE='All '` (trailing space, 857 rows) is confirmed an **upstream WDPA quirk** — present in the source `WDPA_Jun2026_Public.gdb` itself (all five category counts match the published parquet exactly), **not** introduced by our conversion. So no `cng-datasets` MRE/issue is warranted (HARD BOUNDARY 2).

Per maintainer decision (bugs-before-new-processing), the fix is **STAC-only**: the `wdpa` collection's `NO_TAKE` now declares the real value `'All '` and documents `WHERE trim(NO_TAKE) = 'All'` on all three assets. That is an S3-only write to `public-wdpa` (this repo holds no STAC JSON) and is not part of this diff. A follow-up issue tracks the **durable** fix — normalizing trailing whitespace in the WDPA build recipe so every future monthly edition is clean.

The one-shot investigation manifest (`catalog/wdpa/k8s/check-no-take-upstream.yaml`) is included as the reproducible evidence.

Refs #511.