### PR TITLE
fix(#509): #534 nested-column/partition false-positives + drop 30 stale table:columns

### DIFF
--- a/catalog/audit/k8s/stac-drop-stale-columns.yaml
+++ b/catalog/audit/k8s/stac-drop-stale-columns.yaml
@@ -1,0 +1,110 @@
+# data-workflows#509 — drop genuinely-stale columns from table:columns so the STAC matches
+# the parquet (#534). These are the declared-column-absent findings that remain AFTER the
+# nested-column / multi-level-partition check fix: columns the data really lacks —
+#   bbox on the BLM/imma/kba HEX assets (the hex carries no bbox or its leaves),
+#   shape__area / shape__length on swap/missouri (the data has the Esri `Shape.STArea()` /
+#     `Shape.STLength()` names instead — those become undocumented-advisory, not HARD),
+#   objectid on swap/wdoecm (the data has OBJECTID_1 / none; _cng_fid is the id).
+# In-cluster (STAC canonical on NRP S3); drops are grouped per collection and validated.
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: drop-stale-map, namespace: geo-workflows}
+data:
+  map.tsv: |
+    https://s3-west.nrp-nautilus.io/public-blm/coal-cases/stac-collection.json	coal-cases-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/geothermal-leases/stac-collection.json	geothermal-leases-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/locatable-operations/stac-collection.json	locatable-operations-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/mineral-materials/stac-collection.json	mineral-materials-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/mining-claims/stac-collection.json	mining-claims-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/non-energy-leasables/stac-collection.json	non-energy-leasables-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/oil-gas-agreements/stac-collection.json	oil-gas-agreements-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/oil-gas-participating-areas/stac-collection.json	oil-gas-participating-areas-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-blm/oil-shale-leases/stac-collection.json	oil-shale-leases-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-high-seas/imma/stac-collection.json	imma-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-kba/kba-2026-03/sites/stac-collection.json	sites-hex	bbox
+    https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/noaa-esu-dps/stac-collection.json	noaa-esu-dps-parquet	objectid
+    https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/noaa-esu-dps/stac-collection.json	noaa-esu-dps-hex	objectid
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/cave-karst-coa/stac-collection.json	cave-karst-coa-parquet	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/cave-karst-coa/stac-collection.json	cave-karst-coa-hex	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/forest-woodland-coa/stac-collection.json	forest-woodland-coa-parquet	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/forest-woodland-coa/stac-collection.json	forest-woodland-coa-hex	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/glade-coa/stac-collection.json	glade-coa-parquet	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/glade-coa/stac-collection.json	glade-coa-hex	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/grassland-prairie-savanna-coa/stac-collection.json	grassland-prairie-savanna-coa-parquet	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/grassland-prairie-savanna-coa/stac-collection.json	grassland-prairie-savanna-coa-hex	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/priority-geographies/stac-collection.json	priority-geographies-parquet	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/priority-geographies/stac-collection.json	priority-geographies-hex	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/stream-reach-coa/stac-collection.json	stream-reach-coa-parquet	shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/stream-reach-coa/stac-collection.json	stream-reach-coa-hex	shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/wetland-coa/stac-collection.json	wetland-coa-parquet	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/wetland-coa/stac-collection.json	wetland-coa-hex	shape__area,shape__length
+    https://s3-west.nrp-nautilus.io/public-swap/nevada/swap-2022/key-habitats/stac-collection.json	key-habitats-parquet	objectid
+    https://s3-west.nrp-nautilus.io/public-swap/nevada/swap-2022/key-habitats/stac-collection.json	key-habitats-hex	objectid
+    https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026/stac-collection.json	wdoecm-parquet	objectid
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-drop-stale-columns
+  namespace: geo-workflows
+  labels: {k8s-app: stac-drop-stale-columns}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata: {labels: {k8s-app: stac-drop-stale-columns}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: drop
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: map, mountPath: /config, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -uo pipefail
+          python3 - <<'PY'
+          import json, subprocess, re
+          from collections import defaultdict
+          groups = defaultdict(dict)   # url -> {asset: set(cols)}
+          for line in open('/config/map.tsv'):
+              line=line.rstrip('\n')
+              if not line.strip(): continue
+              url, asset, cols = line.split('\t')
+              groups[url].setdefault(asset, set()).update(c.lower() for c in cols.split(','))
+          for url, amap in groups.items():
+              key='nrp:'+re.sub(r'https?://s3-west\.nrp-nautilus\.io/','',url)
+              cid=url.split('/public-')[-1].replace('/stac-collection.json','')
+              try:
+                  doc=json.loads(subprocess.check_output(['rclone','cat',key]))
+              except Exception as e:
+                  print(f"{cid}\tERROR-read\t{e}"); continue
+              changed=[]
+              for asset, drop in amap.items():
+                  a=doc.get('assets',{}).get(asset)
+                  if not a or 'table:columns' not in a:
+                      print(f"{cid}\t{asset}\tSKIP no-asset/table:columns"); continue
+                  before=len(a['table:columns'])
+                  a['table:columns']=[c for c in a['table:columns'] if c.get('name','').lower() not in drop]
+                  removed=before-len(a['table:columns'])
+                  changed.append(f"{asset}:-{removed}({','.join(sorted(drop))})")
+              if not changed: continue
+              open('/tmp/o.json','w').write(json.dumps(doc, indent=2))
+              json.load(open('/tmp/o.json'))
+              subprocess.check_call(['rclone','copyto','/tmp/o.json',key])
+              print(f"{cid}\tDROPPED\t{'; '.join(changed)}")
+          print("done")
+          PY
+        resources:
+          requests: {cpu: '1', memory: 1Gi, ephemeral-storage: 1Gi}
+          limits:   {cpu: '1', memory: 1Gi, ephemeral-storage: 1Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: map, configMap: {name: drop-stale-map}}

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1466,7 +1466,10 @@ def check_polygon_row_dup(doc: dict, mcp: MCPClient) -> list[Finding]:
 # #534 — declared STAC schema vs actual parquet schema (per file)
 # ---------------------------------------------------------------------------
 
-_PARTITION_KEY_RE = re.compile(r"/([^/=]+)=\*/")
+# No leading `/`: consecutive hive partitions share a slash (…/Z=*/h0=*/…), and a
+# leading-slash pattern consumes it, so `findall` would miss every key after the first
+# (glwd's class-area-hex is partitioned Z=*/h0=*, and h0 was mis-reported absent, #509).
+_PARTITION_KEY_RE = re.compile(r"([^/=]+)=\*/")
 # GeoParquet 1.1 bbox-covering struct leaves: a STAC declares a single `bbox` column but
 # the file stores it as a struct with these leaves. Neither the `bbox` declaration nor the
 # leaves should be treated as absent/undocumented.
@@ -1523,13 +1526,19 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
         # geometry column, and bbox (validated separately as a possible covering struct).
         to_check = {n for n in declared_lower
                     if n not in part_keys and n not in GEOM_COLS and n != "bbox"}
-        # `type IS NOT NULL` keeps only leaf columns, dropping the schema root / struct
-        # group nodes (physical type NULL) so they aren't phantom columns (#534 caveat).
+        # `present` (leaves, physical type NOT NULL) is used for the bbox-covering leaves.
+        # `present_all` ALSO keeps the parquet GROUP nodes (physical type NULL) — a top-level
+        # LIST or STRUCT column (`country_codes VARCHAR[]`, Overture `names`/`sources`) is a
+        # group node whose only leaf is the internal `element`/`value`, so matching declared
+        # names against leaves alone false-flagged every nested column absent (#509). The
+        # parquet LIST/MAP internal names are excluded so they never mask a real absence.
         base = (f"WITH sch AS (SELECT lower(name) AS name, file_name, type "
                 f"FROM parquet_schema('{s3}')), "
                 f"files AS (SELECT COUNT(DISTINCT file_name) AS total FROM sch), "
                 f"present AS (SELECT name, COUNT(DISTINCT file_name) AS nf FROM sch "
-                f"WHERE type IS NOT NULL GROUP BY 1) ")
+                f"WHERE type IS NOT NULL GROUP BY 1), "
+                f"present_all AS (SELECT name, COUNT(DISTINCT file_name) AS nf FROM sch "
+                f"WHERE name NOT IN ('list','element','key_value','key','value') GROUP BY 1) ")
         try:
             total = int(mcp.query(base + "SELECT total FROM files")[0]["total"])
             parts = []
@@ -1537,12 +1546,13 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
                 parts.append(
                     f"SELECT d.name AS name, COALESCE(p.nf,0) AS nf "
                     f"FROM (VALUES {_names_values(to_check)}) d(name) "
-                    f"LEFT JOIN present p ON p.name = d.name "
+                    f"LEFT JOIN present_all p ON p.name = d.name "
                     f"WHERE COALESCE(p.nf,0) < (SELECT total FROM files)")
             if has_bbox:
                 cover = ", ".join(f"'{c}'" for c in sorted(_BBOX_COVER))
-                # bbox is present if declared directly OR stored as its covering leaves
-                bexpr = (f"COALESCE((SELECT nf FROM present WHERE name='bbox'), "
+                # bbox is present if declared directly (a struct group node, so present_all)
+                # OR stored as its covering leaves (present)
+                bexpr = (f"COALESCE((SELECT nf FROM present_all WHERE name='bbox'), "
                          f"(SELECT MIN(nf) FROM present WHERE name IN ({cover})), 0)")
                 parts.append(f"SELECT 'bbox' AS name, {bexpr} AS nf "
                              f"WHERE {bexpr} < (SELECT total FROM files)")
@@ -1568,15 +1578,18 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
                     f"asset '{key}': STAC declares column '{nm}' but it is missing from "
                     f"{total - nf} of {total} parquet file(s) — a partial/mixed-vintage "
                     f"build; rebuild the asset. See data-workflows#534/#520."))
-        # ADVISORY: columns present in every file but undeclared. Separate query so a
-        # truncation on a large undocumented set (guarded in _rows_from_tool_result) is
-        # caught here and skipped rather than dropping the HARD result above.
+        # ADVISORY: columns present in every file but undeclared. Excludes the parquet
+        # LIST/MAP internal names so a nested column's `element`/`value` leaf is never
+        # mis-reported as an undocumented column. Separate query so a truncation on a large
+        # undocumented set (guarded in _rows_from_tool_result) is caught here and skipped,
+        # not dropping the HARD result above.
         keep = declared_lower | part_keys | GEOM_COLS | _BBOX_COVER | {"bbox"}
         try:
             undoc = mcp.query(
                 base + f"SELECT p.name AS name FROM present p, files "
-                f"WHERE p.nf = files.total AND p.name NOT IN "
-                f"(SELECT name FROM (VALUES {_names_values(keep)}) k(name))")
+                f"WHERE p.nf = files.total "
+                f"AND p.name NOT IN ('list','element','key_value','key','value') "
+                f"AND p.name NOT IN (SELECT name FROM (VALUES {_names_values(keep)}) k(name))")
         except (MCPError, ValueError, KeyError, IndexError):
             undoc = []  # truncated/failed advisory — non-critical
         for r in undoc:

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -283,9 +283,9 @@ class DeclaredSchemaMatch(unittest.TestCase):
     preview cap can't drop wide-schema columns and fabricate 'absent' findings, #509).
     These run that real SQL against a synthetic parquet_schema relation."""
 
-    def _run(self, name_nf, declared, href=HEX_HREF):
+    def _run(self, name_nf, declared, href=HEX_HREF, raw_rows=None):
         import duckdb
-        rows = _present(name_nf)
+        rows = raw_rows if raw_rows is not None else _present(name_nf)
         vals = ", ".join(
             "('%s','%s',%s)" % (n, f, "NULL" if t is None else "'%s'" % t)
             for (n, f, t) in rows)
@@ -334,6 +334,27 @@ class DeclaredSchemaMatch(unittest.TestCase):
     def test_geometry_column_is_skipped(self):
         # geometry may be writer-named differently; skip it both directions.
         f = self._run({"_cng_fid": 1}, ["_cng_fid", "geom"], href="https://x/d.parquet")
+        self.assertEqual(f, [])
+
+    def test_nested_list_column_is_present_not_absent(self):
+        # A top-level LIST column (`country_codes VARCHAR[]`) is a parquet GROUP node with
+        # physical type NULL; its only leaf is the internal `element`. Declaring it must NOT
+        # read as absent (data-workflows#509: iucn-taxonomy, Overture names/sources).
+        raw = [("_cng_fid", "f0", "INT"),
+               ("country_codes", "f0", None),   # LIST group node
+               ("list", "f0", None), ("element", "f0", "BYTE_ARRAY")]
+        f = self._run({}, ["_cng_fid", "country_codes"], raw_rows=raw)
+        self.assertEqual(f, [])
+
+    def test_multilevel_partition_key_not_flagged(self):
+        # Two-level hive partition Z=*/h0=*: both keys are path-supplied, so declaring `h0`
+        # must not read as absent (the consecutive partitions share a slash, #509).
+        self.assertEqual(
+            vs._partition_keys("https://x/glwd/class-area-hex/Z=*/h0=*/data_0.parquet"),
+            {"z", "h0"})
+        raw = [("area_ha", "f0", "INT")]   # file stores neither Z nor h0
+        f = self._run({}, ["area_ha", "h0"], raw_rows=raw,
+                      href="https://x/glwd/class-area-hex/Z=*/h0=*/data_0.parquet")
         self.assertEqual(f, [])
 
     def test_wide_schema_is_not_truncated(self):


### PR DESCRIPTION
Fourth remediation batch: the **28 `declared-column-absent` (#534)** collections. Investigation split them cleanly into **check false-positives** and **genuinely-stale STAC**.

## Two more #534 check bugs fixed (the "fix the checks" mandate)
1. **Nested LIST/STRUCT columns** — a top-level `country_codes VARCHAR[]`, Overture `names`/`sources`, mappinginequality `geom_bbox`, gbif `issue` is a parquet **GROUP node with physical type NULL** (its only leaf is the internal `element`/`value`). The check's `type IS NOT NULL` leaf filter dropped it, so every nested column false-flagged absent — iucn-taxonomy alone fabricated 9. Added a `present_all` CTE that keeps group nodes (minus the LIST/MAP internals) for the declared-vs-present match; the bbox-covering case now also matches a struct `bbox` node.
2. **Multi-level hive partitions** — `_PARTITION_KEY_RE` required a leading `/`, but consecutive partitions share one (`…/Z=*/h0=*/…`), so `findall` returned only `Z` and glwd's `h0` false-flagged absent.

Cleared 7 collections (iucn-taxonomy, overture ×3, mappinginequality, glwd, gbif). 40 unit tests pass (added nested-column + multi-partition cases). Verified live: those go clean, the genuinely-stale `bbox` on blm-coal still flags.

## 21 collections genuinely stale → dropped
The remainder really lack the declared columns, so `stac-drop-stale-columns.yaml` dropped them (STAC now matches data):
- **bbox** on 9 BLM + imma + kba **hex** assets (the hex carries no bbox / leaves),
- **shape__area / shape__length** on the 7 swap/missouri ccs layers (data has the Esri `Shape.STArea()`/`STLength()` names),
- **objectid** on swap noaa-esu-dps / nevada key-habitats / wdoecm (data has `OBJECTID_1` / none; `_cng_fid` is the id).

Verified clean (blm/coal-cases, swap/missouri/glade-coa → declared-column-absent = 0). `scripts/**`+`tests/**` run the unit suite; the STAC edits are already live on S3.