### PR TITLE
fix(#509): verify-stac wide-table truncation bug + reproducible pre-gate audit

### DIFF
--- a/catalog/audit/pregate-verify-sweep/README.md
+++ b/catalog/audit/pregate-verify-sweep/README.md
@@ -1,0 +1,72 @@
+# Pre-gate `verify-stac` sweep (data-workflows#509)
+
+The Verify-STAC CI gate is **PR-triggered on changed `catalog/**` YAMLs** — deliberately,
+so recipes are gated at creation. The corollary: any collection **published before a
+check existed** is never retro-verified unless someone touches its recipe. This harness
+runs the *current, full, data-backed* `scripts/verify-stac.py` against **every** collection
+in the catalog so the pre-gate cohort is evaluated by today's rules — the systematic audit
+required by #509's scope amendment.
+
+## Run it
+
+```bash
+cd catalog/audit/pregate-verify-sweep
+python3 enumerate-collections.py > /tmp/sweep/collections.tsv   # walk the STAC tree
+./run-sweep.sh /tmp/sweep                                       # 8 parallel workers
+python3 analyze-findings.py /tmp/sweep/all-results.txt          # per-category + per-collection
+```
+
+`run-sweep.sh` interleaves collections across `SLICES` workers (default 8) to spread the
+big `COUNT(DISTINCT)` datasets, and caps each collection at `PERCOLL_TIMEOUT` (default
+300 s). It posts SQL to the public duckdb-geo MCP, so it is not bound by laptop resources
+— but keep `SLICES` modest (≤8) to stay friendly on the shared MCP.
+
+## Snapshot — 2026-08-17 (266 collections, checker at commit that fixed the truncation bug)
+
+`161 CLEAN · 97 HARD · 8 TIMEOUT`. Full run in `RESULTS-2026-08-17.txt`.
+
+> **Before triaging this list, note the checker fix that produced it.** The first pass
+> reported **1,474 `declared-column-absent` findings across 50 collections** — all false.
+> `check_declared_schema_matches_data` row-parsed the MCP's 50-row markdown preview as if
+> complete, so every asset with >50 columns had its columns-past-50 read as absent (SVI
+> county: 162 cols → 112 false). Fixed by computing the set-difference in SQL (+ a global
+> guard that refuses a truncated preview). `declared-column-absent` fell to **59 real
+> findings across 28 collections**. Re-run after any checker change.
+
+### HARD findings by category (collections affected)
+
+| category | colls | disposition |
+|---|--:|---|
+| `hex-missing-features` (#535) | 50 | **Triage each**: legit sub-cell shortfall (features smaller than one cell polyfill to zero) → document in the asset description; a real dropped chunk / silent coverage cap → re-hex. Distinguish by the *magnitude* and *size* of the missing features (a 1-of-84,120 SVI drop is sub-cell; PAD-US fee 64,576-of-296,456 = 22% is suspicious and needs the area check). |
+| `declared-column-absent` (#534) | 28 | Real stale STAC — the `table:columns` declares a column the parquet lacks. Metadata fix (drop/rename). Clusters: BLM MLRS (8), swap/missouri ccs (7), overturemaps, iucn/taxonomy (9 list-columns). |
+| `table-columns-collection-level` | 14 | `table:columns` sits at collection level, not on the asset. Metadata fix. Mostly the **Wyoming** + **cpad** families. |
+| `parquet-no-table-columns` | 14 | Parquet asset carries no `table:columns` at all. Same Wyoming/cpad families. |
+| `hex-href-not-glob` | 14 | Hex `href` is a bare dir, not `hex/h0=*/data_0.parquet`. **Wyoming** family. Metadata fix. |
+| `hex-no-native-res` / `hex-no-parent-res` | 14 | Hex asset omits `h3:native_resolution` / `h3:parent_resolutions`. **Wyoming** family. Metadata fix. |
+| `hex-duplicate-feature-cell-rows` (#509) | 10 | Row-dup remnants NOT in the original dedup sweep (rivers/american-rivers *nri/roo-cjest/wild-scenic*, overturemaps/counties, tpl/landvote, ecoregion, swap ranges). Cheap `SELECT DISTINCT *` — the known, provably-lossless pattern. |
+| `license-*`, `nav-parent-missing`, `temporal-extent-missing`, `categorical` | 1–2 each | Singletons on `data` (root), tpl/high-seas, cgs/sierra-nevada. Metadata fixes. |
+
+### Two mechanical clusters dominate the metadata findings
+
+- **Wyoming family (13 collections)** — `wgfd-*`, `rap-*`, `wy-counties`, `sagebrush-design`,
+  `nlcd-2024`, `sage-grouse-priority`: built with an older STAC template missing the hex
+  glob, `h3:*` resolutions, and per-asset `table:columns`. Batch-fixable.
+- **cpad family (3)** — `cpad-holdings`, `cpad-units`, `cced`: `table:columns` at collection
+  level + a parquet asset with none.
+
+### 8 TIMEOUTs (exceeded 300 s — big `COUNT(DISTINCT)` / many assets)
+
+`iucn/iucn-ranges-2025`, `carbon` (meta), `facts/common-attributes-2026-06`, `nci-frontiers`,
+`census-2025/sldu`, `land-cover/cgls-lc100-2019`, `land-cover/nlcd` (meta), `wui`. Re-run
+individually with a larger `PERCOLL_TIMEOUT`, or verify per-child for the meta collections.
+
+## Remediation classes (do NOT auto-fix — most are per-collection judgment or cluster jobs)
+
+1. **Metadata-only** (Wyoming, cpad, declared-column-absent, singletons) — edit the S3 STAC
+   JSON, `rclone copyto`, re-verify. Batch by family.
+2. **Row-dup** (`hex-duplicate-feature-cell-rows`) — the `SELECT DISTINCT *` rewrite; template
+   `catalog/audit/k8s/hex-dedup-sweep.yaml`. Provably lossless (byte-identical dup rows).
+3. **Missing-features** (`hex-missing-features`) — per-collection: doc-note vs re-hex. A re-hex
+   is a cluster job; a shortfall that is genuinely sub-cell only needs a description sentence
+   the `_COVERAGE_NOTE` matcher accepts. **File real drops against #535 / a per-dataset rebuild
+   issue**, not the dedup batch (they can't be rewritten from what's on S3).

--- a/catalog/audit/pregate-verify-sweep/RESULTS-2026-08-17.txt
+++ b/catalog/audit/pregate-verify-sweep/RESULTS-2026-08-17.txt
@@ -1,0 +1,486 @@
+HARD(2)	28s	https://s3-west.nrp-nautilus.io/public-blm/mineral-materials/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [mineral-materials] asset 'mineral-materials-hex': STAC declares column 'bbox' but it is absent from all 8 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [mineral-materials] asset 'mineral-materials-hex' holds 34277 of 35670 features from 'mineral-materials-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1393 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(2)	152s	https://s3-west.nrp-nautilus.io/public-ca-dac/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [ca-dac-eda-2023] asset 'dac-blockgroup-hex' holds 25606 of 25607 features from 'dac-blockgroup-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+    [HARD][hex-missing-features] [ca-dac-eda-2023] asset 'eda-blockgroup-hex' holds 25606 of 25607 features from 'eda-blockgroup-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	23s	https://s3-west.nrp-nautilus.io/public-ca30x30/ecoregion/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-ca30x30/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-calenviroscreen/stac-collection.json	exit=0
+CLEAN	28s	https://s3-west.nrp-nautilus.io/public-census/census-2024/place/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-cgs/stac-collection.json	exit=0
+HARD(2)	6s	https://s3-west.nrp-nautilus.io/public-cpad/cpad-holdings-stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [cpad-holdings-2025b] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [cpad-holdings-2025b] parquet asset 'holdings-parquet' has no 'table:columns'.
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-epa-water/stac-collection.json	exit=0
+HARD(1)	13s	https://s3-west.nrp-nautilus.io/public-fire/usgs-fires-2021/combined/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [usgs-fires-2021-combined] asset 'combined-hex' holds 71510 of 135061 features from 'combined-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 63551 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp1rcp26-2050-wbvert/stac-collection.json	exit=0
+HARD(1)	61s	https://s3-west.nrp-nautilus.io/public-hazard/flood-hazard/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [flood-hazard] asset 'flood-hazard-hex' holds 5631497 of 5631998 features from 'flood-hazard-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 501 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	36s	https://s3-west.nrp-nautilus.io/public-high-seas/iho/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [iho-maritime-boundaries] asset 'eez-hex' holds 284 of 285 features from 'eez-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	47s	https://s3-west.nrp-nautilus.io/public-high-seas/meow/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-icca/icca-registry/icca-polygon/stac-collection.json	exit=0
+TIMEOUT	300s	https://s3-west.nrp-nautilus.io/public-iucn/iucn-ranges-2025/stac-collection.json
+HARD(3)	15s	https://s3-west.nrp-nautilus.io/public-mappinginequality/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [mappinginequality] asset 'mappinginequality-parquet': STAC declares column 'geom_bbox' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [mappinginequality] asset 'mappinginequality-hex': STAC declares column 'geom_bbox' but it is absent from all 6 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [mappinginequality] asset 'mappinginequality-hex' holds 10151 of 10154 features from 'mappinginequality-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 3 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	55s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/combined/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [pad-us-4.1-combined] asset 'combined-hex' holds 518152 of 656986 features from 'combined-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 138834 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	20s	https://s3-west.nrp-nautilus.io/public-parks/park-access-2020/tract-acres-per-thousand/stac-collection.json	exit=0
+HARD(1)	9s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/campaigns/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [american-rivers-campaigns] asset 'campaigns-hex' holds 739 of 740 features from 'campaigns-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	12s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/wild-scenic-eligible/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [american-rivers-wild-scenic-eligible] asset 'wild-scenic-eligible-hex': 10 rows (0.014%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-storms/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/sgcn-species-units/stac-collection.json	exit=0
+HARD(4)	9s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/priority-geographies/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-priority-geographies] asset 'priority-geographies-parquet': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-priority-geographies] asset 'priority-geographies-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-priority-geographies] asset 'priority-geographies-hex': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-priority-geographies] asset 'priority-geographies-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(1)	3s	https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-funding/stac-collection.json	exit=1
+    [HARD][license-link-missing] [conservation-almanac-2024-funding] license is 'proprietary' but there is no {'rel':'license'} link to the canonical terms URL (exempt only for a meta-collection with child links, whose per-child licenses govern; this is a leaf).
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/service-areas/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usfws/critical-habitat/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-usgs-ungulate-migration/ungulate-routes/stac-collection.json	exit=0
+CLEAN	25s	https://s3-west.nrp-nautilus.io/public-usgs/mrds/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-wdpa/stac-collection.json	exit=0
+HARD(1)	34s	https://s3-west.nrp-nautilus.io/public-wyoming/blm-sma/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [wyoming-blm-sma] asset 'blm-sma-hex' holds 277 of 865059 features from 'blm-sma-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 864782 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(3)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/sagebrush-design/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-sagebrush-design] asset 'sagebrush-design-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/sagebrush-design/hex/'.
+    [HARD][hex-no-native-res] [wyoming-sagebrush-design] asset 'sagebrush-design-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-sagebrush-design] asset 'sagebrush-design-hex' missing 'h3:parent_resolutions'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-seasonal/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-pronghorn-seasonal] asset 'wgfd-pronghorn-seasonal-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-seasonal/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-pronghorn-seasonal] asset 'wgfd-pronghorn-seasonal-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-pronghorn-seasonal] asset 'wgfd-pronghorn-seasonal-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-pronghorn-seasonal] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-seasonal] parquet asset 'wgfd-pronghorn-seasonal-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-seasonal] parquet asset 'wgfd-pronghorn-seasonal-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-0.txt
+CLEAN	17s	https://s3-west.nrp-nautilus.io/public-barred-owl/stac-collection.json	exit=0
+HARD(2)	65s	https://s3-west.nrp-nautilus.io/public-blm/mining-claims/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [mining-claims] asset 'mining-claims-hex': STAC declares column 'bbox' but it is absent from all 7 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [mining-claims] asset 'mining-claims-hex' holds 610911 of 655792 features from 'mining-claims-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 44881 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	29s	https://s3-west.nrp-nautilus.io/public-ca-wolves/rca-boundary/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-ca30x30/fmmp-2022/stac-collection.json	exit=0
+HARD(1)	10s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2021/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [williamson-act-2021] asset 'williamson-act-2021-hex' holds 90530 of 90538 features from 'williamson-act-2021-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 8 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+TIMEOUT	300s	https://s3-west.nrp-nautilus.io/public-carbon/stac-collection.json
+CLEAN	33s	https://s3-west.nrp-nautilus.io/public-census/census-2024/state/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-connectivity/climate-migration-routes/stac-collection.json	exit=0
+HARD(2)	7s	https://s3-west.nrp-nautilus.io/public-cpad/cpad-units-stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [cpad-units-2025b] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [cpad-units-2025b] parquet asset 'units-parquet' has no 'table:columns'.
+TIMEOUT	300s	https://s3-west.nrp-nautilus.io/public-facts/common-attributes-2026-06/stac-collection.json
+HARD(1)	166s	https://s3-west.nrp-nautilus.io/public-gbif/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [gbif-derived] asset 'gbif-hex-2026-06': STAC declares column 'issue' but it is absent from all 122 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp3rcp60-2050-overall/stac-collection.json	exit=0
+CLEAN	7s	https://s3-west.nrp-nautilus.io/public-hazard/mid-century-habitat-climate-exposure/stac-collection.json	exit=0
+HARD(1)	15s	https://s3-west.nrp-nautilus.io/public-high-seas/imma/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [imma] asset 'imma-hex': STAC declares column 'bbox' but it is absent from all 81 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(1)	11s	https://s3-west.nrp-nautilus.io/public-high-seas/mpa-candidates/stac-collection.json	exit=1
+    [HARD][license-link-missing] [mpa-candidates] license is 'proprietary' but there is no {'rel':'license'} link to the canonical terms URL (exempt only for a meta-collection with child links, whose per-child licenses govern; this is a leaf).
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-icca/stac-collection.json	exit=0
+CLEAN	63s	https://s3-west.nrp-nautilus.io/public-iucn/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-mobi/mobi-species-richness-all/stac-collection.json	exit=0
+HARD(1)	28s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [pad-us-4.1-easement] asset 'easement-hex' holds 271292 of 341954 features from 'easement-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 70662 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-parks/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/dam-removal/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2000/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-swap/california/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/sgcn-species/stac-collection.json	exit=0
+HARD(2)	6s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/stream-reach-coa/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-stream-reach-coa] asset 'stream-reach-coa-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-stream-reach-coa] asset 'stream-reach-coa-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(1)	22s	https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-sites/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [conservation-almanac-2024-sites] asset 'conservation-almanac-2024-sites-hex' holds 53191 of 67428 features from 'conservation-almanac-2024-sites-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 14237 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/urban-areas/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-usfws/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usgs/stac-collection.json	exit=0
+HARD(2)	13s	https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [wdoecm-may-2026] asset 'wdoecm-parquet': STAC declares column 'objectid' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [wdoecm-may-2026] asset 'wdoecm-hex' holds 2594 of 7378 features from 'wdoecm-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 4784 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(3)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/nlcd-2024/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-nlcd-2024] asset 'nlcd-2024-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/nlcd-2024/hex/'.
+    [HARD][hex-no-native-res] [wyoming-nlcd-2024] asset 'nlcd-2024-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-nlcd-2024] asset 'nlcd-2024-hex' missing 'h3:parent_resolutions'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-wyoming/stac-collection.json	exit=0
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wy-counties/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wy-counties] asset 'wy-counties-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wy-counties/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wy-counties] asset 'wy-counties-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wy-counties] asset 'wy-counties-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wy-counties] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wy-counties] parquet asset 'wy-counties-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wy-counties] parquet asset 'wy-counties-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-1.txt
+CLEAN	225s	https://s3-west.nrp-nautilus.io/public-blm/acquisitions/stac-collection.json	exit=1
+HARD(2)	43s	https://s3-west.nrp-nautilus.io/public-blm/non-energy-leasables/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [non-energy-leasables] asset 'non-energy-leasables-hex': STAC declares column 'bbox' but it is absent from all 9 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [non-energy-leasables] asset 'non-energy-leasables-hex' holds 6894 of 7106 features from 'non-energy-leasables-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 212 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-ca-wolves/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-ca30x30/freshwater-species-richness/stac-collection.json	exit=0
+HARD(1)	10s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2022/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [williamson-act-2022] asset 'williamson-act-2022-hex' holds 113358 of 113360 features from 'williamson-act-2022-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 2 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-cdfw/ace/terrestrial-biodiversity-summary/stac-collection.json	exit=0
+CLEAN	56s	https://s3-west.nrp-nautilus.io/public-census/census-2024/tract/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-connectivity/present-day-connectivity/categories/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-cpad/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-facts/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-gfw/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp3rcp60-2050-plants/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-hazard/sea-level-rise/stac-collection.json	exit=0
+CLEAN	50s	https://s3-west.nrp-nautilus.io/public-high-seas/longhurst/stac-collection.json	exit=0
+CLEAN	271s	https://s3-west.nrp-nautilus.io/public-high-seas/rfmo/stac-collection.json	exit=0
+CLEAN	45s	https://s3-west.nrp-nautilus.io/public-inat/stac-collection.json	exit=0
+HARD(9)	6s	https://s3-west.nrp-nautilus.io/public-iucn/taxonomy/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'common_names_en' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'conservation_action_codes' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'country_codes' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'habitat_codes' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'plant_growth_forms' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'research_needed_codes' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'synonyms' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'threat_codes' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [iucn-taxonomy-2025] asset 'taxonomy-parquet': STAC declares column 'use_trade_codes' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+TIMEOUT	300s	https://s3-west.nrp-nautilus.io/public-nci-frontiers/stac-collection.json
+HARD(1)	117s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [pad-us-4.1-fee] asset 'fee-hex' holds 231880 of 296456 features from 'fee-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 64576 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	68s	https://s3-west.nrp-nautilus.io/public-population/ghs-pop-2020/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/ira-watersheds/stac-collection.json	exit=0
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2010/stac-collection.json	exit=0
+CLEAN	6s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/bay-delta-conservation-unit/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/strategies/stac-collection.json	exit=0
+HARD(4)	6s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/wetland-coa/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-wetland-coa] asset 'wetland-coa-parquet': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-wetland-coa] asset 'wetland-coa-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-wetland-coa] asset 'wetland-coa-hex': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-wetland-coa] asset 'wetland-coa-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(1)	20s	https://s3-west.nrp-nautilus.io/public-tpl/landvote/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [landvote] asset 'landvote-hex': 940 rows (0.003%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-tpl/stac-collection.json	exit=0
+CLEAN	189s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/nhdplus-hr/flowline/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu10/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-utah/bears-ears/stac-collection.json	exit=0
+CLEAN	65s	https://s3-west.nrp-nautilus.io/public-wdpa/wdpa/stac-collection.json	exit=0
+HARD(3)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/pad-us/stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [wyoming-pad-us] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-pad-us] parquet asset 'fee-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-pad-us] parquet asset 'easement-parquet' has no 'table:columns'.
+HARD(2)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/ungulate-migration/stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [wyoming-ungulate-migration] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-ungulate-migration] parquet asset 'ungulate-migration-parquet' has no 'table:columns'.
+HARD(6)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/wyoming-places/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wyoming-places] asset 'wyoming-places-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wyoming-places/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wyoming-places] asset 'wyoming-places-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wyoming-places] asset 'wyoming-places-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wyoming-places] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wyoming-places] parquet asset 'wyoming-places-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wyoming-places] parquet asset 'wyoming-places-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-2.txt
+HARD(2)	33s	https://s3-west.nrp-nautilus.io/public-blm/coal-cases/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [coal-cases] asset 'coal-cases-hex': STAC declares column 'bbox' but it is absent from all 9 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [coal-cases] asset 'coal-cases-hex' holds 2886 of 3857 features from 'coal-cases-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 971 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(2)	90s	https://s3-west.nrp-nautilus.io/public-blm/oil-gas-agreements/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [oil-gas-agreements] asset 'oil-gas-agreements-hex': STAC declares column 'bbox' but it is absent from all 7 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [oil-gas-agreements] asset 'oil-gas-agreements-hex' holds 32344 of 32787 features from 'oil-gas-agreements-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 443 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	54s	https://s3-west.nrp-nautilus.io/public-ca30x30/2024/conserved-areas-terrestrial/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [ca30x30-conserved-areas-terrestrial-2024] asset 'conserved-areas-terrestrial-hex' holds 124067 of 124075 features from 'conserved-areas-terrestrial-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 8 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-ca30x30/groundwater-dependent-ecosystems/stac-collection.json	exit=0
+HARD(1)	19s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2023/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [williamson-act-2023] asset 'williamson-act-2023-hex' holds 116356 of 116359 features from 'williamson-act-2023-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 3 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	20s	https://s3-west.nrp-nautilus.io/public-cdfw/fish-passage-pad/stac-collection.json	exit=0
+CLEAN	87s	https://s3-west.nrp-nautilus.io/public-census/census-2025/sldl/stac-collection.json	exit=0
+CLEAN	5s	https://s3-west.nrp-nautilus.io/public-connectivity/present-day-connectivity/flow/stac-collection.json	exit=0
+HARD(3)	0s	https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json	exit=1
+    [HARD][license-missing] [boettiger-lab-datasets] collection has no top-level `license` — set the upstream SPDX id (or other/various/proprietary/public-domain).
+    [HARD][nav-parent-missing] [boettiger-lab-datasets] missing required navigation link rel='parent'.
+    [HARD][temporal-extent-missing] [boettiger-lab-datasets] collection has no `extent` object.
+HARD(1)	20s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2024/firep/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [calfire-2024-firep] asset 'firep-hex' holds 21877 of 22810 features from 'firep-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 933 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-2015-overall/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp3rcp60-2050-wbvert/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-hazard/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/corridors/stac-collection.json	exit=0
+HARD(1)	15s	https://s3-west.nrp-nautilus.io/public-high-seas/seafloor-geomorphology/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [seafloor-geomorphology] asset 'seafloor-geomorphology-hex' holds 132693 of 152079 features from 'seafloor-geomorphology-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 19386 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	21s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/indicative-poly-stac.json	exit=1
+    [HARD][hex-missing-features] [landmark-indicative-poly] asset 'indicative-poly-hex' holds 17462 of 17539 features from 'indicative-poly-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 77 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	34s	https://s3-west.nrp-nautilus.io/public-kba/kba-2026-03/sites/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [kba-2026-03-sites] asset 'sites-hex': STAC declares column 'bbox' but it is absent from all 110 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-ncp/stac-collection.json	exit=0
+HARD(1)	237s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [pad-us-4.1-marine] asset 'marine-hex' holds 1724 of 1739 features from 'marine-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 15 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-population/stac-collection.json	exit=0
+HARD(1)	16s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/nri-2016/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [american-rivers-nri-2016] asset 'nri-2016-hex': 18 rows (0.012%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	30s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2020/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/conservation-units/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/targets/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-swap/missouri/stac-collection.json	exit=0
+CLEAN	38s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/parks/stac-collection.json	exit=0
+HARD(1)	14s	https://s3-west.nrp-nautilus.io/public-tpl/wcb-approved-projects/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [wcb-approved-projects] asset 'wcb-approved-projects-hex' holds 3583 of 3915 features from 'wcb-approved-projects-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 332 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	31s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/perennial-streams/stac-collection.json	exit=0
+CLEAN	22s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu12/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-utah/coal-deposits/stac-collection.json	exit=0
+HARD(1)	78s	https://s3-west.nrp-nautilus.io/public-wetlands/glwd/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [wetlands-glwd-v2] asset 'glwd-class-area-hex': STAC declares column 'h0' but it is absent from all 2327 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-wyoming/priority-areas-gye/stac-collection.json	exit=0
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-crucial/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-elk-crucial] asset 'wgfd-elk-crucial-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-crucial/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-elk-crucial] asset 'wgfd-elk-crucial-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-elk-crucial] asset 'wgfd-elk-crucial-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-elk-crucial] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-crucial] parquet asset 'wgfd-elk-crucial-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-crucial] parquet asset 'wgfd-elk-crucial-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-3.txt
+HARD(2)	28s	https://s3-west.nrp-nautilus.io/public-blm/geothermal-leases/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [geothermal-leases] asset 'geothermal-leases-hex': STAC declares column 'bbox' but it is absent from all 7 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [geothermal-leases] asset 'geothermal-leases-hex' holds 7199 of 7394 features from 'geothermal-leases-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 195 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	195s	https://s3-west.nrp-nautilus.io/public-blm/oil-gas-leases/stac-collection.json	exit=1
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-ca30x30/ca-climate-zones/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-ca30x30/groundwater-dependent-ecosystems/vegetation/stac-collection.json	exit=0
+HARD(1)	10s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2024/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [williamson-act-2024] asset 'williamson-act-2024-hex' holds 123523 of 123526 features from 'williamson-act-2024-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 3 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-cdfw/stac-collection.json	exit=0
+TIMEOUT	301s	https://s3-west.nrp-nautilus.io/public-census/census-2025/sldu/stac-collection.json
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-connectivity/regional-connectivity-linkages/stac-collection.json	exit=0
+CLEAN	29s	https://s3-west.nrp-nautilus.io/public-dem/copernicus-glo90/stac-collection.json	exit=0
+HARD(1)	17s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2024/rxburn/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [calfire-2024-rxburn] asset 'rxburn-hex' holds 10092 of 10675 features from 'rxburn-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 583 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-2015-plants/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp5rcp85-2050-overall/stac-collection.json	exit=0
+CLEAN	56s	https://s3-west.nrp-nautilus.io/public-high-seas/ebsa/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/immegas/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-high-seas/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/indicative-pt-stac.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-kba/stac-collection.json	exit=0
+HARD(5)	59s	https://s3-west.nrp-nautilus.io/public-overturemaps/2026-02-18.0/counties/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [overture-divisions-counties-2026-02-18] asset 'counties-parquet': STAC declares column 'names' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [overture-divisions-counties-2026-02-18] asset 'counties-parquet': STAC declares column 'sources' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [overture-divisions-counties-2026-02-18] asset 'counties-hex': STAC declares column 'names' but it is absent from all 87 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [overture-divisions-counties-2026-02-18] asset 'counties-hex': STAC declares column 'sources' but it is absent from all 87 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-duplicate-feature-cell-rows] [overture-divisions-counties-2026-02-18] asset 'counties-hex': 19,599 rows (0.011%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+HARD(1)	107s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [pad-us-4.1-proclamation] asset 'proclamation-hex' holds 3354 of 3439 features from 'proclamation-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 85 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	26s	https://s3-west.nrp-nautilus.io/public-rap/rap-arte/stac-collection.json	exit=0
+HARD(1)	12s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/nri-2024/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [american-rivers-nri-2024] asset 'nri-2024-hex': 19 rows (0.011%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+HARD(1)	54s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2022/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [svi-2022] asset 'tract-hex' holds 84119 of 84120 features from 'tract-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	6s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/marine-bioregions/stac-collection.json	exit=0
+HARD(4)	6s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/cave-karst-coa/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-cave-karst-coa] asset 'cave-karst-coa-parquet': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-cave-karst-coa] asset 'cave-karst-coa-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-cave-karst-coa] asset 'cave-karst-coa-hex': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-cave-karst-coa] asset 'cave-karst-coa-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-swap/nevada/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/parkscore/stac-collection.json	exit=0
+HARD(1)	15s	https://s3-west.nrp-nautilus.io/public-trails/federal-trails-2026/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [federal-trails-2026] asset 'federal-trails-2026-hex' holds 122063 of 127619 features from 'federal-trails-2026-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 5556 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu2/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-utah/grand-staircase-escalante/stac-collection.json	exit=0
+HARD(1)	27s	https://s3-west.nrp-nautilus.io/public-wetlands/nwi/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [wetlands-nwi] asset 'nwi-hex' holds 11273455 of 38065251 features from 'nwi-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 26791796 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(3)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/rap-arte/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-rap-arte] asset 'rap-arte-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/rap-arte/hex/'.
+    [HARD][hex-no-native-res] [wyoming-rap-arte] asset 'rap-arte-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-rap-arte] asset 'rap-arte-hex' missing 'h3:parent_resolutions'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-seasonal/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-elk-seasonal] asset 'wgfd-elk-seasonal-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-seasonal/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-elk-seasonal] asset 'wgfd-elk-seasonal-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-elk-seasonal] asset 'wgfd-elk-seasonal-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-elk-seasonal] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-seasonal] parquet asset 'wgfd-elk-seasonal-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-seasonal] parquet asset 'wgfd-elk-seasonal-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-4.txt
+HARD(2)	21s	https://s3-west.nrp-nautilus.io/public-blm/locatable-operations/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [locatable-operations] asset 'locatable-operations-hex': STAC declares column 'bbox' but it is absent from all 5 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [locatable-operations] asset 'locatable-operations-hex' holds 2238 of 2399 features from 'locatable-operations-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 161 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(2)	27s	https://s3-west.nrp-nautilus.io/public-blm/oil-gas-participating-areas/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [oil-gas-participating-areas] asset 'oil-gas-participating-areas-hex': STAC declares column 'bbox' but it is absent from all 7 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [oil-gas-participating-areas] asset 'oil-gas-participating-areas-hex' holds 2545 of 2562 features from 'oil-gas-participating-areas-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 17 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	94s	https://s3-west.nrp-nautilus.io/public-ca30x30/conserved-areas-terrestrial-2025/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-ca30x30/groundwater-dependent-ecosystems/wetlands/stac-collection.json	exit=0
+HARD(1)	12s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2025/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [williamson-act-2025] asset 'williamson-act-2025-hex' holds 120993 of 123980 features from 'williamson-act-2025-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 2987 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	94s	https://s3-west.nrp-nautilus.io/public-census/acs-2020-2024/blockgroup/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [acs-2020-2024-blockgroup] asset 'blockgroup-hex' holds 242747 of 242748 features from 'blockgroup-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-census/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-connectivity/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-dem/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2025/firep/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-2015-wbvert/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp5rcp85-2050-plants/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-high-seas/ecs/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/residencies/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-human-modification/stac-collection.json	exit=0
+HARD(1)	87s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/iplc-poly-stac.json	exit=1
+    [HARD][hex-missing-features] [landmark-iplc-poly] asset 'iplc-poly-hex' holds 106914 of 124616 features from 'iplc-poly-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 17702 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+TIMEOUT	300s	https://s3-west.nrp-nautilus.io/public-land-cover/cgls-lc100-2019/stac-collection.json
+HARD(3)	57s	https://s3-west.nrp-nautilus.io/public-overturemaps/2026-02-18.0/countries/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [overture-divisions-countries-2026-02-18] asset 'countries-parquet': STAC declares column 'names' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [overture-divisions-countries-2026-02-18] asset 'countries-parquet': STAC declares column 'sources' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][hex-missing-features] [overture-divisions-countries-2026-02-18] asset 'countries-hex' holds 195 of 378 features from 'countries-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 183 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-padus/stac-collection.json	exit=0
+CLEAN	5s	https://s3-west.nrp-nautilus.io/public-rap/rap-iag/stac-collection.json	exit=0
+HARD(2)	138s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/roo-cjest/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [american-rivers-roo-cjest] asset 'roo-cjest-hex' holds 73767 of 74134 features from 'roo-cjest-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 367 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+    [HARD][hex-duplicate-feature-cell-rows] [american-rivers-roo-cjest] asset 'roo-cjest-hex': 64 rows (0.000%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/stac-collection.json	exit=0
+HARD(2)	11s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/noaa-esu-dps/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [swap-2025-noaa-esu-dps] asset 'noaa-esu-dps-parquet': STAC declares column 'objectid' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [swap-2025-noaa-esu-dps] asset 'noaa-esu-dps-hex': STAC declares column 'objectid' but it is absent from all 2 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(4)	7s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/forest-woodland-coa/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-forest-woodland-coa] asset 'forest-woodland-coa-parquet': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-forest-woodland-coa] asset 'forest-woodland-coa-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-forest-woodland-coa] asset 'forest-woodland-coa-hex': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-forest-woodland-coa] asset 'forest-woodland-coa-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(2)	10s	https://s3-west.nrp-nautilus.io/public-swap/nevada/swap-2022/key-habitats/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [nevada-swap-2022-key-habitats] asset 'key-habitats-parquet': STAC declares column 'objectid' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [nevada-swap-2022-key-habitats] asset 'key-habitats-hex': STAC declares column 'objectid' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/places/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-trails/stac-collection.json	exit=0
+CLEAN	44s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/streams-by-order/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu4/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-utah/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-wetlands/ramsar/stac-collection.json	exit=0
+HARD(3)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/rap-iag/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-rap-iag] asset 'rap-iag-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/rap-iag/hex/'.
+    [HARD][hex-no-native-res] [wyoming-rap-iag] asset 'rap-iag-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-rap-iag] asset 'rap-iag-hex' missing 'h3:parent_resolutions'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-crucial/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-mule-deer-crucial] asset 'wgfd-mule-deer-crucial-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-crucial/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-mule-deer-crucial] asset 'wgfd-mule-deer-crucial-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-mule-deer-crucial] asset 'wgfd-mule-deer-crucial-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-mule-deer-crucial] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-crucial] parquet asset 'wgfd-mule-deer-crucial-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-crucial] parquet asset 'wgfd-mule-deer-crucial-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-5.txt
+HARD(1)	32s	https://s3-west.nrp-nautilus.io/public-blm/lua-leases-permits-easements/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [lua-leases-permits-easements] asset 'lua-leases-permits-easements-hex' holds 37477 of 39598 features from 'lua-leases-permits-easements-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 2121 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(1)	76s	https://s3-west.nrp-nautilus.io/public-blm/oil-shale-leases/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [oil-shale-leases] asset 'oil-shale-leases-hex': STAC declares column 'bbox' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-ca30x30/cwhr/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-ca30x30/plant-richness/stac-collection.json	exit=0
+HARD(1)	12s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/all-years/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [williamson-act-all-years] asset 'williamson-act-all-years-hex' holds 563977 of 567763 features from 'williamson-act-all-years-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 3786 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	104s	https://s3-west.nrp-nautilus.io/public-census/census-2024/cd/stac-collection.json	exit=0
+HARD(2)	16s	https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/map-unit-polys/stac-collection.json	exit=1
+    [HARD][categorical] [sierra-nevada-atlas-map-unit-polys] asset 'map-unit-polys-descriptions', column 'MapUnit': coded categorical column missing 'values' array.
+    [HARD][hex-missing-features] [sierra-nevada-atlas-map-unit-polys] asset 'map-unit-polys-hex' holds 6187 of 6221 features from 'map-unit-polys-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 34 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-connectivity/wildlife-movement-barriers/stac-collection.json	exit=0
+HARD(1)	56s	https://s3-west.nrp-nautilus.io/public-ecoregion/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [wwf-ecoregions-2017] asset 'ecoregion-hex': 6,356 rows (0.003%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	17s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2025/rxburn/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp1rcp26-2050-overall/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp5rcp85-2050-wbvert/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-high-seas/gebco-2025/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/stac-collection.json	exit=0
+HARD(1)	46s	https://s3-west.nrp-nautilus.io/public-hydrobasins/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [hydrobasins-v1c] asset 'level-03-hex' holds 291 of 292 features from 'level-03-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/iplc-pt-stac.json	exit=0
+TIMEOUT	300s	https://s3-west.nrp-nautilus.io/public-land-cover/nlcd/stac-collection.json
+HARD(2)	27s	https://s3-west.nrp-nautilus.io/public-overturemaps/2026-02-18.0/regions/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [overture-divisions-regions-2026-02-18] asset 'regions-parquet': STAC declares column 'names' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [overture-divisions-regions-2026-02-18] asset 'regions-parquet': STAC declares column 'sources' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-parks/park-access-2020/half-mile-access/stac-collection.json	exit=0
+CLEAN	7s	https://s3-west.nrp-nautilus.io/public-rap/rap-pfg-cover/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/stac-collection.json	exit=0
+CLEAN	55s	https://s3-west.nrp-nautilus.io/public-storms/ibtracs-v04r01/lines/stac-collection.json	exit=0
+HARD(1)	18s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/provinces/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [swap-2025-provinces] asset 'provinces-hex' holds 7 of 8 features from 'provinces-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(4)	8s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/glade-coa/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-glade-coa] asset 'glade-coa-parquet': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-glade-coa] asset 'glade-coa-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-glade-coa] asset 'glade-coa-hex': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-glade-coa] asset 'glade-coa-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+HARD(1)	49s	https://s3-west.nrp-nautilus.io/public-swap/nevada/swap-2022/species-distributions/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [nevada-swap-2022-species-distributions] asset 'species-distributions-hex': 1 rows (0.000%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/priority-areas-place/stac-collection.json	exit=0
+HARD(1)	20s	https://s3-west.nrp-nautilus.io/public-usfws/critical-habitat/final/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [usfws-critical-habitat-final] asset 'final-hex' holds 679 of 728 features from 'final-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 49 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usgs-ungulate-migration/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu6/stac-collection.json	exit=0
+CLEAN	47s	https://s3-west.nrp-nautilus.io/public-utah/udogm/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-wetlands/stac-collection.json	exit=0
+HARD(3)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/rap-pfg-biomass/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-rap-pfg-cover] asset 'rap-pfg-cover-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/rap-pfg-biomass/hex/'.
+    [HARD][hex-no-native-res] [wyoming-rap-pfg-cover] asset 'rap-pfg-cover-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-rap-pfg-cover] asset 'rap-pfg-cover-hex' missing 'h3:parent_resolutions'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-seasonal/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-mule-deer-seasonal] asset 'wgfd-mule-deer-seasonal-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-seasonal/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-mule-deer-seasonal] asset 'wgfd-mule-deer-seasonal-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-mule-deer-seasonal] asset 'wgfd-mule-deer-seasonal-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-mule-deer-seasonal] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-seasonal] parquet asset 'wgfd-mule-deer-seasonal-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-seasonal] parquet asset 'wgfd-mule-deer-seasonal-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-6.txt
+HARD(1)	90s	https://s3-west.nrp-nautilus.io/public-blm/lua-row/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [lua-row] asset 'lua-row-hex' holds 191959 of 196751 features from 'lua-row-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 4792 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-blm/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-ca30x30/cwhr13/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-ca30x30/rarity-weighted-endemic-plant-richness/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/stac-collection.json	exit=0
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-census/census-2024/county/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/stac-collection.json	exit=0
+HARD(2)	5s	https://s3-west.nrp-nautilus.io/public-cpad/cced-stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [cced-2025b] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [cced-2025b] parquet asset 'cced-parquet' has no 'table:columns'.
+HARD(1)	41s	https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [epa-sab-v3-cws] asset 'sab-cws-hex' holds 44128 of 44656 features from 'sab-cws-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 528 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+HARD(3)	113s	https://s3-west.nrp-nautilus.io/public-fire/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [fire-perimeters] asset 'firep-hex' holds 21877 of 22810 features from 'firep-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 933 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+    [HARD][hex-missing-features] [fire-perimeters] asset 'rxburn-hex' holds 10092 of 10675 features from 'rxburn-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 583 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+    [HARD][hex-missing-features] [fire-perimeters] asset 'combined-hex' holds 71510 of 135061 features from 'combined-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 63551 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp1rcp26-2050-plants/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-globio/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-high-seas/hydrothermal-vents/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/tracked-individuals/stac-collection.json	exit=0
+CLEAN	17s	https://s3-west.nrp-nautilus.io/public-icca/icca-registry/icca-point/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-indigenous/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-land-cover/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-overturemaps/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-parks/park-access-2020/no-park-access/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-rap/stac-collection.json	exit=0
+HARD(1)	10s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/wild-scenic-designated/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [american-rivers-wild-scenic-designated] asset 'wild-scenic-designated-hex': 4 rows (0.015%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+CLEAN	30s	https://s3-west.nrp-nautilus.io/public-storms/ibtracs-v04r01/points/stac-collection.json	exit=0
+HARD(1)	19s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/sgcn-ranges/stac-collection.json	exit=1
+    [HARD][hex-duplicate-feature-cell-rows] [swap-2025-sgcn-ranges] asset 'sgcn-ranges-hex': 1,315 rows (0.003%) are duplicate (finest-cell, _cng_fid) pairs — one hex row must be one (feature, cell) pair, so COUNT(*) and any per-cell SUM over this asset are inflated. Almost certainly a vector hex built before the 2026-07-12 polyfill fix (boettiger-lab/datasets#150); remediate with a SELECT DISTINCT * rewrite or re-hex. See data-workflows#509.
+HARD(4)	6s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/grassland-prairie-savanna-coa/stac-collection.json	exit=1
+    [HARD][declared-column-absent] [missouri-ccs-2022-grassland-prairie-savanna-coa] asset 'grassland-prairie-savanna-coa-parquet': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-grassland-prairie-savanna-coa] asset 'grassland-prairie-savanna-coa-parquet': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-grassland-prairie-savanna-coa] asset 'grassland-prairie-savanna-coa-hex': STAC declares column 'shape__area' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+    [HARD][declared-column-absent] [missouri-ccs-2022-grassland-prairie-savanna-coa] asset 'grassland-prairie-savanna-coa-hex': STAC declares column 'shape__length' but it is absent from all 1 parquet file(s) — a stale/incorrect schema; fix the STAC table:columns.
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-swap/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/priority-areas-urban-area/stac-collection.json	exit=0
+HARD(1)	26s	https://s3-west.nrp-nautilus.io/public-usfws/critical-habitat/proposed/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [usfws-critical-habitat-proposed] asset 'proposed-hex' holds 48 of 49 features from 'proposed-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-usgs-ungulate-migration/ungulate-ranges/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu8/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-utah/ugs-mineral-occurrences/stac-collection.json	exit=0
+TIMEOUT	301s	https://s3-west.nrp-nautilus.io/public-wui/stac-collection.json
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/sage-grouse-priority/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-sage-grouse-priority] asset 'sage-grouse-priority-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/sage-grouse-priority/hex/'.
+    [HARD][hex-no-native-res] [wyoming-sage-grouse-priority] asset 'sage-grouse-priority-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-sage-grouse-priority] asset 'sage-grouse-priority-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-sage-grouse-priority] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-sage-grouse-priority] parquet asset 'sage-grouse-priority-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-sage-grouse-priority] parquet asset 'sage-grouse-priority-hex' has no 'table:columns'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-crucial/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-pronghorn-crucial] asset 'wgfd-pronghorn-crucial-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-crucial/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-pronghorn-crucial] asset 'wgfd-pronghorn-crucial-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-pronghorn-crucial] asset 'wgfd-pronghorn-crucial-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-pronghorn-crucial] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-crucial] parquet asset 'wgfd-pronghorn-crucial-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-crucial] parquet asset 'wgfd-pronghorn-crucial-hex' has no 'table:columns'.
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/778c843a-f963-435a-a5d8-c25eac9ba400/scratchpad/slice-7.txt

--- a/catalog/audit/pregate-verify-sweep/analyze-findings.py
+++ b/catalog/audit/pregate-verify-sweep/analyze-findings.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Summarise a pre-gate sweep: HARD findings by category and by collection.
+
+Usage:  python3 analyze-findings.py /path/to/all-results.txt
+"""
+import re, sys
+from collections import Counter, defaultdict
+
+lines = open(sys.argv[1]).read().splitlines()
+cur, per_coll = None, defaultdict(Counter)
+for ln in lines:
+    m = re.match(r'^HARD\(\d+\)\t\d+s\t(\S+)', ln)
+    if m:
+        cur = m.group(1).split('/public-')[-1].rsplit('/stac', 1)[0]
+        per_coll.setdefault(cur, Counter())
+        continue
+    m = re.match(r'^\s+\[HARD\]\[([a-z0-9-]+)\]', ln)
+    if m and cur:
+        per_coll[cur][m.group(1)] += 1
+
+total = lambda c: sum(per_coll[c].values())
+print(f"{'COLLECTION':48} {'N':>3}  categories")
+for c in sorted(per_coll, key=lambda c: -total(c)):
+    cats = ", ".join(f"{k}×{v}" if v > 1 else k for k, v in per_coll[c].most_common())
+    print(f"{c:48} {total(c):>3}  {cats}")
+
+cat_colls = defaultdict(set)
+for c, cnt in per_coll.items():
+    for k in cnt:
+        cat_colls[k].add(c)
+print(f"\n# {len(per_coll)} collections with HARD findings\n# by category (collections affected):")
+for k in sorted(cat_colls, key=lambda k: -len(cat_colls[k])):
+    print(f"  {len(cat_colls[k]):>3}  {k}")

--- a/catalog/audit/pregate-verify-sweep/enumerate-collections.py
+++ b/catalog/audit/pregate-verify-sweep/enumerate-collections.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Walk the NRP STAC tree from the root catalog and emit every collection URL.
+
+Cheap: fetches only JSON docs (catalog.json / stac-collection.json) over HTTPS and
+follows `child` links — no data reads. One line per collection:
+
+    <kind>\t<id>\t<self-url>\t<error>
+
+kind is `leaf-data` (has a parquet asset — the data-backed checks apply), `meta`
+(only child links), or `leaf-nodata`. Feed the URLs to run-sweep.sh.
+
+Usage:  python3 enumerate-collections.py > collections.tsv
+"""
+import json, sys, urllib.request
+from collections import Counter
+
+ROOT = "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
+seen = {}
+
+
+def fetch(url):
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            return json.load(r)
+    except Exception as e:  # noqa: BLE001 — record and continue the walk
+        return {"__error__": str(e)}
+
+
+def walk(url):
+    if url in seen:
+        return
+    doc = seen.setdefault(url, fetch(url))
+    if "__error__" in doc:
+        return
+    for link in doc.get("links", []):
+        if link.get("rel") == "child" and link.get("href"):
+            walk(link["href"])
+
+
+walk(ROOT)
+
+rows = []
+for url, doc in seen.items():
+    if "__error__" in doc:
+        rows.append(("ERROR", "", url, doc["__error__"]))
+        continue
+    assets = doc.get("assets", {}) or {}
+    has_parquet = any(
+        (a.get("type", "") or "").endswith("parquet") or "parquet" in (a.get("href", "") or "")
+        for a in assets.values())
+    has_children = any(l.get("rel") == "child" for l in doc.get("links", []))
+    kind = "leaf-data" if has_parquet else ("meta" if has_children else "leaf-nodata")
+    rows.append((kind, doc.get("id", ""), url, ""))
+
+for kind, cid, url, err in sorted(rows):
+    print(f"{kind}\t{cid}\t{url}\t{err}")
+
+print(f"# {len(rows)} collections; by kind: {dict(Counter(r[0] for r in rows))}",
+      file=sys.stderr)

--- a/catalog/audit/pregate-verify-sweep/run-sweep.sh
+++ b/catalog/audit/pregate-verify-sweep/run-sweep.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Catalog-wide pre-gate verify-stac sweep (data-workflows#509 scope amendment).
+#
+# Runs the FULL data-backed scripts/verify-stac.py against every collection the
+# enumerator finds, in parallel, and records a compact per-collection verdict. This is
+# the "run the current rule set against every collection published before the CI gate"
+# pass — the gate is PR-triggered on changed catalog/** YAMLs, so pre-gate collections
+# are otherwise never re-verified.
+#
+# Usage:
+#   python3 enumerate-collections.py > /tmp/sweep/collections.tsv
+#   ./run-sweep.sh /tmp/sweep            # workdir; writes collections.tsv results there
+#
+# Output: $WORKDIR/results/r<N>.txt, one verdict line per collection —
+#   CLEAN <secs> <url> | HARD(<n>) <secs> <url>  (+ indented [HARD] lines) | TIMEOUT <secs> <url>
+# Aggregate with analyze-findings.py.
+set -u
+WORKDIR="${1:-/tmp/pregate-sweep}"
+SLICES="${SLICES:-8}"                 # parallel workers (keep MCP load sane)
+PERCOLL_TIMEOUT="${PERCOLL_TIMEOUT:-300}"
+VS="$(cd "$(dirname "$0")/../../.." && pwd)/scripts/verify-stac.py"
+mkdir -p "$WORKDIR/results"
+TSV="$WORKDIR/collections.tsv"
+[ -f "$TSV" ] || { echo "missing $TSV — run enumerate-collections.py first"; exit 1; }
+
+# leaf-data + meta (verify handles both; leaf-nodata has nothing to check)
+grep -E '^leaf-data|^meta' "$TSV" | awk -F'\t' '{print $3}' > "$WORKDIR/urls.txt"
+# interleave into SLICES so the big collections spread across workers
+awk -v n="$SLICES" '{print > "'"$WORKDIR"'/slice-" (NR%n) ".txt"}' "$WORKDIR/urls.txt"
+
+run_slice() {  # $1 slice file, $2 result file
+  : > "$2"
+  while IFS= read -r url; do
+    [ -z "$url" ] && continue
+    start=$(date +%s)
+    raw=$(timeout "$PERCOLL_TIMEOUT" python3 "$VS" "$url" 2>&1); rc=$?
+    el=$(( $(date +%s) - start ))
+    if [ $rc -eq 124 ]; then
+      echo "TIMEOUT	${el}s	$url" >> "$2"
+    else
+      n=$(echo "$raw" | grep -cE '^\[HARD\]')
+      if [ "$n" -eq 0 ]; then echo "CLEAN	${el}s	$url	exit=$rc" >> "$2"
+      else echo "HARD($n)	${el}s	$url	exit=$rc" >> "$2"
+           echo "$raw" | grep -E '^\[HARD\]' | sed 's/^/    /' >> "$2"; fi
+    fi
+  done < "$1"
+  echo "### slice done: $1" >> "$2"
+}
+
+pids=()
+for i in $(seq 0 $((SLICES-1))); do
+  run_slice "$WORKDIR/slice-$i.txt" "$WORKDIR/results/r$i.txt" &
+  pids+=($!)
+done
+echo "launched $SLICES workers over $(wc -l < "$WORKDIR/urls.txt") collections → $WORKDIR/results/"
+wait "${pids[@]}"
+cat "$WORKDIR"/results/r*.txt > "$WORKDIR/all-results.txt"
+echo "done. HARD collections: $(grep -cE '^HARD' "$WORKDIR/all-results.txt"), "\
+"CLEAN: $(grep -cE '^CLEAN' "$WORKDIR/all-results.txt"), TIMEOUT: $(grep -cE '^TIMEOUT' "$WORKDIR/all-results.txt")"

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1047,6 +1047,15 @@ def _first_text(result: dict) -> str:
     return ""
 
 
+# The duckdb-geo MCP renders at most a 50-row markdown PREVIEW and appends a warning
+# ("⚠️ Showing the first 50 rows only …"). A check that row-parses that preview as if it
+# were the whole result silently drops the tail — this is how check_declared_schema_matches_data
+# fabricated ~110 'absent' columns on every >50-column asset (SVI, FACTS; data-workflows#509).
+# Refuse to return a truncated preview: every check must compute its result server-side
+# (aggregate / set-diff) so the row count stays small, or it degrades to an advisory here.
+_TRUNCATED_PREVIEW_RE = re.compile(r"first\s+\d+\s+rows only", re.I)
+
+
 def _rows_from_tool_result(result: dict):
     """The query tool returns a markdown table in a text block. We only need the
     single projected column's values, so parse the markdown table generically."""
@@ -1055,6 +1064,9 @@ def _rows_from_tool_result(result: dict):
     sc = result.get("structuredContent")
     if isinstance(sc, dict) and isinstance(sc.get("rows"), list):
         return sc["rows"]
+    if _TRUNCATED_PREVIEW_RE.search(text or ""):
+        raise MCPError("MCP returned a truncated preview (first N rows only) — the query "
+                       "must aggregate / set-diff server-side, not row-parse a large table")
     return _parse_markdown_table(text)
 
 
@@ -1464,6 +1476,13 @@ def _partition_keys(href: str) -> set[str]:
     return {m.lower() for m in _PARTITION_KEY_RE.findall(href)}
 
 
+def _names_values(names) -> str:
+    """`('a'),('b'),…` — a de-duplicated, lowercased, quote-escaped name set for a SQL
+    VALUES anti-join. Callers guarantee the set is non-empty."""
+    esc = sorted({str(n).lower().replace("'", "''") for n in names})
+    return ", ".join(f"('{n}')" for n in esc)
+
+
 def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Finding]:
     """Every column the STAC declares must exist in the parquet, and vice versa — checked
     PER FILE, not against the glob's unioned schema (data-workflows#534). A whole-glob
@@ -1475,6 +1494,13 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
       present in data, undocumented        -> ADVISORY (self-describing contract; kept
                                               advisory because nested/covering leaves make
                                               a hard extra-column failure FP-prone)
+
+    The declared-vs-present set difference is computed IN SQL, returning only the
+    discrepancies, because the MCP `query` tool caps its output at a 50-row markdown
+    preview — a wide asset (SVI: 162 columns) row-parsed in Python would silently drop
+    every column past row 50 and fabricate ~110 'absent' findings (data-workflows#509).
+    The HARD (absent/heterogeneous) and ADVISORY (undocumented) diffs run as separate
+    queries so a large undocumented set can't truncate away the critical HARD result.
     """
     out = []
     for key, asset in doc.get("assets", {}).items():
@@ -1487,55 +1513,73 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
         if not declared:
             continue  # parquet-no-table-columns already HARD-flags a missing schema
         part_keys = _partition_keys(asset.get("href", ""))
+        declared_lower = {n.lower() for n in declared}
+        has_bbox = "bbox" in declared_lower
+        # Names to verify present: exclude path-supplied partition keys, the writer-named
+        # geometry column, and bbox (validated separately as a possible covering struct).
+        to_check = {n for n in declared_lower
+                    if n not in part_keys and n not in GEOM_COLS and n != "bbox"}
+        # `type IS NOT NULL` keeps only leaf columns, dropping the schema root / struct
+        # group nodes (physical type NULL) so they aren't phantom columns (#534 caveat).
+        base = (f"WITH sch AS (SELECT lower(name) AS name, file_name, type "
+                f"FROM parquet_schema('{s3}')), "
+                f"files AS (SELECT COUNT(DISTINCT file_name) AS total FROM sch), "
+                f"present AS (SELECT name, COUNT(DISTINCT file_name) AS nf FROM sch "
+                f"WHERE type IS NOT NULL GROUP BY 1) ")
         try:
-            total = int(mcp.query(
-                f"SELECT COUNT(DISTINCT file_name) AS n FROM parquet_schema('{s3}')")[0]["n"])
-            # `type IS NOT NULL` keeps only leaf columns, dropping the schema root and any
-            # struct group node (whose physical type is NULL) — so `parquet_schema`'s
-            # nested/struct entries do not read as phantom columns (#534 caveat).
-            rows = mcp.query(
-                "SELECT lower(name) AS name, COUNT(DISTINCT file_name) AS nf "
-                f"FROM parquet_schema('{s3}') WHERE type IS NOT NULL GROUP BY 1")
+            total = int(mcp.query(base + "SELECT total FROM files")[0]["total"])
+            parts = []
+            if to_check:
+                parts.append(
+                    f"SELECT d.name AS name, COALESCE(p.nf,0) AS nf "
+                    f"FROM (VALUES {_names_values(to_check)}) d(name) "
+                    f"LEFT JOIN present p ON p.name = d.name "
+                    f"WHERE COALESCE(p.nf,0) < (SELECT total FROM files)")
+            if has_bbox:
+                cover = ", ".join(f"'{c}'" for c in sorted(_BBOX_COVER))
+                # bbox is present if declared directly OR stored as its covering leaves
+                bexpr = (f"COALESCE((SELECT nf FROM present WHERE name='bbox'), "
+                         f"(SELECT MIN(nf) FROM present WHERE name IN ({cover})), 0)")
+                parts.append(f"SELECT 'bbox' AS name, {bexpr} AS nf "
+                             f"WHERE {bexpr} < (SELECT total FROM files)")
+            hard_rows = mcp.query(base + " UNION ALL ".join(parts)) if parts else []
         except (MCPError, ValueError, KeyError, IndexError) as e:
             out.append(Finding(ADVISORY, "schema-match-check-failed",
                                f"asset '{key}': could not read parquet footers ({e})."))
             continue
         if not total:
             continue
-        present = {}
-        for r in rows:
+        for r in hard_rows:
             try:
-                present[str(r["name"]).lower()] = int(r["nf"])
+                nm, nf = str(r["name"]), int(r["nf"])
             except (KeyError, ValueError, TypeError):
                 continue
-        # a `bbox` declared as one column may be stored as a covering struct — treat it as
-        # present if its leaves are (in as many files as the leaves appear).
-        bbox_leaf_files = (min((present[l] for l in _BBOX_COVER if l in present), default=0))
-
-        declared_lower = set()
-        for name in declared:
-            low = name.lower()
-            declared_lower.add(low)
-            if low in part_keys or _is_geom_col(name):
-                continue  # path-supplied partition key / writer-named geometry column
-            nf = present.get(low, 0)
-            if low == "bbox" and nf == 0:
-                nf = bbox_leaf_files  # covering-struct case
             if nf == 0:
                 out.append(Finding(HARD, "declared-column-absent",
-                    f"asset '{key}': STAC declares column '{name}' but it is absent from "
+                    f"asset '{key}': STAC declares column '{nm}' but it is absent from "
                     f"all {total} parquet file(s) — a stale/incorrect schema; fix the STAC "
                     f"table:columns."))
-            elif nf < total:
+            else:
                 out.append(Finding(HARD, "declared-column-heterogeneous",
-                    f"asset '{key}': STAC declares column '{name}' but it is missing from "
+                    f"asset '{key}': STAC declares column '{nm}' but it is missing from "
                     f"{total - nf} of {total} parquet file(s) — a partial/mixed-vintage "
                     f"build; rebuild the asset. See data-workflows#534/#520."))
-        for low, nf in sorted(present.items()):
-            if (nf == total and low not in declared_lower and low not in part_keys
-                    and not _is_geom_col(low) and low not in _BBOX_COVER and low != "bbox"):
+        # ADVISORY: columns present in every file but undeclared. Separate query so a
+        # truncation on a large undocumented set (guarded in _rows_from_tool_result) is
+        # caught here and skipped rather than dropping the HARD result above.
+        keep = declared_lower | part_keys | GEOM_COLS | _BBOX_COVER | {"bbox"}
+        try:
+            undoc = mcp.query(
+                base + f"SELECT p.name AS name FROM present p, files "
+                f"WHERE p.nf = files.total AND p.name NOT IN "
+                f"(SELECT name FROM (VALUES {_names_values(keep)}) k(name))")
+        except (MCPError, ValueError, KeyError, IndexError):
+            undoc = []  # truncated/failed advisory — non-critical
+        for r in undoc:
+            nm = str(r.get("name", ""))
+            if nm:
                 out.append(Finding(ADVISORY, "undocumented-column",
-                    f"asset '{key}': parquet column '{low}' is present in all {total} "
+                    f"asset '{key}': parquet column '{nm}' is present in all {total} "
                     f"file(s) but not declared in table:columns — add it (assets must be "
                     f"self-describing) or confirm it is intentional."))
     return out

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -20,6 +20,7 @@ Run: python3 -m unittest discover -s tests -v
 """
 import importlib.util
 import pathlib
+import re
 import unittest
 
 _SRC = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "verify-stac.py"
@@ -237,6 +238,27 @@ class ScriptedMCP:
         raise AssertionError(f"unscripted query: {sql}")
 
 
+class TruncationGuard(unittest.TestCase):
+    """The MCP caps output at a 50-row markdown preview; consuming it as complete is how
+    check_declared_schema_matches_data fabricated ~110 'absent' columns (#509). The client
+    must refuse a truncated preview rather than silently return a partial row set."""
+
+    @staticmethod
+    def _result(text):
+        return {"content": [{"type": "text", "text": text}]}
+
+    def test_truncated_preview_raises(self):
+        text = ("| name |\n|:--|\n| a |\n| b |\n\n"
+                "⚠️ Showing the first 50 rows only — this is a preview, not the full result.")
+        with self.assertRaises(vs.MCPError):
+            vs._rows_from_tool_result(self._result(text))
+
+    def test_full_result_parses(self):
+        text = "| name | nf |\n|:--|--:|\n| a | 2 |\n| b | 2 |"
+        self.assertEqual(vs._rows_from_tool_result(self._result(text)),
+                         [{"name": "a", "nf": "2"}, {"name": "b", "nf": "2"}])
+
+
 # --- #534: declared STAC schema vs actual parquet schema (per file) ---------
 
 def _schema_doc(declared, href=HEX_HREF):
@@ -244,38 +266,61 @@ def _schema_doc(declared, href=HEX_HREF):
                                  "table:columns": [{"name": n} for n in declared]}}}
 
 
-def _schema_mcp(total, name_nf):
-    return ScriptedMCP([
-        ("AS n FROM parquet_schema", [{"n": total}]),   # total-files query
-        ("GROUP BY 1", [{"name": n, "nf": nf} for n, nf in name_nf.items()]),
-    ])
+def _present(name_nf):
+    """Expand a {name: files_present} map into synthetic parquet_schema rows
+    (name, file_name, type). The total file count is COUNT(DISTINCT file_name), so the
+    scenario must include a column present in every file (the common case)."""
+    rows = []
+    for name, nf in name_nf.items():
+        for i in range(nf):
+            rows.append((name, f"f{i}", "INT"))
+    return rows
 
 
+@unittest.skipUnless(importlib.util.find_spec("duckdb"), "duckdb not installed")
 class DeclaredSchemaMatch(unittest.TestCase):
+    """The declared-vs-present set difference is computed IN SQL (so the MCP's 50-row
+    preview cap can't drop wide-schema columns and fabricate 'absent' findings, #509).
+    These run that real SQL against a synthetic parquet_schema relation."""
+
+    def _run(self, name_nf, declared, href=HEX_HREF):
+        import duckdb
+        rows = _present(name_nf)
+        vals = ", ".join(
+            "('%s','%s',%s)" % (n, f, "NULL" if t is None else "'%s'" % t)
+            for (n, f, t) in rows)
+        repl = "(SELECT * FROM (VALUES %s) _s(name, file_name, type))" % vals
+
+        class Exec:
+            def query(self, sql):
+                con = duckdb.connect()
+                sql2 = re.sub(r"parquet_schema\('[^']*'\)", lambda m: repl, sql)
+                cur = con.execute(sql2)
+                names = [d[0] for d in cur.description]
+                return [dict(zip(names, r)) for r in cur.fetchall()]
+
+        return vs.check_declared_schema_matches_data(_schema_doc(declared, href), Exec())
+
     def test_clean_reports_nothing(self):
         # h0 is a path partition key (from /h0=*/), so it is legitimately skipped.
-        doc = _schema_doc(["_cng_fid", "rfb", "h0"])
-        mcp = _schema_mcp(2, {"_cng_fid": 2, "rfb": 2, "h0": 2})
-        self.assertEqual(vs.check_declared_schema_matches_data(doc, mcp), [])
+        f = self._run({"_cng_fid": 2, "rfb": 2}, ["_cng_fid", "rfb", "h0"])
+        self.assertEqual(f, [])
 
     def test_declared_absent_everywhere_is_hard(self):
-        doc = _schema_doc(["_cng_fid", "ghost"])
-        f = vs.check_declared_schema_matches_data(doc, _schema_mcp(2, {"_cng_fid": 2}))
+        f = self._run({"_cng_fid": 2}, ["_cng_fid", "ghost"])
         self.assertEqual([x.code for x in f], ["declared-column-absent"])
         self.assertEqual(f[0].severity, vs.HARD)
         self.assertIn("ghost", f[0].message)
 
     def test_heterogeneous_hole_is_hard_and_counts_files(self):
         # THE #520 case: _cng_fid present in only some files.
-        doc = _schema_doc(["_cng_fid", "rfb"])
-        f = vs.check_declared_schema_matches_data(doc, _schema_mcp(121, {"_cng_fid": 99, "rfb": 121}))
+        f = self._run({"_cng_fid": 99, "rfb": 121}, ["_cng_fid", "rfb"])
         self.assertEqual([x.code for x in f], ["declared-column-heterogeneous"])
         self.assertEqual(f[0].severity, vs.HARD)
         self.assertIn("22 of 121", f[0].message)
 
     def test_undocumented_extra_is_advisory(self):
-        doc = _schema_doc(["_cng_fid"])
-        f = vs.check_declared_schema_matches_data(doc, _schema_mcp(2, {"_cng_fid": 2, "surprise": 2}))
+        f = self._run({"_cng_fid": 2, "surprise": 2}, ["_cng_fid"])
         self.assertEqual([x.code for x in f], ["undocumented-column"])
         self.assertEqual(f[0].severity, vs.ADVISORY)
         self.assertIn("surprise", f[0].message)
@@ -283,15 +328,19 @@ class DeclaredSchemaMatch(unittest.TestCase):
     def test_partition_key_absent_from_footer_is_not_flagged(self):
         # Mutation guard: a partition key lives in the PATH, not the footer. Declaring h0
         # while parquet_schema shows no h0 must NOT read as an absent column.
-        doc = _schema_doc(["_cng_fid", "h0"])
-        f = vs.check_declared_schema_matches_data(doc, _schema_mcp(2, {"_cng_fid": 2}))
+        f = self._run({"_cng_fid": 2}, ["_cng_fid", "h0"])
         self.assertEqual(f, [])
 
     def test_geometry_column_is_skipped(self):
         # geometry may be writer-named differently; skip it both directions.
-        doc = {"assets": {"d-parquet": {"href": "https://x/d.parquet", "type": PARQUET,
-               "table:columns": [{"name": "_cng_fid"}, {"name": "geom"}]}}}
-        f = vs.check_declared_schema_matches_data(doc, _schema_mcp(1, {"_cng_fid": 1}))
+        f = self._run({"_cng_fid": 1}, ["_cng_fid", "geom"], href="https://x/d.parquet")
+        self.assertEqual(f, [])
+
+    def test_wide_schema_is_not_truncated(self):
+        # #509 regression: 160 present+declared columns must all read present. A row-parsed
+        # 50-row preview would fabricate ~110 'absent' findings here.
+        wide = {f"col{i}": 1 for i in range(160)}
+        f = self._run(wide, [f"col{i}" for i in range(160)], href="https://x/d.parquet")
         self.assertEqual(f, [])
 
 


### PR DESCRIPTION
Advances #509's scope amendment (systematic pre-gate `verify-stac` audit + **fix the checks as well as the data**).

## The check bug (the headline)
Running the full data-backed `verify-stac.py` against all 266 catalog collections, the dominant finding was **1,474 `declared-column-absent` HARD findings across 50 collections — every one false.** `check_declared_schema_matches_data` (#534) pulled every leaf column via `parquet_schema` and compared in Python, but the duckdb-geo MCP renders at most a **50-row markdown preview**. Any asset with >50 columns had its columns-past-50 read as absent (SVI county: 162 cols → 112 false; FACTS: 128 → 127). It had been **silently failing CI for every wide-table recipe since #534 landed**.

**Fix:** compute the declared-vs-present set-difference **in SQL** (VALUES anti-join, returns only discrepancies — the pattern `check_values_match_distinct` already uses), plus a global guard in `_rows_from_tool_result` that raises on the truncation marker so no check can ever again consume a preview as complete. After the fix, `declared-column-absent` → **59 real findings / 28 collections** (genuinely stale schemas). Real defects still caught (iucn-taxonomy's 9 absent list-columns; the #520 heterogeneous `_cng_fid` hole). Tests: `DeclaredSchemaMatch` now runs the real SQL against synthetic `parquet_schema` data + a 160-column no-truncation regression + truncation-guard tests — **34 pass**.

## Reproducible pre-gate audit
`catalog/audit/pregate-verify-sweep/` — enumerate every collection from the STAC tree, run the full verifier in parallel, summarise findings. The gate is PR-triggered on changed YAMLs, so pre-gate collections are otherwise never retro-verified; this makes the systematic pass repeatable. Includes the 2026-08-17 snapshot: **161 CLEAN / 97 HARD / 8 TIMEOUT**.

## Triaged inventory (post-fix)
| category | colls | disposition |
|---|--:|---|
| `hex-missing-features` (#535) | 50 | per-collection: sub-cell → doc note; real drop → re-hex (file vs #535) |
| `declared-column-absent` (#534) | 28 | stale STAC — metadata fix (BLM MLRS, swap/missouri, overturemaps, iucn/taxonomy) |
| Wyoming STAC-template cluster (13) | 14×3 | missing hex glob / `h3:*` res / per-asset `table:columns` — batch metadata fix |
| cpad family (3) | — | `table:columns` at collection level + none on asset |
| `hex-duplicate-feature-cell-rows` (#509) | 10 | `SELECT DISTINCT *` (known lossless pattern) — rivers/nri, overturemaps/counties, landvote, ecoregion, swap ranges |
| singletons | 1–2 | license / nav-parent / temporal / categorical |

Remediation of the 97 is **follow-up work** (per-collection judgment + cluster jobs), tracked in this PR's issue thread — this PR delivers the checker fix (which removes the largest false-positive class) and the audit that scopes the rest. Full breakdown in the README + `RESULTS-2026-08-17.txt`.

> Reviewer note: `scripts/**` + `tests/**` changes run the unit suite (34 pass). The sweep harness under `catalog/audit/**` is excluded from the Verify-STAC path filter by design.