### PR TITLE
fix: verify-stac reports existing parquet columns as absent (nested columns, wide assets)

### DIFF
--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1488,13 +1488,31 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
         part_keys = _partition_keys(asset.get("href", ""))
         try:
             total = int(mcp.query(
-                f"SELECT COUNT(DISTINCT file_name) AS n FROM parquet_schema('{s3}')")[0]["n"])
-            # `type IS NOT NULL` keeps only leaf columns, dropping the schema root and any
-            # struct group node (whose physical type is NULL) — so `parquet_schema`'s
-            # nested/struct entries do not read as phantom columns (#534 caveat).
+                f"SELECT COUNT(DISTINCT file_name) AS n FROM parquet_metadata('{s3}')")[0]["n"])
+            # Read TOP-LEVEL column names from each leaf chunk's `path_in_schema`, whose
+            # FIRST segment is the column that leaf belongs to: a `string[]` column reads
+            # 'common_names_en, list, element', a struct 'bbox, xmin', a map
+            # 'tags, key_value, key', a plain column just its own name.
+            #
+            # `parquet_schema`'s flat name list cannot answer this. The parquet schema is a
+            # TREE flattened in pre-order, and a LIST / STRUCT / MAP column is a group node
+            # whose physical `type` is NULL — the same NULL that marks the schema root. So
+            # filtering on `type IS NOT NULL` to drop the root also drops the column itself,
+            # and it kept the group's machinery leaves ('element', 'key', 'value', struct
+            # fields) instead. Both halves misfire: every declared nested column HARD-failed
+            # `declared-column-absent` while its leaves read as phantom top-level columns
+            # (iucn-taxonomy-2025: 9 populated `string[]` columns reported absent, plus an
+            # 'element' undocumented-column advisory). Splitting the leaf path is exact and
+            # needs no ordering assumption. It also covers the `bbox` struct, whose fallback
+            # below stays for a writer that emits xmin/ymin as real top-level columns.
+            #
+            # `parquet_metadata` is the column-chunk footer, so this remains a footer read.
+            # A file with no row groups has no chunks and so drops out of both the presence
+            # map and `total`, which is what we want: an empty file has no data to disagree
+            # with the STAC, and counting it would report every column missing from it.
             rows = mcp.query(
-                "SELECT lower(name) AS name, COUNT(DISTINCT file_name) AS nf "
-                f"FROM parquet_schema('{s3}') WHERE type IS NOT NULL GROUP BY 1")
+                "SELECT lower(split_part(path_in_schema, ', ', 1)) AS name, "
+                f"COUNT(DISTINCT file_name) AS nf FROM parquet_metadata('{s3}') GROUP BY 1")
         except (MCPError, ValueError, KeyError, IndexError) as e:
             out.append(Finding(ADVISORY, "schema-match-check-failed",
                                f"asset '{key}': could not read parquet footers ({e})."))

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1450,10 +1450,12 @@ def check_polygon_row_dup(doc: dict, mcp: MCPClient) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 _PARTITION_KEY_RE = re.compile(r"/([^/=]+)=\*/")
-# GeoParquet 1.1 bbox-covering struct leaves: a STAC declares a single `bbox` column but
-# the file stores it as a struct with these leaves. Neither the `bbox` declaration nor the
-# leaves should be treated as absent/undocumented.
-_BBOX_COVER = {"xmin", "ymin", "zmin", "xmax", "ymax", "zmax"}
+# A GeoParquet 1.1 bbox covering is spatial-index machinery, not a column an author writes
+# up, so an undeclared one is not an undocumented column. Its DECLARED side needs no
+# special case any more: the check reads a column's name from its leaf's path, so the
+# covering struct lands on 'bbox' — the name the STAC declares — like any other column.
+# The leaf names stay listed for a writer that emits them as real top-level columns.
+_BBOX_COVER = {"bbox", "xmin", "ymin", "zmin", "xmax", "ymax", "zmax"}
 
 
 def _partition_keys(href: str) -> set[str]:
@@ -1472,8 +1474,15 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
       declared but absent from EVERY file  -> HARD (stale STAC; a metadata fix)
       declared but absent from SOME files  -> HARD (heterogeneous; a data rebuild)
       present in data, undocumented        -> ADVISORY (self-describing contract; kept
-                                              advisory because nested/covering leaves make
-                                              a hard extra-column failure FP-prone)
+                                              advisory because a lookup/crosswalk table
+                                              may carry a column nobody wrote up yet)
+
+    Both comparisons run IN SQL and return only the discrepancies, for the same reason
+    check_values_match_distinct does it: the MCP query tool caps a result at 50 rows, so
+    reading back a whole column list and diffing it in Python drops the tail of any asset
+    wider than that and reports the dropped columns as absent. gbif-hex-2026-06 has 61
+    top-level columns, and which 11 vanished varied run to run with the (unordered)
+    GROUP BY. A discrepancy list is short by construction — usually empty.
     """
     out = []
     for key, asset in doc.get("assets", {}).items():
@@ -1486,75 +1495,88 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
         if not declared:
             continue  # parquet-no-table-columns already HARD-flags a missing schema
         part_keys = _partition_keys(asset.get("href", ""))
+        # A path-supplied partition key and the writer-named geometry column are exempt in
+        # both directions: neither has to appear in a footer, and neither is undocumented.
+        exempt = set(part_keys)
+        original = {}
+        for name in declared:
+            low = name.lower()
+            original.setdefault(low, name)   # report the STAC's own spelling back
+            if _is_geom_col(name):
+                exempt.add(low)
+        compare = [low for low in original if low not in exempt]
+        if not compare:
+            continue
+        # `present` reads TOP-LEVEL column names from each leaf chunk's `path_in_schema`,
+        # whose FIRST segment is the column that leaf belongs to: a `string[]` column reads
+        # 'common_names_en, list, element', a struct 'bbox, xmin', a map
+        # 'tags, key_value, key', a plain column just its own name.
+        #
+        # `parquet_schema`'s flat name list cannot answer this. The parquet schema is a TREE
+        # flattened in pre-order, and a LIST / STRUCT / MAP column is a group node whose
+        # physical `type` is NULL — the same NULL that marks the schema root. So filtering on
+        # `type IS NOT NULL` to drop the root also dropped the column itself, and kept the
+        # group's machinery leaves ('element', 'key', 'value', struct fields) in its place:
+        # every declared nested column read as absent while its leaves read as phantom
+        # top-level columns (iucn-taxonomy-2025: 9 populated `string[]` columns reported
+        # absent, plus an 'element' undocumented-column advisory). Splitting the leaf path is
+        # exact, needs no ordering assumption, and subsumes the GeoParquet `bbox` covering
+        # struct, which lands on 'bbox' like any other column.
+        #
+        # `parquet_metadata` is the column-chunk footer, so this stays a footer read. A file
+        # with no row groups has no chunks and drops out of both `present` and `total`, which
+        # is what we want: an empty file has no data to disagree with the STAC, and counting
+        # it would report every column as missing from it.
+        # MATERIALIZED so the footer is read once per query rather than once per CTE that
+        # references it — two queries, two reads, the same as the pair this replaced.
+        ctes = (f"WITH meta AS MATERIALIZED (SELECT lower(split_part(path_in_schema, ', ', 1)) "
+                f"AS name, file_name FROM parquet_metadata('{s3}')), "
+                "present AS (SELECT name, COUNT(DISTINCT file_name) AS nf FROM meta GROUP BY 1), "
+                "total AS (SELECT COUNT(DISTINCT file_name) AS n FROM meta) ")
+        cmp_values = ", ".join("('" + n.replace("'", "''") + "')" for n in sorted(compare))
+        known_values = ", ".join(
+            "('" + n.replace("'", "''") + "')" for n in sorted(set(original) | exempt))
         try:
-            total = int(mcp.query(
-                f"SELECT COUNT(DISTINCT file_name) AS n FROM parquet_metadata('{s3}')")[0]["n"])
-            # Read TOP-LEVEL column names from each leaf chunk's `path_in_schema`, whose
-            # FIRST segment is the column that leaf belongs to: a `string[]` column reads
-            # 'common_names_en, list, element', a struct 'bbox, xmin', a map
-            # 'tags, key_value, key', a plain column just its own name.
-            #
-            # `parquet_schema`'s flat name list cannot answer this. The parquet schema is a
-            # TREE flattened in pre-order, and a LIST / STRUCT / MAP column is a group node
-            # whose physical `type` is NULL — the same NULL that marks the schema root. So
-            # filtering on `type IS NOT NULL` to drop the root also drops the column itself,
-            # and it kept the group's machinery leaves ('element', 'key', 'value', struct
-            # fields) instead. Both halves misfire: every declared nested column HARD-failed
-            # `declared-column-absent` while its leaves read as phantom top-level columns
-            # (iucn-taxonomy-2025: 9 populated `string[]` columns reported absent, plus an
-            # 'element' undocumented-column advisory). Splitting the leaf path is exact and
-            # needs no ordering assumption. It also covers the `bbox` struct, whose fallback
-            # below stays for a writer that emits xmin/ymin as real top-level columns.
-            #
-            # `parquet_metadata` is the column-chunk footer, so this remains a footer read.
-            # A file with no row groups has no chunks and so drops out of both the presence
-            # map and `total`, which is what we want: an empty file has no data to disagree
-            # with the STAC, and counting it would report every column missing from it.
-            rows = mcp.query(
-                "SELECT lower(split_part(path_in_schema, ', ', 1)) AS name, "
-                f"COUNT(DISTINCT file_name) AS nf FROM parquet_metadata('{s3}') GROUP BY 1")
+            missing = mcp.query(
+                ctes + f"SELECT d.name AS name, COALESCE(p.nf, 0) AS nf, t.n AS total "
+                f"FROM (VALUES {cmp_values}) d(name) CROSS JOIN total t "
+                "LEFT JOIN present p ON p.name = d.name "
+                "WHERE t.n > 0 AND COALESCE(p.nf, 0) < t.n ORDER BY 1")
+            extra = mcp.query(
+                ctes + "SELECT p.name AS name, t.n AS total FROM present p CROSS JOIN total t "
+                f"WHERE t.n > 0 AND p.nf = t.n AND p.name NOT IN "
+                f"(SELECT * FROM (VALUES {known_values}) k(name)) ORDER BY 1")
         except (MCPError, ValueError, KeyError, IndexError) as e:
             out.append(Finding(ADVISORY, "schema-match-check-failed",
                                f"asset '{key}': could not read parquet footers ({e})."))
             continue
-        if not total:
-            continue
-        present = {}
-        for r in rows:
+        for r in missing:
             try:
-                present[str(r["name"]).lower()] = int(r["nf"])
+                low, nf, total = str(r["name"]).lower(), int(r["nf"]), int(r["total"])
             except (KeyError, ValueError, TypeError):
                 continue
-        # a `bbox` declared as one column may be stored as a covering struct — treat it as
-        # present if its leaves are (in as many files as the leaves appear).
-        bbox_leaf_files = (min((present[l] for l in _BBOX_COVER if l in present), default=0))
-
-        declared_lower = set()
-        for name in declared:
-            low = name.lower()
-            declared_lower.add(low)
-            if low in part_keys or _is_geom_col(name):
-                continue  # path-supplied partition key / writer-named geometry column
-            nf = present.get(low, 0)
-            if low == "bbox" and nf == 0:
-                nf = bbox_leaf_files  # covering-struct case
+            name = original.get(low, low)
             if nf == 0:
                 out.append(Finding(HARD, "declared-column-absent",
                     f"asset '{key}': STAC declares column '{name}' but it is absent from "
                     f"all {total} parquet file(s) — a stale/incorrect schema; fix the STAC "
                     f"table:columns."))
-            elif nf < total:
+            else:
                 out.append(Finding(HARD, "declared-column-heterogeneous",
                     f"asset '{key}': STAC declares column '{name}' but it is missing from "
                     f"{total - nf} of {total} parquet file(s) — a partial/mixed-vintage "
                     f"build; rebuild the asset. See data-workflows#534/#520."))
-        for low, nf in sorted(present.items()):
-            if (nf == total and low not in declared_lower and low not in part_keys
-                    and not _is_geom_col(low) and low not in _BBOX_COVER and low != "bbox"):
-                out.append(Finding(ADVISORY, "undocumented-column",
-                    f"asset '{key}': parquet column '{low}' is present in all {total} "
-                    f"file(s) but not declared in table:columns — add it (assets must be "
-                    f"self-describing) or confirm it is intentional."))
+        for r in extra:
+            try:
+                low, total = str(r["name"]).lower(), int(r["total"])
+            except (KeyError, ValueError, TypeError):
+                continue
+            if _is_geom_col(low) or low in _BBOX_COVER or low.endswith("_bbox"):
+                continue
+            out.append(Finding(ADVISORY, "undocumented-column",
+                f"asset '{key}': parquet column '{low}' is present in all {total} "
+                f"file(s) but not declared in table:columns — add it (assets must be "
+                f"self-describing) or confirm it is intentional."))
     return out
 
 

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -20,6 +20,7 @@ Run: python3 -m unittest discover -s tests -v
 """
 import importlib.util
 import pathlib
+import re
 import unittest
 
 _SRC = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "verify-stac.py"
@@ -246,7 +247,7 @@ def _schema_doc(declared, href=HEX_HREF):
 
 def _schema_mcp(total, name_nf):
     return ScriptedMCP([
-        ("AS n FROM parquet_schema", [{"n": total}]),   # total-files query
+        ("AS n FROM parquet_metadata", [{"n": total}]),   # total-files query
         ("GROUP BY 1", [{"name": n, "nf": nf} for n, nf in name_nf.items()]),
     ])
 
@@ -293,6 +294,76 @@ class DeclaredSchemaMatch(unittest.TestCase):
                "table:columns": [{"name": "_cng_fid"}, {"name": "geom"}]}}}
         f = vs.check_declared_schema_matches_data(doc, _schema_mcp(1, {"_cng_fid": 1}))
         self.assertEqual(f, [])
+
+    def test_column_names_come_from_the_leaf_path_not_the_flat_name_list(self):
+        # Dependency-free guard on the generated SQL: a nested column is a group node with
+        # a NULL physical type, so any name list filtered on `type IS NOT NULL` loses it.
+        doc = _schema_doc(["_cng_fid"])
+        mcp = _schema_mcp(1, {"_cng_fid": 1})
+        vs.check_declared_schema_matches_data(doc, mcp)
+        grouped = [s for s in mcp.sql if "GROUP BY 1" in s][0]
+        self.assertIn("path_in_schema", grouped)
+        self.assertNotIn("type IS NOT NULL", grouped)
+
+
+class DeclaredSchemaMatchNestedColumns(unittest.TestCase):
+    """Run the generated SQL against a REAL parquet footer carrying LIST / STRUCT / MAP
+    columns, rather than trusting that the SQL text looks right.
+
+    iucn-taxonomy-2025 is the live case: nine populated `string[]` columns
+    (`common_names_en`, `synonyms`, `threat_codes`, …) were each reported HARD as
+    "absent from all 1 parquet file(s)", and the LIST's `element` leaf was reported as an
+    undocumented top-level column. Acting on either finding would have deleted correct
+    schema documentation or documented a column that does not exist.
+    """
+
+    ROWS = ("SELECT 1 AS _cng_fid, ['a','b'] AS names, {'p': 1, 'q': 2} AS box, "
+            "MAP{'k':'v'} AS tags, 'x' AS plain")
+
+    def _run(self, declared):
+        try:
+            import duckdb
+        except ImportError:                      # pragma: no cover - CI installs it
+            self.skipTest("duckdb not installed")
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "data_0.parquet"
+            con = duckdb.connect()
+            con.execute(f"COPY ({self.ROWS}) TO '{path}' (FORMAT PARQUET)")
+
+            class Exec:
+                """Point the check's footer reads at the local file. Both function names
+                are rewritten so this test is a true red/green against either
+                implementation instead of erroring out on the s3 path."""
+
+                def query(self, sql):
+                    sql = re.sub(r"parquet_(metadata|schema)\('[^']*'\)",
+                                 lambda m: f"parquet_{m.group(1)}('{path}')", sql)
+                    cur = con.execute(sql)
+                    names = [d[0] for d in cur.description]
+                    return [dict(zip(names, r)) for r in cur.fetchall()]
+
+            return vs.check_declared_schema_matches_data(_schema_doc(declared), Exec())
+
+    def test_declared_nested_columns_are_not_reported_absent(self):
+        # THE iucn-taxonomy case: every one of these exists and holds data.
+        self.assertEqual(self._run(["_cng_fid", "names", "box", "tags", "plain"]), [],
+                         "a LIST / STRUCT / MAP column must not read as absent")
+
+    def test_nested_machinery_is_not_an_undocumented_column(self):
+        # 'element', 'key', 'value' and the struct's fields are parts of a column, not
+        # columns; only the three real undeclared columns may be reported.
+        f = self._run(["_cng_fid", "plain"])
+        self.assertEqual({x.code for x in f}, {"undocumented-column"})
+        named = sorted(re.search(r"parquet column '([^']+)'", x.message).group(1) for x in f)
+        self.assertEqual(named, ["box", "names", "tags"])
+
+    def test_a_genuinely_absent_column_still_hard_fails(self):
+        # Mutation guard: the fix must not blind the check it is fixing.
+        f = self._run(["_cng_fid", "names", "box", "tags", "plain", "ghost"])
+        self.assertEqual([x.code for x in f], ["declared-column-absent"])
+        self.assertEqual(f[0].severity, vs.HARD)
+        self.assertIn("ghost", f[0].message)
 
 
 # --- #535: a vector hex must hold every feature of its flat GeoParquet -------

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -245,11 +245,41 @@ def _schema_doc(declared, href=HEX_HREF):
                                  "table:columns": [{"name": n} for n in declared]}}}
 
 
+class _SchemaMCP:
+    """Emulate the two discrepancy queries the check runs, from a
+    {column: number-of-files-containing-it} map.
+
+    Both comparisons happen in SQL and return only the columns that DISAGREE, so a stub
+    replaying a whole column list would not exercise what the check actually asks for.
+    The declared / known name lists are read back out of the SQL's VALUES clause.
+    """
+
+    def __init__(self, total, name_nf):
+        self.total, self.name_nf, self.sql = total, name_nf, []
+
+    @staticmethod
+    def _values(sql, marker):
+        head = sql.split(marker)[0]
+        return re.findall(r"\('([^']*)'\)", head[head.rfind("(VALUES"):])
+
+    def query(self, sql):
+        self.sql.append(sql)
+        if not self.total:
+            return []
+        if "LEFT JOIN present" in sql:
+            return [{"name": n, "nf": self.name_nf.get(n, 0), "total": self.total}
+                    for n in self._values(sql, ") d(name)")
+                    if self.name_nf.get(n, 0) < self.total]
+        if "FROM present p CROSS JOIN total" in sql:
+            known = self._values(sql, ") k(name)")
+            return [{"name": n, "total": self.total}
+                    for n, nf in sorted(self.name_nf.items())
+                    if nf == self.total and n not in known]
+        raise AssertionError(f"unscripted query: {sql}")
+
+
 def _schema_mcp(total, name_nf):
-    return ScriptedMCP([
-        ("AS n FROM parquet_metadata", [{"n": total}]),   # total-files query
-        ("GROUP BY 1", [{"name": n, "nf": nf} for n, nf in name_nf.items()]),
-    ])
+    return _SchemaMCP(total, name_nf)
 
 
 class DeclaredSchemaMatch(unittest.TestCase):
@@ -306,61 +336,79 @@ class DeclaredSchemaMatch(unittest.TestCase):
         self.assertNotIn("type IS NOT NULL", grouped)
 
 
-class DeclaredSchemaMatchNestedColumns(unittest.TestCase):
-    """Run the generated SQL against a REAL parquet footer carrying LIST / STRUCT / MAP
-    columns, rather than trusting that the SQL text looks right.
+class DeclaredSchemaMatchAgainstRealParquet(unittest.TestCase):
+    """Run the generated SQL against a REAL parquet footer, under the MCP's own result-row
+    cap, rather than trusting that the SQL text looks right.
 
-    iucn-taxonomy-2025 is the live case: nine populated `string[]` columns
-    (`common_names_en`, `synonyms`, `threat_codes`, …) were each reported HARD as
-    "absent from all 1 parquet file(s)", and the LIST's `element` leaf was reported as an
-    undocumented top-level column. Acting on either finding would have deleted correct
-    schema documentation or documented a column that does not exist.
+    Two live shapes this pins, both of which reported columns that exist as absent:
+
+      * NESTED columns — iucn-taxonomy-2025's nine populated `string[]` columns
+        (`common_names_en`, `synonyms`, `threat_codes`, …) each read as "absent from all 1
+        parquet file(s)" while the LIST's `element` leaf read as an undocumented top-level
+        column.
+      * WIDE assets — gbif-hex-2026-06 has 61 top-level columns and the MCP returns at
+        most 50 rows, so whichever 11 fell off the end read as absent.
+
+    Acting on either would have deleted correct schema documentation.
     """
 
-    ROWS = ("SELECT 1 AS _cng_fid, ['a','b'] AS names, {'p': 1, 'q': 2} AS box, "
+    MCP_ROW_CAP = 50   # the MCP query tool's result cap, reproduced here on purpose
+    ROWS = ("SELECT 1 AS _cng_fid, ['a','b'] AS names, {'xmin': 1, 'xmax': 2} AS bbox, "
             "MAP{'k':'v'} AS tags, 'x' AS plain")
 
-    def _run(self, declared):
+    def _run(self, declared, rows_sql=None):
         try:
             import duckdb
         except ImportError:                      # pragma: no cover - CI installs it
             self.skipTest("duckdb not installed")
         import tempfile
+        cap = self.MCP_ROW_CAP
         with tempfile.TemporaryDirectory() as tmp:
             path = pathlib.Path(tmp) / "data_0.parquet"
             con = duckdb.connect()
-            con.execute(f"COPY ({self.ROWS}) TO '{path}' (FORMAT PARQUET)")
+            con.execute(f"COPY ({rows_sql or self.ROWS}) TO '{path}' (FORMAT PARQUET)")
 
             class Exec:
-                """Point the check's footer reads at the local file. Both function names
-                are rewritten so this test is a true red/green against either
-                implementation instead of erroring out on the s3 path."""
+                """Point the check's footer reads at the local file, and truncate the way
+                the MCP does. Both function names are rewritten so this is a true
+                red/green against either implementation rather than erroring on the s3
+                path."""
 
                 def query(self, sql):
                     sql = re.sub(r"parquet_(metadata|schema)\('[^']*'\)",
                                  lambda m: f"parquet_{m.group(1)}('{path}')", sql)
                     cur = con.execute(sql)
                     names = [d[0] for d in cur.description]
-                    return [dict(zip(names, r)) for r in cur.fetchall()]
+                    return [dict(zip(names, r)) for r in cur.fetchall()][:cap]
 
             return vs.check_declared_schema_matches_data(_schema_doc(declared), Exec())
 
     def test_declared_nested_columns_are_not_reported_absent(self):
-        # THE iucn-taxonomy case: every one of these exists and holds data.
-        self.assertEqual(self._run(["_cng_fid", "names", "box", "tags", "plain"]), [],
+        # THE iucn-taxonomy case: every one of these exists and holds data. `bbox` is the
+        # GeoParquet 1.1 covering struct, declared as one column and stored as leaves.
+        self.assertEqual(self._run(["_cng_fid", "names", "bbox", "tags", "plain"]), [],
                          "a LIST / STRUCT / MAP column must not read as absent")
 
     def test_nested_machinery_is_not_an_undocumented_column(self):
-        # 'element', 'key', 'value' and the struct's fields are parts of a column, not
-        # columns; only the three real undeclared columns may be reported.
+        # 'element', 'key', 'value' and the struct's leaves are parts of a column, not
+        # columns; only the real undeclared columns may be reported. An undeclared bbox
+        # covering stays exempt — it is spatial-index machinery, not authored schema.
         f = self._run(["_cng_fid", "plain"])
         self.assertEqual({x.code for x in f}, {"undocumented-column"})
         named = sorted(re.search(r"parquet column '([^']+)'", x.message).group(1) for x in f)
-        self.assertEqual(named, ["box", "names", "tags"])
+        self.assertEqual(named, ["names", "tags"])
+
+    def test_a_wide_asset_survives_the_result_row_cap(self):
+        # THE gbif case: more columns than the MCP will return rows. Diffing a truncated
+        # column list in Python reports the tail as absent; diffing in SQL returns only
+        # the (here empty) discrepancy list.
+        wide = [f"c{i:02d}" for i in range(self.MCP_ROW_CAP + 11)]
+        f = self._run(wide, rows_sql="SELECT " + ", ".join(f"{i} AS {c}" for i, c in enumerate(wide)))
+        self.assertEqual(f, [], "a wide asset must not report its tail columns as absent")
 
     def test_a_genuinely_absent_column_still_hard_fails(self):
         # Mutation guard: the fix must not blind the check it is fixing.
-        f = self._run(["_cng_fid", "names", "box", "tags", "plain", "ghost"])
+        f = self._run(["_cng_fid", "names", "bbox", "tags", "plain", "ghost"])
         self.assertEqual([x.code for x in f], ["declared-column-absent"])
         self.assertEqual(f[0].severity, vs.HARD)
         self.assertIn("ghost", f[0].message)


### PR DESCRIPTION
This PR proposes two fixes to `verify-stac.py`'s `check_declared_schema_matches_data`, which currently reports parquet columns that exist — and hold data — as `declared-column-absent`. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/322. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

**1. A nested column is read as absent.** The presence map came from `parquet_schema(...) WHERE type IS NOT NULL`. That filter drops the schema root — but the parquet schema is a tree, and a `LIST` / `STRUCT` / `MAP` column is a group node whose physical `type` is *also* NULL. So the filter dropped the column itself and kept its machinery leaves (`element`, `key`, `value`, struct fields) in its place. Every declared nested column then failed HARD, and its leaves were reported as undocumented top-level columns.

**2. Any asset wider than 50 columns loses its tail.** The check read the whole column list back over the MCP and diffed it in Python. The MCP query tool caps a result at 50 rows, so column 51 onwards silently vanished from the comparison and was reported absent. `GROUP BY` is unordered, so which columns fell off changed between runs on the same asset. This is exactly the failure `check_values_match_distinct` already documents and sidesteps by pushing its set-difference into DuckDB.

Both are live on the published catalog, and both are HARD, so `verify-stac.py` exits 1 and the advice it prints ("fix the STAC `table:columns`") would delete correct documentation.

## Reproduction at current HEAD (86f09eb)

```
$ python3 scripts/verify-stac.py --no-recall https://s3-west.nrp-nautilus.io/public-iucn/taxonomy/stac-collection.json
[HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'common_names_en' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
... 8 more, one per string[] column ...
[ADVISORY][undocumented-column] [iucn-taxonomy-2025] asset 'taxonomy-parquet': parquet column 'element' is present in all 1 file(s) but not declared in table:columns
  9 hard, 3 advisory

FAIL: 9 hard finding(s) across 1 collection(s).
```

All nine exist and are populated — `SELECT common_names_en FROM read_parquet('s3://public-iucn/taxonomy/iucn-taxonomy.parquet') WHERE common_names_en IS NOT NULL LIMIT 1` returns `['Caucasian Woodsia']`. What the old query looked at is the LIST group node: `SELECT name, type, converted_type FROM parquet_schema(...) WHERE name = 'common_names_en'` gives `type = NULL, converted_type = LIST`, so `type IS NOT NULL` discards it.

The width cap is just as easy to see. `gbif-hex-2026-06` has 61 top-level columns, and the grouped presence query returns 50 rows:

```sql
SELECT COUNT(*) FROM (SELECT DISTINCT lower(split_part(path_in_schema, ', ', 1))
                      FROM parquet_metadata('s3://public-gbif/2026-06/hex/h0=*/data_0.parquet'));
-- 61
```

## The change

A column's name now comes from its leaf chunk's `path_in_schema`, whose first segment is the column that leaf belongs to (`common_names_en, list, element` → `common_names_en`; `bbox, xmin` → `bbox`). That is exact, needs no assumption about schema row order, and covers structs and maps as well as lists — it also subsumes the `bbox` covering-struct special case, which is why that one goes away. `parquet_metadata` is the column-chunk footer, so this stays a footer read, and the CTE is `MATERIALIZED` so each query reads it once.

Both comparisons then run in SQL and return only the discrepancies — declared columns whose file count is short, and undocumented columns present in every file — so the result is bounded by the number of problems rather than the width of the table, and is normally empty.

Deliberately unchanged: the per-file grain that `#534` exists for (`COUNT(DISTINCT file_name)` per column, so the `#520` heterogeneous hole still reads as `declared-column-heterogeneous`), the severities, the finding codes, and the message text. A file with no row groups now drops out of both the presence map and the file count, which is the honest reading — an empty file has no data to disagree with the STAC.

## Verification

`python3 -m unittest discover -s tests` — 36 tests, green, both with and without `duckdb` installed. Against upstream HEAD the four new tests plus the six updated ones fail (10 failures); with the change all 36 pass. The new tests execute the generated SQL against a real parquet file carrying `LIST`, `STRUCT`, `MAP` and 61-column shapes, through a stub that truncates at 50 rows the way the MCP does — so they fail if either defect returns. One is a mutation guard: a genuinely absent declared column must still fail HARD, and does.

End to end on the live collection above: `9 hard, 3 advisory` / `FAIL` becomes `0 hard, 2 advisory` / `PASS`, with the two genuine advisories (`geoparquet-no-geom-column`, `cng-fid-missing-nonspatial`) retained.

Because the change touches a gate rather than a dataset, I also ran the check across 117 published collections before and after. `declared-column-absent` goes from 1,179 findings across 26 collections to 6 — and all 6 also fired before, so no new HARD finding appears anywhere: `wdoecm-parquet OBJECTID`, `glwd-class-area-hex h0`, `regions-hex cartography` / `population` / `wikidata`, and `imma-hex bbox`. Those look like genuine stale declarations worth a look, but they are yours to judge and are untouched here. The `undocumented-column` advisories go from 443 to 384: 38 nested machinery names (`element`, `key`, `value`, and the Overture struct fields) stop being reported, while real undeclared columns the 50-row cap had been hiding — `identifiedby`, `recordedby`, `mrgid_sov5`, and `h4` / `h6` / `h7` / `h9` on the GBIF hex — now surface. An undeclared bbox covering stays exempt, as before. Six assets that previously answered `schema-match-check-failed` are now checked, since `parquet_metadata` does not bind column names the way the old query did.

## How this was managed

Your issues and pull requests were imported to a live board, and this fix was tracked there as its own story: [the story for this work](https://eastagiletracker.com/projects/322/stories/210350), on [the board](https://eastagiletracker.com/projects/322).

![board](https://raw.githubusercontent.com/eastagiletracker/data-workflows/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
