### PR TITLE
fix(#549): census state/county hex carry the flat's _cng_fid + verify-stac gate

### DIFF
--- a/catalog/census/k8s/county/derive-county-hex.yaml
+++ b/catalog/census/k8s/county/derive-county-hex.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: census-2024-county-derive-hex
-  namespace: biodiversity
+  namespace: geo-workflows
   labels:
     k8s-app: census-2024-county-derive-hex
 spec:
@@ -63,9 +63,11 @@ spec:
             SET s3_url_style='path';
           """)
 
-          # Load county attributes (3,235 rows — trivial)
+          # Load county attributes (3,235 rows — trivial). _cng_fid is carried from the
+          # flat so the hex shares the flat's per-feature id by construction (#549).
           county = conn.execute("""
-            SELECT STATEFP, COUNTYFP, COUNTYNS, GEOID, GEOIDFQ,
+            SELECT _cng_fid,
+                   STATEFP, COUNTYFP, COUNTYNS, GEOID, GEOIDFQ,
                    NAME, NAMELSAD, LSAD, CLASSFP, MTFCC,
                    CSAFP, CBSAFP, METDIVFP, FUNCSTAT,
                    ALAND, AWATER, INTPTLAT, INTPTLON
@@ -88,6 +90,7 @@ spec:
                 COPY (
                   SELECT DISTINCT
                     t.h8,
+                    c._cng_fid,
                     c.STATEFP, c.COUNTYFP, c.COUNTYNS, c.GEOID, c.GEOIDFQ,
                     c.NAME, c.NAMELSAD, c.LSAD, c.CLASSFP, c.MTFCC,
                     c.CSAFP, c.CBSAFP, c.METDIVFP, c.FUNCSTAT,

--- a/catalog/census/k8s/state/derive-state-hex.yaml
+++ b/catalog/census/k8s/state/derive-state-hex.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: census-2024-state-derive-hex
-  namespace: biodiversity
+  namespace: geo-workflows
   labels:
     k8s-app: census-2024-state-derive-hex
 spec:
@@ -63,9 +63,11 @@ spec:
             SET s3_url_style='path';
           """)
 
-          # Load state attributes (56 rows — trivial)
+          # Load state attributes (56 rows — trivial). _cng_fid is carried from the
+          # flat so the hex shares the flat's per-feature id by construction (#549).
           state = conn.execute("""
-            SELECT REGION, DIVISION, STATEFP, STATENS, GEOID, GEOIDFQ,
+            SELECT _cng_fid,
+                   REGION, DIVISION, STATEFP, STATENS, GEOID, GEOIDFQ,
                    STUSPS, NAME, LSAD, MTFCC, FUNCSTAT,
                    ALAND, AWATER, INTPTLAT, INTPTLON
             FROM read_parquet('s3://public-census/census-2024/state.parquet')
@@ -87,6 +89,7 @@ spec:
                 COPY (
                   SELECT DISTINCT
                     t.h8,
+                    s._cng_fid,
                     s.REGION, s.DIVISION, s.STATEFP, s.STATENS,
                     s.GEOID, s.GEOIDFQ, s.STUSPS, s.NAME,
                     s.LSAD, s.MTFCC, s.FUNCSTAT,

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -52,6 +52,10 @@ Data-backed checks (delegated to the duckdb-geo MCP server, --no-data to skip):
     or from only SOME files (heterogeneous/mixed-vintage build) — checked per file, not
     against the unioned glob schema which hides a partial hole (#534/#520); ADVISORY for a
     column present in the data but undocumented
+  - HARD: a vector hex whose `_cng_fid` numbers features differently than its flat
+    GeoParquet (#549). Presence (#369) and cardinality (#535) both pass when a hex
+    merely renumbers features, but the id then points at a different feature per asset;
+    caught by joining hex->flat on `_cng_fid` and asserting a shared attribute agrees.
   - HARD: a vector hex holding fewer features than its flat GeoParquet — a silently
     dropped feature (rfmo/rfb lost CCAMLR) that leaves schema + partitions intact and no
     other check sees (#535/#520); COUNT(DISTINCT _cng_fid) vs flat COUNT(*)
@@ -1636,6 +1640,108 @@ def check_hex_holds_all_features(doc: dict, mcp: MCPClient) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------------
+# #549 — a vector hex must share the flat GeoParquet's _cng_fid numbering
+# ---------------------------------------------------------------------------
+
+# Columns that cannot serve as an identity witness: the row-unique ids, the H3
+# index columns, and the geometry/bbox scaffolding. A witness must be a plain
+# per-feature attribute carried verbatim onto every hex cell.
+_WITNESS_SKIP = re.compile(
+    r"^(h\d+|_cng_fid|ogc_fid|objectid|fid|gid|uid|bbox|geometry|geom|shape)$", re.I)
+# Preferred witnesses first: a stable source id / name is least likely to be
+# re-typed and most likely to vary across features.
+_WITNESS_PREF = ("geoid", "geoidfq", "geoidfull", "name", "namelsad", "stusps", "statefp")
+
+
+def _pick_witness(flat_cols: dict, hex_cols: dict) -> str | None:
+    """A shared, non-id attribute column present on both assets to compare on."""
+    shared = {c for c in set(flat_cols) & set(hex_cols) if not _WITNESS_SKIP.match(c)}
+    if not shared:
+        return None
+    for pref in _WITNESS_PREF:
+        if pref in shared:
+            return pref
+    strs = sorted(c for c in shared
+                  if any(t in (flat_cols.get(c, "") or "").lower()
+                         for t in ("char", "string", "varchar", "utf8")))
+    return strs[0] if strs else sorted(shared)[0]
+
+
+def check_hex_fid_matches_flat(doc: dict, mcp: MCPClient) -> list[Finding]:
+    """A vector hex must carry the SAME `_cng_fid` numbering as its flat GeoParquet
+    (data-workflows#549).
+
+    `_cng_fid` is the universal per-feature id (#369). The #369 presence check and the
+    #535 cardinality check both pass when a hex merely *renumbers* the features — e.g. a
+    custom derive step that assigned its own ROW_NUMBER instead of carrying the flat's id
+    (census-2024 state/county did exactly this, agreeing with the flat on only 10/56 and
+    1/3,235 features). The id then points at a different feature depending on which asset
+    you read. Caught here by joining hex->flat on `_cng_fid` and asserting a shared
+    per-feature attribute (a source id / name) agrees. Raster-derived hexes have no
+    `_cng_fid` and are skipped; a witness that is constant across the whole flat cannot
+    distinguish a permutation, so that downgrades to advisory rather than a wrong pass.
+    """
+    out = []
+    assets = doc.get("assets", {})
+    flats, hexes = {}, {}
+    for key, asset in assets.items():
+        if not is_parquet(asset):
+            continue
+        s3 = _to_s3(asset.get("href", ""))
+        if not s3:
+            continue
+        cols = {c.get("name", "").lower(): (c.get("type", "") or "")
+                for c in asset.get("table:columns", [])}
+        if is_hex_asset(key, asset):
+            if "_cng_fid" in cols:
+                hexes[key] = (s3, cols)
+        elif _asset_has_geom(asset):
+            if "_cng_fid" in cols:
+                flats.setdefault(_asset_stem(key), (key, s3, cols))
+    for hkey, (h_s3, h_cols) in hexes.items():
+        flat = flats.get(_asset_stem(hkey))
+        if flat is None and len(flats) == 1 and len(hexes) == 1:
+            flat = next(iter(flats.values()))  # single flat + single hex: pair them
+        if flat is None:
+            continue
+        fkey, f_s3, f_cols = flat
+        witness = _pick_witness(f_cols, h_cols)
+        if witness is None:
+            out.append(Finding(ADVISORY, "hex-fid-identity-unverifiable",
+                f"asset '{hkey}': shares no non-id attribute column with flat '{fkey}', "
+                f"so the flat<->hex _cng_fid numbering cannot be verified."))
+            continue
+        try:
+            row = mcp.query(
+                f'WITH h AS (SELECT DISTINCT _cng_fid, "{witness}" AS w '
+                f"FROM read_parquet('{h_s3}')), "
+                f'f AS (SELECT _cng_fid, "{witness}" AS w FROM read_parquet(\'{f_s3}\')) '
+                "SELECT COUNT(*) AS n_join, "
+                "COUNT(*) FILTER (WHERE h.w IS DISTINCT FROM f.w) AS mism, "
+                "COUNT(DISTINCT f.w) AS fdist "
+                "FROM h JOIN f USING (_cng_fid)")[0]
+            matched, mism, fdist = int(row["n_join"]), int(row["mism"]), int(row["fdist"])
+        except (MCPError, ValueError, KeyError, IndexError) as e:
+            out.append(Finding(ADVISORY, "hex-fid-identity-check-failed",
+                f"asset '{hkey}': could not compare _cng_fid numbering vs '{fkey}' ({e})."))
+            continue
+        if fdist <= 1:
+            out.append(Finding(ADVISORY, "hex-fid-identity-unverifiable",
+                f"asset '{hkey}': the only shared attribute ('{witness}') is constant "
+                f"across '{fkey}', so a _cng_fid permutation cannot be detected."))
+            continue
+        if mism:
+            out.append(Finding(HARD, "hex-fid-mismatch",
+                f"asset '{hkey}': _cng_fid identifies a different feature than the flat "
+                f"'{fkey}' on {mism:,} of {matched:,} ids (join on _cng_fid; '{witness}' "
+                f"disagrees) — the hex was built with its own feature numbering instead of "
+                f"carrying the flat's _cng_fid (data-workflows#549). Rebuild the hex so it "
+                f"preserves the flat's _cng_fid: the standard cng-datasets vector path does "
+                f"this automatically; a custom derive step must SELECT the flat's _cng_fid."))
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
 
@@ -1670,6 +1776,7 @@ def verify(source: str, do_data: bool = True, do_recall: bool = True,
                 findings.extend(check_values_match_distinct(doc, client))
                 findings.extend(check_declared_schema_matches_data(doc, client))  # #534 (hard)
                 findings.extend(check_hex_holds_all_features(doc, client))        # #535 (hard)
+                findings.extend(check_hex_fid_matches_flat(doc, client))          # #549 (hard)
                 findings.extend(check_null_hex_index(doc, client))      # #309 §2 (hard)
                 findings.extend(check_hex_row_uniqueness(doc, client))  # #509 (hard)
                 findings.extend(check_polygon_row_dup(doc, client))     # #309 §1 (advisory)

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -410,5 +410,44 @@ class ValuesMatchDistinctArtifactTokens(unittest.TestCase):
         self.assertNotIn("not in ('none'", sql)
 
 
+class HexFidMatchesFlat(unittest.TestCase):
+    """#549: a vector hex must carry the SAME _cng_fid numbering as its flat GeoParquet.
+    Presence (#369) and cardinality (#535) both pass a renumbered hex; this joins on
+    _cng_fid and asserts a shared witness attribute agrees. The query returns a single
+    aggregate row, so a stub replaying that row exercises the finding logic."""
+
+    def _doc(self, witness=True):
+        flat_cols = [{"name": "_cng_fid", "type": "int64"}, {"name": "geom", "type": "geometry"}]
+        hex_cols = ["_cng_fid", "h0"]
+        if witness:
+            flat_cols.insert(1, {"name": "GEOID", "type": "string"})
+            hex_cols.insert(1, "GEOID")
+        return {"assets": {
+            "d-parquet": {"href": "https://s3-west.nrp-nautilus.io/public-x/d.parquet",
+                          "type": PARQUET, "table:columns": flat_cols},
+            "d-hex": hex_asset(hex_cols)}}
+
+    def test_mismatch_is_hard(self):
+        f = vs.check_hex_fid_matches_flat(self._doc(), StubMCP(rows=[{"n_join": 56, "mism": 56, "fdist": 56}]))
+        self.assertEqual([x.code for x in f], ["hex-fid-mismatch"])
+        self.assertEqual(f[0].severity, vs.HARD)
+
+    def test_full_agreement_is_clean(self):
+        f = vs.check_hex_fid_matches_flat(self._doc(), StubMCP(rows=[{"n_join": 56, "mism": 0, "fdist": 56}]))
+        self.assertEqual(f, [])
+
+    def test_constant_witness_is_advisory_not_hard(self):
+        # fdist<=1: the witness can't distinguish a permutation, so never a false HARD.
+        f = vs.check_hex_fid_matches_flat(self._doc(), StubMCP(rows=[{"n_join": 56, "mism": 56, "fdist": 1}]))
+        self.assertEqual([x.code for x in f], ["hex-fid-identity-unverifiable"])
+        self.assertEqual(f[0].severity, vs.ADVISORY)
+
+    def test_no_shared_witness_is_advisory_and_unqueried(self):
+        mcp = StubMCP(rows=[{"n_join": 1, "mism": 1, "fdist": 1}])
+        f = vs.check_hex_fid_matches_flat(self._doc(witness=False), mcp)
+        self.assertEqual([x.code for x in f], ["hex-fid-identity-unverifiable"])
+        self.assertEqual(mcp.sql, [], "no witness → must not query")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #549.

## Problem (verified against live data)
`_cng_fid` is the universal per-feature id (#369), but on `census-2024-state` and `census-2024-county` the flat GeoParquet and the hex carried **different numberings of the same features**, so the id pointed at a different feature depending on which asset you read.

| collection | flat rows | hex distinct `_cng_fid` | NAME agrees (before) |
|---|---:|---:|---:|
| `census-2024-state` | 56 | 56 | 10 / 56 |
| `census-2024-county` | 3,235 | 3,235 | 1 / 3,235 |

Both passed the existing gate because presence (#369) and cardinality (#535: 56=56, 3,235=3,235) both held.

## Root cause
`derive-{state,county}-hex.yaml` build the hex by joining a coarser already-hexed layer on FIPS codes (county←tract on STATEFP+COUNTYFP, state←county on STATEFP) with `SELECT DISTINCT h8, <attrs>` — and **never select `_cng_fid` from the flat**. The published ids came from a since-retired reencode that assigned its own `ROW_NUMBER()` (~alphabetical). The standard `cng-datasets vector` path instead carries the flat's `_cng_fid` straight through polyfill, which is why every other census layer (cd 444/444, tract, place, sldl, sldu) is clean.

## Fix
- **Carry the flat's `_cng_fid`** through both derive joins (1:1 on the FIPS key). Rebuilt both hexes on the cluster (`geo-workflows`, ~1–2 min each). After: flat↔hex agree **56/56** and **3,235/3,235** on both GEOID and NAME; coverage and native **res-8** unchanged; single `data_0.parquet` per `h0` (no fragmentation).
- **New verify-stac gate** `check_hex_fid_matches_flat` (HARD, #549): joins hex→flat on `_cng_fid` and asserts a shared per-feature attribute agrees, so a renumbered hex can no longer slip past presence+cardinality. Guards against a constant/absent witness (advisory, never a wrong pass). Validated: flags the pre-fix data (56/56 mismatch), passes the fixed data and the clean `cd` control.
- Move both derive jobs to the `geo-workflows` namespace.

## Verification
`scripts/verify-stac.py --bucket public-census --dataset census-2024/state` and `.../county` both exit 0 (full data-backed run) against the rebuilt data.

> Note for the reviewer: the data was rebuilt on the cluster in this session, so the CI Verify-STAC check reflects the live (fixed) S3 state.