### PR TITLE
feat(#532): reconcile-column-descriptions tool + catalog-wide divergence cleanup

### DIFF
--- a/scripts/reconcile-column-descriptions.py
+++ b/scripts/reconcile-column-descriptions.py
@@ -62,8 +62,22 @@ FLAT_SPECIFIC = re.compile(
     re.I)
 
 
+# Index / key columns are never per-feature magnitudes — they must not be named in a
+# "never SUM, dedup" note even if their hex text happens to mention repetition.
+SAFE_COLS = {"_cng_fid", "bbox", "fid", "ogc_fid", "objectid"}
+_H3 = re.compile(r"^h\d{1,2}$")
+
+
 def norm(s: str) -> str:
     return re.sub(r"\s+", " ", s or "").strip()
+
+
+def grain_neutral(text: str) -> str:
+    """Drop whole sentences that make a flat-grain-specific claim, leaving a canonical text
+    true on every asset. Returns '' if nothing survives (then the column needs judgment)."""
+    parts = re.split(r"(?<=[.!?])\s+", text.strip())
+    kept = [p for p in parts if p and not FLAT_SPECIFIC.search(p)]
+    return norm(" ".join(kept))
 
 
 def fetch(url: str) -> dict:
@@ -108,68 +122,149 @@ def divergent_columns(doc: dict) -> dict:
     return {n: d for n, d in m.items() if len({norm(x) for x in d.values()}) > 1}
 
 
-def reconcile(doc: dict, verbose=False) -> dict:
+def _h3_canonical(name: str) -> str:
+    """Grain-neutral text for an H3 index column. Grain (native vs rollup) is declared by
+    h3:native_resolution / h3:parent_resolutions on the asset, so the column text must not
+    encode it (that is exactly what makes h-columns diverge across hex/hex-fractions)."""
+    n = int(name[1:])
+    if n == 0:
+        return "H3 cell ID at resolution 0; the Hive partition key for hive-partitioned reads."
+    return f"H3 cell ID at resolution {n}."
+
+
+def _has_cng_fid(asset: dict) -> bool:
+    """A vector feature hex carries _cng_fid; a raster reduction (categorical/continuous hex)
+    does not. A '_cng_fid dedup' note only makes sense on the former."""
+    return any(c.get("name") == "_cng_fid" for c in asset.get("table:columns", []))
+
+
+def _apply_canonical(doc: dict, name: str, canonical: str, report: dict,
+                     stripped_by_asset: dict) -> None:
+    """Set `canonical` as the description of `name` on every asset that carries it, recording
+    any hex per-feature-magnitude column whose inline dedup clause is thereby stripped."""
+    for ak, a in doc.get("assets", {}).items():
+        for c in a.get("table:columns", []):
+            if c.get("name") != name:
+                continue
+            old = c.get("description", "")
+            if norm(old) == norm(canonical):
+                continue
+            # Only a vector feature hex (has _cng_fid) can carry a per-feature dedup note.
+            # A raster reduction hex has no _cng_fid — its "do not SUM" is a categorical
+            # caution, not a per-feature-duplication clause, so never relocate one there.
+            if (is_hex_href(a.get("href", "")) and DEDUP_CLAUSE.search(old)
+                    and name.lower() not in SAFE_COLS and not _H3.match(name)
+                    and _has_cng_fid(a)):
+                stripped_by_asset.setdefault(ak, []).append(name)
+            c["description"] = canonical
+    report["changed"].append(name)
+
+
+def _ensure_hex_notes(doc: dict, stripped_by_asset: dict, report: dict) -> None:
+    """Relocate stripped per-feature dedup clauses to the hex asset description (the location
+    the #303 fold always renders and that satisfies check_hex_dup_warning)."""
+    for ak, names in stripped_by_asset.items():
+        asset = doc["assets"][ak]
+        if ASSET_NOTE.search(asset.get("description", "") or ""):
+            continue
+        uniq = sorted(set(names))
+        note = (f" Per-feature attribute columns ({', '.join(uniq)}) are repeated on every "
+                f"hex cell the feature covers, so a raw SUM over hex rows double-counts; dedup "
+                f"by _cng_fid first, e.g. SELECT DISTINCT _cng_fid, {uniq[0]}.")
+        asset["description"] = ((asset.get("description", "") or "").rstrip() + note).strip()
+        report["hex_notes_added"].append({"asset": ak, "columns": uniq})
+
+
+def _apply_overrides(doc: dict, ov: dict, report: dict, stripped_by_asset: dict) -> None:
+    """Apply a hand-authored per-collection override: set canonical text for named columns on
+    every asset, and append any asset-specific notes to the named asset descriptions."""
+    for name, text in (ov.get("columns") or {}).items():
+        _apply_canonical(doc, name, text, report, stripped_by_asset)
+        report.setdefault("overridden", []).append(name)
+    for ak, note in (ov.get("asset_notes") or {}).items():
+        if ak in doc.get("assets", {}):
+            cur = doc["assets"][ak].get("description", "") or ""
+            if norm(note) not in norm(cur):
+                doc["assets"][ak]["description"] = (cur.rstrip() + " " + note).strip()
+
+
+def _resolve_generic(doc: dict, name: str, per: dict, report: dict,
+                     stripped_by_asset: dict) -> bool:
+    """Resolve a divergent column with no flat canonical by the safe mechanical rules:
+    grain-neutral H3 columns, or a clean superset (one variant contains all the others).
+    Returns True if resolved; False means it needs a hand-authored override."""
+    if _H3.match(name):
+        _apply_canonical(doc, name, _h3_canonical(name), report, stripped_by_asset)
+        return True
+    longest = max(per.values(), key=lambda t: len(norm(t)))
+    if all(norm(v) in norm(longest) for v in per.values()):
+        base = min(per.values(), key=lambda t: len(norm(t)))
+        _apply_canonical(doc, name, base, report, stripped_by_asset)
+        return True
+    return False
+
+
+def reconcile(doc: dict, verbose=False, allow_no_flat=False, overrides=None) -> dict:
     """Mutate doc in place. Return a report dict."""
     report = {"id": doc.get("id", "?"), "status": "ok", "changed": [], "skipped": [],
               "hex_notes_added": [], "reason": ""}
+    stripped_by_asset: dict[str, list[str]] = {}
+
+    # 1) Hand-authored overrides first (judgment cohort). They win over any auto rule.
+    ov = (overrides or {}).get(doc.get("id", ""), {})
+    if ov:
+        _apply_overrides(doc, ov, report, stripped_by_asset)
+
     div = divergent_columns(doc)
     if not div:
-        report["status"] = "already-clean"
+        _ensure_hex_notes(doc, stripped_by_asset, report)
+        report["status"] = "already-clean" if not report["changed"] else "ok"
         return report
+
     fk = flat_asset_key(doc)
-    if not fk:
+    if fk:
+        # 2a) AUTO cohort: canonical = the flat GeoParquet asset's text.
+        flat_cols = {c.get("name", ""): c.get("description", "")
+                     for c in doc["assets"][fk].get("table:columns", [])}
+        for name in sorted(div):
+            if name not in flat_cols or not flat_cols[name]:
+                # Column absent from the flat asset (typically a hex-only H3 index). Fall back
+                # to the mechanical no-flat rules; only skip if those can't resolve it.
+                if allow_no_flat and _resolve_generic(doc, name, div[name], report,
+                                                      stripped_by_asset):
+                    continue
+                report["skipped"].append(name)
+                report.setdefault("skip_reasons", {})[name] = "not on flat asset"
+                continue
+            canonical = flat_cols[name]
+            if FLAT_SPECIFIC.search(canonical):
+                scrubbed = grain_neutral(canonical)
+                if scrubbed and not FLAT_SPECIFIC.search(scrubbed):
+                    canonical = scrubbed
+                    report.setdefault("scrubbed", []).append(name)
+                else:
+                    report["skipped"].append(name)
+                    report.setdefault("skip_reasons", {})[name] = "flat text wholly grain-specific"
+                    continue
+            _apply_canonical(doc, name, canonical, report, stripped_by_asset)
+    elif allow_no_flat:
+        # 2b) JUDGMENT cohort: no flat canonical. Auto-resolve only the safe, mechanical
+        # classes — grain-neutral H3 columns and clean supersets (one variant is a superset
+        # of the others). Genuine data-column divergences are left for --overrides.
+        for name, per in sorted(div.items()):
+            if not _resolve_generic(doc, name, per, report, stripped_by_asset):
+                report["skipped"].append(name)
+                report.setdefault("skip_reasons", {})[name] = "genuine divergence (needs override)"
+    else:
         report["status"] = "judgment"
         report["reason"] = "no flat GeoParquet asset"
         report["skipped"] = sorted(div)
         return report
-    flat_cols = {c.get("name", ""): c.get("description", "")
-                 for c in doc["assets"][fk].get("table:columns", [])}
 
-    # Per hex asset, the per-feature-total column names whose inline dedup clause we strip.
-    stripped_by_asset: dict[str, list[str]] = {}
-
-    for name, per in sorted(div.items()):
-        if name not in flat_cols or not flat_cols[name]:
-            report["skipped"].append(name)
-            report.setdefault("skip_reasons", {})[name] = "not on flat asset"
-            continue
-        canonical = flat_cols[name]
-        if FLAT_SPECIFIC.search(canonical):
-            report["skipped"].append(name)
-            report.setdefault("skip_reasons", {})[name] = "flat text is grain-specific"
-            continue
-        # Apply canonical to every asset that carries this column; record hex strips.
-        for ak, a in doc.get("assets", {}).items():
-            for c in a.get("table:columns", []):
-                if c.get("name") != name:
-                    continue
-                old = c.get("description", "")
-                if norm(old) == norm(canonical):
-                    continue
-                if is_hex_href(a.get("href", "")) and DEDUP_CLAUSE.search(old):
-                    stripped_by_asset.setdefault(ak, []).append(name)
-                c["description"] = canonical
-        report["changed"].append(name)
-
-    # Ensure the per-feature dedup note survives at the hex asset description level — the
-    # location the #303 fold always renders and that satisfies check_hex_dup_warning. Added
-    # only when we actually stripped an inline clause and the hex asset lacks its own note.
-    for ak, names in stripped_by_asset.items():
-        asset = doc["assets"][ak]
-        if ASSET_NOTE.search(asset.get("description", "") or ""):
-            continue  # already carries a note
-        cols_list = ", ".join(sorted(set(names)))
-        note = (f" Per-feature attribute columns ({cols_list}) are repeated on every hex "
-                f"cell the feature covers, so a raw SUM over hex rows double-counts; dedup "
-                f"by _cng_fid first, e.g. SELECT DISTINCT _cng_fid, {sorted(set(names))[0]}.")
-        asset["description"] = (asset.get("description", "") or "").rstrip()
-        asset["description"] = (asset["description"] + note).strip()
-        report["hex_notes_added"].append({"asset": ak, "columns": sorted(set(names))})
-
-    # Post-check: recompute divergences.
+    _ensure_hex_notes(doc, stripped_by_asset, report)
     remaining = divergent_columns(doc)
     report["remaining"] = sorted(remaining)
-    if remaining and not report["skipped"]:
+    if remaining:
         report["status"] = "partial"
     return report
 
@@ -181,6 +276,13 @@ def main():
     p.add_argument("--bucket", help="bucket (with --dataset) to derive the collection URL")
     p.add_argument("--dataset", default="")
     p.add_argument("--out", default="/tmp/recon", help="output dir for reconciled JSON")
+    p.add_argument("--no-flat", action="store_true",
+                   help="also reconcile collections with no flat GeoParquet asset (JUDGMENT "
+                        "cohort): grain-neutral H3 columns + clean supersets auto; genuine "
+                        "data-column divergences need --overrides")
+    p.add_argument("--overrides", help="JSON file of hand-authored canonical text: "
+                                       "{collection_id: {columns: {col: text}, "
+                                       "asset_notes: {asset_key: note}}}")
     p.add_argument("--verbose", action="store_true")
     args = p.parse_args()
 
@@ -191,12 +293,14 @@ def main():
     if not srcs:
         p.error("provide a collection URL/file or --bucket [--dataset]")
 
+    overrides = json.loads(Path(args.overrides).read_text()) if args.overrides else None
     outdir = Path(args.out)
     outdir.mkdir(parents=True, exist_ok=True)
     reports = []
     for src in srcs:
         doc = load(src)
-        rep = reconcile(doc, verbose=args.verbose)
+        rep = reconcile(doc, verbose=args.verbose, allow_no_flat=args.no_flat,
+                        overrides=overrides)
         reports.append(rep)
         if rep["status"] in ("ok", "partial") and rep["changed"]:
             cid = doc.get("id", "collection")
@@ -210,6 +314,8 @@ def main():
             print(f"  reason: {rep['reason']}")
         if rep["changed"]:
             print(f"  reconciled ({len(rep['changed'])}): {', '.join(rep['changed'])}")
+        if rep.get("scrubbed"):
+            print(f"  (grain-specific clause scrubbed from: {', '.join(rep['scrubbed'])})")
         for hn in rep["hex_notes_added"]:
             print(f"  + hex note on '{hn['asset']}' for: {', '.join(hn['columns'])}")
         if rep["skipped"]:

--- a/scripts/reconcile-column-descriptions.py
+++ b/scripts/reconcile-column-descriptions.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Reconcile divergent per-column descriptions in a STAC collection (data-workflows#532).
+
+`get_stac_details` folds per-column `description` text across all assets in a collection and
+**first-seen wins** (mcp-data-server#303), so a column documented two ways loses one version
+silently. `verify-stac.py check_column_description_consistency` reports each such
+`column-description-divergent`. This tool fixes them mechanically for the AUTO cohort:
+
+    canonical text = the flat GeoParquet asset's text for that column, applied to EVERY asset.
+
+The flat GeoParquet is the documented single authority (AGENTS.md). Any per-feature
+duplication note that lived inline on a hex column is not deleted — it is ensured at the hex
+asset `description` level, which is the location the renderer always surfaces and which
+satisfies `verify-stac.py check_hex_dup_warning` for the whole asset.
+
+Two safety guards, because a flat text is not always grain-neutral:
+  * If the flat canonical text contains a FLAT-GRAIN-SPECIFIC claim that would be false on a
+    hex asset (e.g. "one row per case on the flat GeoParquet, so SUM is correct here"), the
+    column is NOT auto-set — it is reported as needs-judgment and left untouched.
+  * A collection with no flat GeoParquet asset, or with a divergent column absent from the
+    flat asset, is out of scope for this tool (the #532 JUDGMENT cohort) — reported, skipped.
+
+The tool is a pure transform: it reads a collection JSON (URL / file / --bucket [--dataset])
+and writes the reconciled JSON to an output dir. It never writes to S3 (publishing is a
+separate cluster step). Run `verify-stac.py` on the output before publishing.
+
+Usage:
+    reconcile-column-descriptions.py <url-or-file> [...] [--out DIR] [--verbose]
+    reconcile-column-descriptions.py --bucket public-wdpa --dataset wdpa --out /tmp/recon
+"""
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+NRP = "https://s3-west.nrp-nautilus.io"
+GEOM = {"geom", "geometry", "shape", "the_geom"}
+
+# A hex column carrying a per-feature magnitude gets an inline dedup clause; detect it so we
+# can (a) know which columns to name in the relocated asset-level note and (b) know the clause
+# is being intentionally stripped, not lost.
+DEDUP_CLAUSE = re.compile(
+    r"repeated (on|for|across) (every|the)|never (use )?sum|do not sum|don't sum|"
+    r"dedup|deduplicat|select distinct|count\(distinct|row_number|per[- ]?feature total",
+    re.I)
+
+# Same signal verify-stac.py check_hex_dup_warning accepts at the asset/collection level.
+ASSET_NOTE = re.compile(
+    r"repeated (on|for|across) (every|the)|never (use )?sum|do not sum|don't sum|"
+    r"not safe to sum|per[- ]?feature|count\(distinct|select distinct|dedup|"
+    r"deduplicat|multiply by .*cell area|sum is the .*total|area-weighted|reducer",
+    re.I)
+
+# A flat text that makes a claim only true at the flat grain — copying it onto a hex asset
+# would render a FALSE statement for every consumer (the #512 "stale text outlives its asset"
+# trap). Such a column needs manual reconciliation, not a verbatim copy.
+FLAT_SPECIFIC = re.compile(
+    r"on the flat geoparquet|one row per .{0,40}\bflat\b|sum is correct here|"
+    r"flat asset[^s]|so sum is correct|one row per (case|feature|site|record)\b",
+    re.I)
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s or "").strip()
+
+
+def fetch(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=60) as r:
+        return json.load(r)
+
+
+def load(src: str) -> dict:
+    if src.startswith("http"):
+        return fetch(src)
+    return json.loads(Path(src).read_text())
+
+
+def is_hex_href(href: str) -> bool:
+    return "h0=" in href or "/hex/" in href
+
+
+def flat_asset_key(doc: dict) -> str | None:
+    """The flat GeoParquet asset: a non-hex parquet asset carrying a geometry column."""
+    for k, a in doc.get("assets", {}).items():
+        href = a.get("href", "")
+        if is_hex_href(href):
+            continue
+        if a.get("type", "") not in ("application/x-parquet", "application/parquet",
+                                     "application/vnd.apache.parquet"):
+            # still accept if it clearly has table:columns + a geom column
+            pass
+        cols = {c.get("name", "").lower() for c in a.get("table:columns", [])}
+        if cols & GEOM:
+            return k
+    return None
+
+
+def divergent_columns(doc: dict) -> dict:
+    """name -> {asset_key: text} for columns whose text differs across assets."""
+    m: dict[str, dict[str, str]] = {}
+    for k, a in doc.get("assets", {}).items():
+        for c in a.get("table:columns", []):
+            n, t = c.get("name", ""), c.get("description", "")
+            if n and t:
+                m.setdefault(n, {})[k] = t
+    return {n: d for n, d in m.items() if len({norm(x) for x in d.values()}) > 1}
+
+
+def reconcile(doc: dict, verbose=False) -> dict:
+    """Mutate doc in place. Return a report dict."""
+    report = {"id": doc.get("id", "?"), "status": "ok", "changed": [], "skipped": [],
+              "hex_notes_added": [], "reason": ""}
+    div = divergent_columns(doc)
+    if not div:
+        report["status"] = "already-clean"
+        return report
+    fk = flat_asset_key(doc)
+    if not fk:
+        report["status"] = "judgment"
+        report["reason"] = "no flat GeoParquet asset"
+        report["skipped"] = sorted(div)
+        return report
+    flat_cols = {c.get("name", ""): c.get("description", "")
+                 for c in doc["assets"][fk].get("table:columns", [])}
+
+    # Per hex asset, the per-feature-total column names whose inline dedup clause we strip.
+    stripped_by_asset: dict[str, list[str]] = {}
+
+    for name, per in sorted(div.items()):
+        if name not in flat_cols or not flat_cols[name]:
+            report["skipped"].append(name)
+            report.setdefault("skip_reasons", {})[name] = "not on flat asset"
+            continue
+        canonical = flat_cols[name]
+        if FLAT_SPECIFIC.search(canonical):
+            report["skipped"].append(name)
+            report.setdefault("skip_reasons", {})[name] = "flat text is grain-specific"
+            continue
+        # Apply canonical to every asset that carries this column; record hex strips.
+        for ak, a in doc.get("assets", {}).items():
+            for c in a.get("table:columns", []):
+                if c.get("name") != name:
+                    continue
+                old = c.get("description", "")
+                if norm(old) == norm(canonical):
+                    continue
+                if is_hex_href(a.get("href", "")) and DEDUP_CLAUSE.search(old):
+                    stripped_by_asset.setdefault(ak, []).append(name)
+                c["description"] = canonical
+        report["changed"].append(name)
+
+    # Ensure the per-feature dedup note survives at the hex asset description level — the
+    # location the #303 fold always renders and that satisfies check_hex_dup_warning. Added
+    # only when we actually stripped an inline clause and the hex asset lacks its own note.
+    for ak, names in stripped_by_asset.items():
+        asset = doc["assets"][ak]
+        if ASSET_NOTE.search(asset.get("description", "") or ""):
+            continue  # already carries a note
+        cols_list = ", ".join(sorted(set(names)))
+        note = (f" Per-feature attribute columns ({cols_list}) are repeated on every hex "
+                f"cell the feature covers, so a raw SUM over hex rows double-counts; dedup "
+                f"by _cng_fid first, e.g. SELECT DISTINCT _cng_fid, {sorted(set(names))[0]}.")
+        asset["description"] = (asset.get("description", "") or "").rstrip()
+        asset["description"] = (asset["description"] + note).strip()
+        report["hex_notes_added"].append({"asset": ak, "columns": sorted(set(names))})
+
+    # Post-check: recompute divergences.
+    remaining = divergent_columns(doc)
+    report["remaining"] = sorted(remaining)
+    if remaining and not report["skipped"]:
+        report["status"] = "partial"
+    return report
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sources", nargs="*", help="collection STAC URL(s) or file path(s)")
+    p.add_argument("--bucket", help="bucket (with --dataset) to derive the collection URL")
+    p.add_argument("--dataset", default="")
+    p.add_argument("--out", default="/tmp/recon", help="output dir for reconciled JSON")
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args()
+
+    srcs = list(args.sources)
+    if args.bucket:
+        seg = f"/{args.dataset}" if args.dataset else ""
+        srcs.append(f"{NRP}/{args.bucket}{seg}/stac-collection.json")
+    if not srcs:
+        p.error("provide a collection URL/file or --bucket [--dataset]")
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+    reports = []
+    for src in srcs:
+        doc = load(src)
+        rep = reconcile(doc, verbose=args.verbose)
+        reports.append(rep)
+        if rep["status"] in ("ok", "partial") and rep["changed"]:
+            cid = doc.get("id", "collection")
+            outpath = outdir / f"{cid}.stac-collection.json"
+            outpath.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+            rep["out"] = str(outpath)
+
+    for rep in reports:
+        print(f"\n=== {rep['id']} [{rep['status']}] ===")
+        if rep.get("reason"):
+            print(f"  reason: {rep['reason']}")
+        if rep["changed"]:
+            print(f"  reconciled ({len(rep['changed'])}): {', '.join(rep['changed'])}")
+        for hn in rep["hex_notes_added"]:
+            print(f"  + hex note on '{hn['asset']}' for: {', '.join(hn['columns'])}")
+        if rep["skipped"]:
+            print(f"  SKIPPED (needs judgment): {', '.join(rep['skipped'])}")
+            for n, why in rep.get("skip_reasons", {}).items():
+                print(f"      {n}: {why}")
+        if rep.get("remaining"):
+            print(f"  REMAINING divergent after run: {', '.join(rep['remaining'])}")
+        if rep.get("out"):
+            print(f"  -> {rep['out']}")
+    # exit non-zero if any collection still has remaining divergences it could not fix
+    bad = [r for r in reports if r.get("remaining")]
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -536,10 +536,11 @@ def check_column_description_consistency(doc: dict) -> list[Finding]:
         h10 text said "one row per (feature, h10) pair", true for the hex asset and wrong
         for the per-cell hex-weights assets.
 
-    ADVISORY rather than HARD for now: pre-gate collections have not been swept yet
-    (data-workflows#509), so a hard failure would block unrelated PRs. Promote to HARD
-    once the catalog is fold-clean. Columns with no description (a lean PMTiles asset,
-    per the PMTiles standard) are skipped — omitting text is not disagreeing about it.
+    HARD as of data-workflows#532: the catalog-wide backlog (99 collections, 558 columns)
+    was swept and reconciled, so a divergence is now a new regression to fix at creation, not
+    inherited debt. It shipped ADVISORY in #512 only because the pre-gate cohort had not been
+    swept yet (#509). Columns with no description (a lean PMTiles asset, per the PMTiles
+    standard) are skipped — omitting text is not disagreeing about it.
     """
     out = []
     seen: dict[str, tuple[str, str]] = {}
@@ -554,7 +555,7 @@ def check_column_description_consistency(doc: dict) -> list[Finding]:
             seen.setdefault(name, (key, text))
     for name, assets in sorted(clashes.items()):
         winner = seen[name][0]
-        out.append(Finding(ADVISORY, "column-description-divergent",
+        out.append(Finding(HARD, "column-description-divergent",
             f"column '{name}' is documented differently on {sorted(assets)} — the #303 fold "
             f"keeps the first-seen text (from '{winner}') and silently drops the others. Use "
             f"one text everywhere; put asset-specific notes in that asset's `description`."))

--- a/tests/test_reconcile_column_descriptions.py
+++ b/tests/test_reconcile_column_descriptions.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Tests for scripts/reconcile-column-descriptions.py (data-workflows#532).
+
+Stdlib unittest only, no network — the tool's transform takes a plain doc dict.
+Run: python3 -m unittest discover -s tests -v
+"""
+import importlib.util
+import pathlib
+import unittest
+
+_SRC = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "reconcile-column-descriptions.py"
+_spec = importlib.util.spec_from_file_location("reconcile_cd", _SRC)
+rc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rc)
+
+PARQUET = "application/x-parquet"
+FLAT_HREF = "https://s3-west.nrp-nautilus.io/public-x/d.parquet"
+HEX_HREF = "https://s3-west.nrp-nautilus.io/public-x/d/hex/h0=*/data_0.parquet"
+
+
+def doc_with(flat_cols, hex_cols, hex_desc="", coll_desc=""):
+    return {
+        "id": "d", "description": coll_desc,
+        "assets": {
+            "d-parquet": {"href": FLAT_HREF, "type": PARQUET, "table:columns": flat_cols},
+            "d-hex": {"href": HEX_HREF, "type": PARQUET, "description": hex_desc,
+                      "table:columns": hex_cols},
+        },
+    }
+
+
+def col(name, desc, type="string"):
+    return {"name": name, "type": type, "description": desc}
+
+
+class CanonicalFromFlat(unittest.TestCase):
+    def test_hex_column_gets_flat_text_and_note_relocates(self):
+        doc = doc_with(
+            flat_cols=[col("geom", "geometry", "geometry"),
+                       col("ALAND", "Land area in square meters.", "int64")],
+            hex_cols=[col("ALAND", "Land area in square meters. Repeated on every hex row — "
+                                   "never SUM(ALAND); dedup by _cng_fid.", "int64"),
+                      col("h0", "H3 res 0.", "int64")],
+        )
+        rep = rc.reconcile(doc)
+        self.assertEqual(rep["status"], "ok")
+        self.assertIn("ALAND", rep["changed"])
+        # hex column now equals the flat text (fold-safe)
+        hex_aland = next(c for c in doc["assets"]["d-hex"]["table:columns"]
+                         if c["name"] == "ALAND")
+        self.assertEqual(hex_aland["description"], "Land area in square meters.")
+        # dedup note relocated to the hex ASSET description
+        self.assertTrue(rc.ASSET_NOTE.search(doc["assets"]["d-hex"]["description"]))
+        self.assertIn("ALAND", doc["assets"]["d-hex"]["description"])
+        # no divergence remains
+        self.assertEqual(rc.divergent_columns(doc), {})
+
+    def test_no_note_added_when_hex_asset_already_has_one(self):
+        doc = doc_with(
+            flat_cols=[col("geom", "g", "geometry"),
+                       col("AREA", "Area km2.", "double")],
+            hex_cols=[col("AREA", "Area km2. dedup by _cng_fid; never sum.", "double")],
+            hex_desc="These per-feature totals are repeated on every cell; dedup first.",
+        )
+        before = doc["assets"]["d-hex"]["description"]
+        rep = rc.reconcile(doc)
+        self.assertIn("AREA", rep["changed"])
+        self.assertEqual(rep["hex_notes_added"], [])
+        self.assertEqual(doc["assets"]["d-hex"]["description"], before)
+
+
+class SafetyGuards(unittest.TestCase):
+    def test_flat_specific_text_is_skipped_not_copied(self):
+        # flat text makes a claim false on hex -> must NOT be copied verbatim
+        doc = doc_with(
+            flat_cols=[col("geom", "g", "geometry"),
+                       col("RCRD_ACRS", "Recorded acreage. One row per case on the flat "
+                                        "GeoParquet, so SUM is correct here.", "double")],
+            hex_cols=[col("RCRD_ACRS", "Recorded acreage. Repeated on every hex cell; "
+                                       "dedup by _cng_fid.", "double")],
+        )
+        rep = rc.reconcile(doc)
+        self.assertIn("RCRD_ACRS", rep["skipped"])
+        self.assertNotIn("RCRD_ACRS", rep["changed"])
+        # untouched -> still divergent (left for judgment)
+        self.assertIn("RCRD_ACRS", rc.divergent_columns(doc))
+
+    def test_no_flat_asset_is_judgment(self):
+        doc = {"id": "r", "description": "",
+               "assets": {
+                   "r-hex": {"href": HEX_HREF, "type": PARQUET,
+                             "table:columns": [col("v", "text A", "double")]},
+                   "r-hex-fractions": {"href": HEX_HREF.replace("hex", "hex-fractions"),
+                                       "type": PARQUET,
+                                       "table:columns": [col("v", "text B", "double")]},
+               }}
+        rep = rc.reconcile(doc)
+        self.assertEqual(rep["status"], "judgment")
+        self.assertIn("v", rep["skipped"])
+
+    def test_already_clean_is_noop(self):
+        doc = doc_with(
+            flat_cols=[col("geom", "g", "geometry"), col("X", "same", "int64")],
+            hex_cols=[col("X", "same", "int64")],
+        )
+        rep = rc.reconcile(doc)
+        self.assertEqual(rep["status"], "already-clean")
+        self.assertEqual(rep["changed"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile_column_descriptions.py
+++ b/tests/test_reconcile_column_descriptions.py
@@ -40,6 +40,7 @@ class CanonicalFromFlat(unittest.TestCase):
                        col("ALAND", "Land area in square meters.", "int64")],
             hex_cols=[col("ALAND", "Land area in square meters. Repeated on every hex row — "
                                    "never SUM(ALAND); dedup by _cng_fid.", "int64"),
+                      col("_cng_fid", "Feature id.", "int64"),
                       col("h0", "H3 res 0.", "int64")],
         )
         rep = rc.reconcile(doc)
@@ -70,20 +71,73 @@ class CanonicalFromFlat(unittest.TestCase):
 
 
 class SafetyGuards(unittest.TestCase):
-    def test_flat_specific_text_is_skipped_not_copied(self):
-        # flat text makes a claim false on hex -> must NOT be copied verbatim
+    def test_wholly_grain_specific_flat_is_skipped_not_copied(self):
+        # every sentence of the flat text is grain-specific -> nothing survives scrubbing
+        # -> must NOT be copied verbatim; left for judgment.
         doc = doc_with(
             flat_cols=[col("geom", "g", "geometry"),
-                       col("RCRD_ACRS", "Recorded acreage. One row per case on the flat "
-                                        "GeoParquet, so SUM is correct here.", "double")],
-            hex_cols=[col("RCRD_ACRS", "Recorded acreage. Repeated on every hex cell; "
-                                       "dedup by _cng_fid.", "double")],
+                       col("X", "One row per feature on the flat GeoParquet, so SUM is "
+                                "correct here.", "double")],
+            hex_cols=[col("X", "Repeated on every hex cell; dedup by _cng_fid.", "double")],
         )
         rep = rc.reconcile(doc)
-        self.assertIn("RCRD_ACRS", rep["skipped"])
-        self.assertNotIn("RCRD_ACRS", rep["changed"])
-        # untouched -> still divergent (left for judgment)
-        self.assertIn("RCRD_ACRS", rc.divergent_columns(doc))
+        self.assertIn("X", rep["skipped"])
+        self.assertNotIn("X", rep["changed"])
+        self.assertIn("X", rc.divergent_columns(doc))  # untouched -> still divergent
+
+    def test_grain_specific_sentence_is_scrubbed_then_applied(self):
+        # flat has a useful base sentence + a flat-grain-specific one; the tool keeps the
+        # base (grain-neutral) and drops the false-on-hex sentence, then applies to all.
+        doc = doc_with(
+            flat_cols=[col("geom", "g", "geometry"),
+                       col("GIS_Acres", "GIS-calculated area in acres. Most reliable area "
+                                        "measure. Safe to use directly on GeoParquet "
+                                        "(one row per feature).", "double")],
+            hex_cols=[col("GIS_Acres", "GIS-calculated area in acres. Repeated on every hex "
+                                       "cell; never SUM on hex; dedup by _cng_fid.", "double"),
+                      col("_cng_fid", "Feature id.", "int64")],
+        )
+        rep = rc.reconcile(doc)
+        self.assertIn("GIS_Acres", rep["changed"])
+        self.assertIn("GIS_Acres", rep.get("scrubbed", []))
+        text = next(c for c in doc["assets"]["d-parquet"]["table:columns"]
+                    if c["name"] == "GIS_Acres")["description"]
+        self.assertEqual(text, "GIS-calculated area in acres. Most reliable area measure.")
+        self.assertNotIn("one row per feature", text.lower())
+        self.assertEqual(rc.divergent_columns(doc), {})
+        # per-feature magnitude → dedup note relocated to hex asset
+        self.assertTrue(rc.ASSET_NOTE.search(doc["assets"]["d-hex"]["description"]))
+
+    def test_index_key_column_not_named_in_dedup_note(self):
+        # _cng_fid is a key, not a magnitude: scrubbed/reconciled but never named "never SUM"
+        doc = doc_with(
+            flat_cols=[col("geom", "g", "geometry"),
+                       col("_cng_fid", "Internal id. One row per site.", "int64")],
+            hex_cols=[col("_cng_fid", "Internal id. Repeated on every hex row the site "
+                                      "covers.", "int64")],
+        )
+        rep = rc.reconcile(doc)
+        self.assertIn("_cng_fid", rep["changed"])
+        self.assertEqual(rep["hex_notes_added"], [])  # key col not named in a SUM warning
+
+    def test_raster_hex_categorical_gets_no_cng_fid_note(self):
+        # A raster reduction hex has no _cng_fid; a categorical "do not SUM" must NOT be
+        # mistaken for a per-feature dedup clause and must not spawn a _cng_fid note.
+        doc = {"id": "r", "description": "",
+               "assets": {
+                   "r-hex": {"href": HEX_HREF, "type": PARQUET, "description": "",
+                             "table:columns": [col("cls", "Class code. Do not SUM or AVG "
+                                                    "(categorical).", "int64")]},
+                   "r-hex-fractions": {"href": HEX_HREF.replace("hex", "hex-fractions"),
+                                       "type": PARQUET, "description": "",
+                                       "table:columns": [col("cls", "Class present in cell; "
+                                                              "frac coverage.", "int64")]},
+               }}
+        overrides = {"r": {"columns": {"cls": "Class code. Categorical — do not SUM or AVG."}}}
+        rep = rc.reconcile(doc, allow_no_flat=True, overrides=overrides)
+        self.assertEqual(rep["hex_notes_added"], [])
+        self.assertNotIn("_cng_fid", doc["assets"]["r-hex"]["description"])
+        self.assertEqual(rc.divergent_columns(doc), {})
 
     def test_no_flat_asset_is_judgment(self):
         doc = {"id": "r", "description": "",

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -175,7 +175,7 @@ class ColumnDescriptionConsistency(unittest.TestCase):
         }}
         f = vs.check_column_description_consistency(doc)
         self.assertEqual([x.code for x in f], ["column-description-divergent"])
-        self.assertEqual(f[0].severity, vs.ADVISORY)
+        self.assertEqual(f[0].severity, vs.HARD)  # promoted from ADVISORY in #532
         self.assertIn("d-parquet", f[0].message)  # first-seen wins
 
     def test_identical_text_is_fine(self):


### PR DESCRIPTION
Closes #532. Adds the reconciliation tool + tests and promotes the divergence detector to HARD. The STAC edits it produced are S3-only writes (not in this diff), all published and verified.

## Result
Full catalog-wide sweep of all 231 collections now reports **0 `column-description-divergent`** — down from **99 collections / 558 columns**.

## What the mcp-data-server#303 fold does
`get_stac_details` folds per-column `description` across all assets in a collection, first-seen-wins — so a column documented two ways loses one version silently, and whichever asset lists first decides what every consumer reads on all assets.

## Tool: `scripts/reconcile-column-descriptions.py`
- **AUTO cohort (78 collections / 448 cols):** canonical text = the flat GeoParquet asset's text, applied to every asset. Inline hex per-feature-dedup clauses relocate to the hex asset `description` (the location the fold always renders and that satisfies `check_hex_dup_warning`). Guards a flat text with a grain-specific claim false on hex (scrubs the sentence, or defers if wholly grain-specific).
- **JUDGMENT cohort (21 collections / 110 cols)** via `--no-flat` + `--overrides`: auto-resolves grain-neutral H3 index columns and clean supersets; genuine data-column divergences use a hand-authored overrides file (canonical text + per-asset reducer/nodata notes). Guards a raster reduction hex (no `_cng_fid`) from a spurious `_cng_fid` dedup note.

## Promotion
`check_column_description_consistency` is now **HARD** (was ADVISORY in #512 only because the pre-gate backlog was unswept, #509). Severity test updated.

## Verification
- Both publish jobs re-fetched every URL post-write: AUTO 78 clean / JUDGMENT 21 clean, 0 problematic.
- Full catalog sweep: 0 divergent.
- 39 unit tests pass (tool + verifier).

## Out of scope (noted, not fixed)
`gbif-derived` / `taxonomic-aggregations` is missing `h3:native_resolution` / `h3:parent_resolutions` (pre-existing HARD on the live catalog, unrelated to descriptions) — worth a small separate issue.