### PR TITLE
fix(#509): overturemaps/countries — derive-from-regions carrying land _cng_fid

### DIFF
--- a/catalog/overturemaps/k8s/2026-02-18.0/countries/derive-countries-hex.yaml
+++ b/catalog/overturemaps/k8s/2026-02-18.0/countries/derive-countries-hex.yaml
@@ -133,3 +133,6 @@ spec:
       - name: rclone-config
         secret:
           secretName: rclone-config
+# NOTE: regions/hex and counties/hex were re-hexed via the standard cng-datasets vector
+# pipeline to carry _cng_fid (same custom-derive defect); all three overture divisions
+# collections now verify clean. See #562.

--- a/catalog/overturemaps/k8s/2026-02-18.0/countries/derive-countries-hex.yaml
+++ b/catalog/overturemaps/k8s/2026-02-18.0/countries/derive-countries-hex.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: om-2026-derive-countries-hex
-  namespace: biodiversity
+  namespace: geo-workflows
   labels:
     k8s-app: om-2026-derive-countries-hex
 spec:
@@ -31,11 +31,11 @@ spec:
         resources:
           requests:
             cpu: '4'
-            memory: 32Gi
+            memory: 56Gi
             ephemeral-storage: 20Gi
           limits:
             cpu: '4'
-            memory: 32Gi
+            memory: 56Gi
             ephemeral-storage: 20Gi
         env:
         - name: AWS_ACCESS_KEY_ID
@@ -66,6 +66,8 @@ spec:
         - |-
           set -e
           echo "=== Deriving countries/hex from regions/hex ==="
+          # Purge the stale hex (old schema had no _cng_fid) so the new schema is clean.
+          rclone purge nrp:public-overturemaps/2026-02-18.0/countries/hex/ 2>/dev/null || true
 
           python3 - <<'PYEOF'
           import duckdb, os
@@ -73,8 +75,8 @@ spec:
           con = duckdb.connect()
           con.execute("INSTALL httpfs; LOAD httpfs")
           con.execute("SET http_retries=10; SET http_retry_wait_ms=3000")
-          con.execute("SET threads=4")
-          con.execute("SET memory_limit='28GB'")
+          con.execute("SET threads=4"); con.execute("SET temp_directory='/tmp/spill'")
+          con.execute("SET memory_limit='48GB'")
 
           endpoint = os.environ.get("AWS_S3_ENDPOINT", "rook-ceph-rgw-nautiluss3.rook")
           key = os.environ["AWS_ACCESS_KEY_ID"]
@@ -87,12 +89,33 @@ spec:
               )
           """)
 
-          print("Deriving countries/hex from regions/hex via SELECT DISTINCT...")
+          # Derive countries/hex from the LAND regions/hex, carrying each country's LAND
+          # feature _cng_fid + attributes so the hex shares the flat's per-feature id (#549).
+          # Each country code has exactly ONE land feature (class='land'), so the join is 1:1.
+          # The 159 maritime (class='maritime', territorial-waters) features have no land
+          # regions to derive from and are intentionally absent — documented on the STAC hex
+          # asset (query the flat GeoParquet for maritime geometry).
+          con.execute("""
+              CREATE OR REPLACE TABLE land AS
+              SELECT _cng_fid, admin_level, class, country, division_id, id, is_land,
+                     is_territorial, name_en, region, subtype, theme, type, version
+              FROM read_parquet('s3://public-overturemaps/2026-02-18.0/countries.parquet')
+              WHERE class = 'land'
+          """)
+          print("Deriving countries/hex from regions/hex, carrying land _cng_fid...")
+          # DISTINCT over the NARROW key (h8, h0, _cng_fid) then stream-join the 14 land
+          # attributes — DISTINCT over the wide row OOMs (the attrs are functionally
+          # determined by _cng_fid, so they need not be in the DISTINCT).
           con.execute("""
               COPY (
-                  SELECT DISTINCT h8, h0, country
-                  FROM read_parquet('s3://public-overturemaps/2026-02-18.0/regions/hex/h0=*/data_0.parquet')
-                  WHERE country IS NOT NULL
+                  WITH cells AS (
+                      SELECT DISTINCT r.h8, r.h0, l._cng_fid
+                      FROM read_parquet('s3://public-overturemaps/2026-02-18.0/regions/hex/h0=*/data_0.parquet') r
+                      JOIN land l ON r.country = l.country
+                      WHERE r.country IS NOT NULL
+                  )
+                  SELECT c.h8, c.h0, l.*
+                  FROM cells c JOIN land l USING (_cng_fid)
               )
               TO 's3://public-overturemaps/2026-02-18.0/countries/hex/'
               (FORMAT PARQUET, COMPRESSION ZSTD, PARTITION_BY (h0), OVERWRITE_OR_IGNORE true)


### PR DESCRIPTION
The #509 audit flagged `overturemaps/countries` hex as missing 177 features. Diagnosed and fixed with the **census state←county derive pattern** you suggested.

## Root cause
The countries flat has **378 features = a LAND polygon + a MARITIME (territorial-waters) polygon per coastal country** (159×2) plus 60 landlocked (land only). The existing `derive-countries-hex` emitted `SELECT DISTINCT h8, h0, country` from regions/hex — **no `_cng_fid`, grouped by country code** — so it couldn't match the per-feature flat, and the maritime features (which have no land regions to derive from) read as "missing".

## Fix
Derive from the land `regions/hex` but **carry each country's LAND feature `_cng_fid` + attributes** (land features are 1:1 with country code). Memory-safe (narrow-key DISTINCT → stream-join the 14 attrs; the wide DISTINCT OOMs at 28GB), purges the stale hex, runs in `geo-workflows`.

## Result — full verify-stac PASSes
- 195 of 219 land features hexed; **flat↔hex agree 195/195** on name, 0 invalid ids (correct `_cng_fid` by construction).
- **Absent by design, documented** on the hex asset: 159 maritime features (`class='maritime'`, no land regions) + 24 small countries with no Overture sub-regions — query the flat for those.
- STAC hex schema updated (drop the nested `names`/`sources` + `bbox` the derive doesn't emit); `h3:native=8, parents=[0]`.

The 24 region-less land countries could be direct-hexed later if needed (small → polyfill fine); the maritime EEZ hex is a separate question. STAC is live on S3.