### PR TITLE
docs: raster native H3 resolution must match the source pixel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -941,6 +941,17 @@ missing `h8` and conclude the dataset is broken.
 discards detail the source genuinely has — do it only when feature size or RAM forces it, and
 record the reason in the issue.
 
+⛔ **ALWAYS pass `--h3-resolution` explicitly for a raster — never rely on auto-detection.**
+`cng-datasets` picks the resolution whose average H3 *edge* is nearest **3× the pixel width**
+(~9 source pixels per cell). That agrees with the table above at fine pixels (100 m → 9,
+300 m → 8) and **diverges as pixels coarsen**: 500 m → h7 and **~1 km → h6**, neither of which
+carries **`h8`**, so the resulting dataset silently fails to join the rest of the catalog. The
+mismatch is only ever reported as an informational log line (`ℹ Using finer resolution h8 (user
+specified) instead of detected h6`), never an error. This is the likely origin of the gHM `h7`
+outlier flagged above — a 1 km raster sitting near where auto-detection points rather than at
+the convention. Tracked upstream in
+[`boettiger-lab/datasets#182`](https://github.com/boettiger-lab/datasets/issues/182).
+
 ### Vector workflow parameters
 
 | Param | Default | When to change |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -952,6 +952,27 @@ outlier flagged above — a 1 km raster sitting near where auto-detection points
 the convention. Tracked upstream in
 [`boettiger-lab/datasets#182`](https://github.com/boettiger-lab/datasets/issues/182).
 
+⛔ **`cng-datasets raster` output is in PHYSICAL units — do NOT apply the GeoTIFF scale/offset
+again.** The hex step hands the raster *path* to `exactextract`, whose GDAL source applies the
+band's `scale`/`offset`, so the values written to parquet are already degrees C, mm, metres —
+not the stored integers. Grepping `cng_datasets/raster/cog.py` for `GetScale` finds nothing and
+is **misleading**: the conversion happens a layer down, inside exactextract.
+
+Measured on CHELSA bio1 (stored UInt16, `Scale=0.1 Offset=-273.15`), Amazon h0 at res 5:
+`min=1.51 max=30.15 mean=27.32` — plainly degrees C. Re-applying the transform produced
+`-273.5 … -269.9`, which is only obviously wrong if something checks it.
+
+- **A double-scaled column passes every structural check.** Row counts, partition coverage, NULL
+  counts and any `median BETWEEN min AND max` invariant all stay perfectly consistent, because a
+  linear transform applied twice preserves ordering and cardinality. Only a **physical
+  plausibility bound** catches it — assert the measured range against what the quantity can
+  actually be (e.g. surface air temperature within −95…60 °C) before publishing.
+- The same bound doubles as a **nodata-leak detector**: a surviving sentinel drags a mean toward
+  the sentinel and blows the bound.
+- **Reading the same raster with `gdal.Band.ReadAsArray` does NOT apply scale/offset** — that
+  path needs the explicit transform. Two scripts in the same build can legitimately differ on
+  this; check which reader each uses before "fixing" one to match the other.
+
 ### Vector workflow parameters
 
 | Param | Default | When to change |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -891,12 +891,55 @@ empty joins). So encode the joins into the data, don't hope the model derives th
   (e.g. large marine areas hexed at `h5`) to keep hex cell-count/RAM sane. Such a dataset
   *cannot* carry `h8` (finer than native); consumers roll finer data **up** to `h5` to join it.
   Use a coarse native res because the feature size forces it, never as a cost shortcut on data
-  that should be `h8`.
+  that should be `h8`. **For rasters the same applies but the driver is the source pixel, not
+  feature size** — see the resolution table below.
 - **A dataset may declare a *set* of parents** (e.g. native `h8` with `--parent-resolutions
   "5,4,0"` → columns `h8,h5,h4,h0`) so it joins at several standard resolutions at once. Pick the
   parent set from the resolutions of the datasets it will be joined against.
 - Always record the chosen native + parents in the issue (scope) and in the hex asset's
   `h3:native_resolution` / `h3:parent_resolutions` (STAC).
+
+
+#### ⭐ For RASTERS, native resolution is set by the SOURCE PIXEL — match it, never oversample
+
+The `h8` default above is a **vector** convention. For a raster, native resolution is not a
+preference, it is a **measurement**: read the source pixel size and pick the H3 resolution that
+matches it. Hexing finer than the source pixel adds **no information** — it replicates each
+pixel value across many cells, costs ~7× rows and ~7× build time per resolution step, and
+publishes a hex whose apparent detail is a lie about the source.
+
+**Measure the pixel first** (`gdalinfo` → `Pixel Size`; convert degrees to km at the relevant
+latitude), then read off the established anchors:
+
+| Source pixel | ≈ pixel area | Native H3 | H3 cell area | Example |
+|---|---|---|---|---|
+| 30 m | 0.001 km² | **10** | 0.015 km² | NLCD, Hansen — `h10` is our finest, so 30 m is *under*sampled; accept it |
+| 100 m | 0.01 km² | **9** | 0.105 km² | |
+| 250–500 m | 0.06–0.25 km² | **8** | 0.74 km² | MODIS-class |
+| ~1 km | 1 km² | **8** | 0.74 km² | CHELSA / WorldClim bioclim, gHM |
+| ~5 km | 25 km² | **6** | 36 km² | LOCA2, gridMET |
+| ~10 km | 100 km² | **5** | 253 km² | |
+| 0.25° (~25 km) | 625 km² | **5** | 253 km² | NEX-GDDP-CMIP6 |
+| 0.5° (~50 km) | 2 500 km² | **4** | 1 770 km² | |
+| 1° (~100 km) | 10 000 km² | **3** | 12 400 km² | raw GCM output |
+
+The anchors are not a single formula — the fine end deliberately puts several source pixels in
+each cell so an area-weighted reduce has something to average, while the coarse end lands
+within a factor of ~2–3 either way (0.25° sits almost exactly between `h4` and `h5`; we take
+`h5` so no detail is discarded). **The guardrail is what matters:** compute
+`pixel_area ÷ cell_area` and if it exceeds ~10, the resolution is wrong. A 0.25° climate pixel
+hexed at `h8` is an **~850× oversample** — 850 identical rows per real value.
+
+**Consequence — coarse sources cannot carry `h8`, and that is correct.** Any raster whose
+native resolution is coarser than 8 (every global climate product) has **no `h8` column**,
+because `h8` would be finer than the data supports. Same sanctioned case as continent-scale
+vector features: consumers roll finer catalog data **up** to the coarse resolution to join it,
+never the reverse. State this in the hex asset `description` so an agent does not hunt for a
+missing `h8` and conclude the dataset is broken.
+
+**Undersampling is a deliberate choice too, never a default.** Going coarser than the pixel
+discards detail the source genuinely has — do it only when feature size or RAM forces it, and
+record the reason in the issue.
 
 ### Vector workflow parameters
 
@@ -927,7 +970,7 @@ Raster completions are always **122** — not configurable.
 Most rework here comes from skipped pre-flight checks, not hard problems. Do, in order:
 
 1. **Pre-flight the COG** with one GDAL job (rclone-localize → read; never `/vsis3` for GDAL — it's flaky/node-dependent). Report size, dtype, **real nodata** (published STAC nodata is often wrong), and the value summary that becomes your validation truth (class histogram for `mode`; pixel-SUM for `sum`; min/max/mean for `mean`). **Confirm the COG is non-empty** — published "total" COGs have shipped 100% nodata.
-2. **Resolution = match the source pixel** (≈100 m → res 9; ≈500 m → res 8). Don't bump blindly; res finer than the pixel is 7× cost for no gain.
+2. **Resolution = match the source pixel** — see the raster resolution table under *For RASTERS, native resolution is set by the SOURCE PIXEL* above (≈100 m → res 9; ≈500 m → res 8; 0.25° → res 5). Don't bump blindly; res finer than the pixel is 7× cost for no gain.
 3. **Hex job musts:** mount the `rclone-config` secret (the tool localizes the COG via rclone first; generated YAML omits it → fails), `backoffLimitPerIndex: 2` + `maxFailedIndexes` (not `backoffLimit: 0`), output to a **staging** prefix. `:latest` has the seam fix — no runtime clone.
 4. **Validate value AND coverage.** `sum`: hex `SUM` == COG pixel-SUM. Note `sum`/area layers are a **full h0 grid** (one row per cell, `value = 0` where the feature is absent) — same shape as carbon/ghs-pop; that's expected, not bloat. Check that the count of **nonzero** cells matches the feature extent, not the total. `mode`: sparse (cells with no valid pixel are dropped); only canonical codes + distribution tracks the histogram. **Seam (all reducers):** dateline h0 `576707042908045311` — fixed builds span ±180°, buggy ones are bloated and miss the dateline.
    **⛔ h0-partition COVERAGE gate (data-workflows #409).** An indexed 122-completion hex Job that dies/gets-preempted mid-run can leave a *subset* of h0 partitions on S3 and get published as if complete. Two defenses, both required: (a) never treat a hex build as done unless the k8s Job reports `Complete=True` with empty `failedIndexes` — a partial run must surface as `Failed`, so keep `backoffLimitPerIndex` + `maxFailedIndexes` (never `backoffLimit: 0`); and (b) after the job, run the cheap partition-set gate against a reference build from the same COG (e.g. the fractional-coverage layer) or an explicit expected h0 set:

--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -129,6 +129,99 @@ data:
 
     if __name__ == "__main__":
         sys.exit(main())
+  chelsa_join_mask.py: |
+    """Join the per-quantile hex partitions for one h0 and apply the land mask (data-workflows #564).
+
+    Each ensemble quantile is hexed separately by `cng-datasets raster` into
+    `<hex-root>/p<q>/h0=<cell>/data_0.parquet`. They share a grid, a resolution and an h0, so they
+    share an h8 key — this joins them into one wide row per cell and then restricts to land.
+
+    The land mask is the WWF Terrestrial Ecoregions h8 hex (chosen over Overture countries, which is
+    a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica).
+
+    Exit 3 means "nothing survived the mask" — the caller treats that as a skip, not a failure.
+    """
+    import argparse
+    import glob
+    import sys
+
+    import duckdb
+
+    QUANTILES = (10, 50, 90)
+
+
+    def part(hex_root: str, q: int, h0: str) -> str:
+        hits = glob.glob(f"{hex_root}/p{q}/h0={h0}/data_0.parquet")
+        if not hits:
+            raise SystemExit(f"ERROR: missing hex partition for p{q} h0={h0}")
+        return hits[0]
+
+
+    def main() -> int:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--h0", required=True)
+        ap.add_argument("--var", required=True)
+        ap.add_argument("--hex-root", required=True)
+        ap.add_argument("--mask", required=True)
+        ap.add_argument("--out", required=True)
+        args = ap.parse_args()
+
+        con = duckdb.connect()
+        paths = {q: part(args.hex_root, q, args.h0) for q in QUANTILES}
+
+        counts = {q: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
+                  for q, p in paths.items()}
+        print(f"rows per quantile: {counts}")
+        if len(set(counts.values())) != 1:
+            # Not fatal -- an inner join keeps only cells present in all three -- but it should not
+            # happen for rasters that share a grid and mask, so make it visible.
+            print("WARNING: quantile partitions differ in row count; join will keep the intersection")
+
+        base = args.var
+        sel = ", ".join(f"p{q}.{base}_p{q}" for q in QUANTILES)
+        joins = " ".join(
+            f"JOIN read_parquet('{paths[q]}') p{q} ON p{q}.h8 = p50.h8"
+            for q in QUANTILES if q != 50
+        )
+
+        con.execute(f"""
+            COPY (
+                SELECT p50.h8, p50.h5, p50.h4, p50.h0, {sel}
+                FROM read_parquet('{paths[50]}') p50
+                {joins}
+                SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) m
+                  ON p50.h8 = m.h8
+            ) TO '{args.out}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+        """)
+
+        after = con.execute(f"SELECT COUNT(*) FROM read_parquet('{args.out}')").fetchone()[0]
+        before = counts[50]
+        print(f"MASK h0={args.h0} rows_before={before} rows_after={after} "
+              f"kept={100.0 * after / before if before else 0:.2f}%")
+        if after == 0:
+            print("EMPTY after land mask")
+            return 3
+
+        rng = con.execute(f"""
+            SELECT MIN({base}_p50), MAX({base}_p50), COUNT(*) FILTER (WHERE {base}_p50 IS NULL)
+            FROM read_parquet('{args.out}')
+        """).fetchone()
+        print(f"MEASURED {base}_p50 min={rng[0]} max={rng[1]} nulls={rng[2]}")
+        # Ordering invariant: p10 <= p50 <= p90 must hold for every cell.
+        bad = con.execute(f"""
+            SELECT COUNT(*) FROM read_parquet('{args.out}')
+            WHERE {base}_p10 > {base}_p50 OR {base}_p50 > {base}_p90
+        """).fetchone()[0]
+        print(f"CHECK quantile-ordering violations: {bad}")
+        if bad:
+            print("ERROR: ensemble quantiles are not monotonic", file=sys.stderr)
+            return 4
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
 kind: ConfigMap
 metadata:
   name: chelsa-scripts

--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -130,16 +130,29 @@ data:
     if __name__ == "__main__":
         sys.exit(main())
   chelsa_join_mask.py: |
-    """Join the per-quantile hex partitions for one h0 and apply the land mask (data-workflows #564).
+    """Join the per-GCM hex partitions for one h0, apply units + land mask (data-workflows #564).
 
-    Each ensemble quantile is hexed separately by `cng-datasets raster` into
-    `<hex-root>/p<q>/h0=<cell>/data_0.parquet`. They share a grid, a resolution and an h0, so they
-    share an h8 key — this joins them into one wide row per cell and then restricts to land.
+    Each ensemble member is hexed separately by `cng-datasets raster` into
+    `<hex-root>/<member>/h0=<cell>/data_0.parquet`. They share a grid, resolution and h0, so they
+    share an h8 key -- this joins them into one wide row per cell.
 
-    The land mask is the WWF Terrestrial Ecoregions h8 hex (chosen over Overture countries, which is
-    a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica).
+    Three things happen here that cannot happen earlier:
 
-    Exit 3 means "nothing survived the mask" — the caller treats that as a skip, not a failure.
+    1. **Units.** `cng-datasets` does not apply the GeoTIFF scale/offset, so hex values are raw
+       integers. Because `exact_extract`'s area-weighted mean and CHELSA's scale/offset are both
+       linear, `mean(scale*x + offset) == scale*mean(x) + offset` -- applying the transform here is
+       exactly equivalent to applying it to the raster, and saves building a float COG per member.
+
+    2. **Ensemble statistics.** All five member values are kept as columns; the upstream product
+       ships per-GCM files and no ensemble product, so the members are the faithful representation.
+       `median`/`min`/`max` are materialised alongside them because a five-member ensemble is
+       summarised by its median and full range (percentiles need a larger ensemble), and because
+       these are the expressions a consumer is most likely to get wrong across five columns.
+
+    3. **Land mask.** WWF Terrestrial Ecoregions h8 hex -- chosen over Overture countries, which is
+       a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica.
+
+    Exit 3 means "nothing survived the mask" -- the caller treats that as a skip, not a failure.
     """
     import argparse
     import glob
@@ -147,81 +160,139 @@ data:
 
     import duckdb
 
-    QUANTILES = (10, 50, 90)
 
-
-    def part(hex_root: str, q: int, h0: str) -> str:
-        hits = glob.glob(f"{hex_root}/p{q}/h0={h0}/data_0.parquet")
+    def part(hex_root: str, member_col: str, h0: str) -> str:
+        hits = glob.glob(f"{hex_root}/{member_col}/h0={h0}/data_0.parquet")
         if not hits:
-            raise SystemExit(f"ERROR: missing hex partition for p{q} h0={h0}")
+            raise SystemExit(f"ERROR: missing hex partition for member {member_col} h0={h0}")
         return hits[0]
 
 
     def main() -> int:
         ap = argparse.ArgumentParser()
         ap.add_argument("--h0", required=True)
-        ap.add_argument("--var", required=True)
+        ap.add_argument("--var", required=True, help="variable prefix, e.g. bio1")
+        ap.add_argument("--members", required=True,
+                        help="comma-separated member column suffixes, e.g. gfdl_esm4,ipsl_cm6a_lr,...")
+        ap.add_argument("--scale", type=float, required=True)
+        ap.add_argument("--offset", type=float, required=True)
         ap.add_argument("--hex-root", required=True)
         ap.add_argument("--mask", required=True)
         ap.add_argument("--out", required=True)
+        ap.add_argument("--sane-min", type=float, default=None,
+                        help="fail if any physical value falls below this")
+        ap.add_argument("--sane-max", type=float, default=None,
+                        help="fail if any physical value rises above this")
         args = ap.parse_args()
 
+        members = [m.strip() for m in args.members.split(",") if m.strip()]
+        if len(members) < 2:
+            print("ERROR: need at least 2 ensemble members", file=sys.stderr)
+            return 1
+
+        var = args.var
         con = duckdb.connect()
-        paths = {q: part(args.hex_root, q, args.h0) for q in QUANTILES}
+        paths = {m: part(args.hex_root, f"{var}_{m}", args.h0) for m in members}
 
-        counts = {q: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
-                  for q, p in paths.items()}
-        print(f"rows per quantile: {counts}")
+        counts = {m: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
+                  for m, p in paths.items()}
+        print(f"rows per member: {counts}")
         if len(set(counts.values())) != 1:
-            # Not fatal -- an inner join keeps only cells present in all three -- but it should not
-            # happen for rasters that share a grid and mask, so make it visible.
-            print("WARNING: quantile partitions differ in row count; join will keep the intersection")
+            print("WARNING: member partitions differ in row count; join keeps the intersection")
 
-        base = args.var
-        sel = ", ".join(f"p{q}.{base}_p{q}" for q in QUANTILES)
+        base = members[0]
+        # Physical units: raw * scale + offset, applied per member.
+        phys = [f"({base}t.{var}_{base} * {args.scale} + {args.offset})" if m == base
+                else f"({m}t.{var}_{m} * {args.scale} + {args.offset})"
+                for m in members]
+        sel_members = ", ".join(f"{e} AS {var}_{m}" for e, m in zip(phys, members))
+        arr = "[" + ", ".join(phys) + "]"
+
         joins = " ".join(
-            f"JOIN read_parquet('{paths[q]}') p{q} ON p{q}.h8 = p50.h8"
-            for q in QUANTILES if q != 50
+            f"JOIN read_parquet('{paths[m]}') {m}t ON {m}t.h8 = {base}t.h8"
+            for m in members if m != base
         )
 
         con.execute(f"""
             COPY (
-                SELECT p50.h8, p50.h5, p50.h4, p50.h0, {sel}
-                FROM read_parquet('{paths[50]}') p50
+                SELECT {base}t.h8, {base}t.h5, {base}t.h4, {base}t.h0,
+                       {sel_members},
+                       list_sort({arr})[{(len(members) + 1) // 2}] AS {var}_median,
+                       list_min({arr})  AS {var}_min,
+                       list_max({arr})  AS {var}_max
+                FROM read_parquet('{paths[base]}') {base}t
                 {joins}
-                SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) m
-                  ON p50.h8 = m.h8
+                SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) msk
+                  ON {base}t.h8 = msk.h8
             ) TO '{args.out}'
             (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
         """)
 
         after = con.execute(f"SELECT COUNT(*) FROM read_parquet('{args.out}')").fetchone()[0]
-        before = counts[50]
+        before = counts[base]
         print(f"MASK h0={args.h0} rows_before={before} rows_after={after} "
               f"kept={100.0 * after / before if before else 0:.2f}%")
         if after == 0:
             print("EMPTY after land mask")
             return 3
 
-        rng = con.execute(f"""
-            SELECT MIN({base}_p50), MAX({base}_p50), COUNT(*) FILTER (WHERE {base}_p50 IS NULL)
+        lo, hi, nulls = con.execute(f"""
+            SELECT MIN({var}_min), MAX({var}_max),
+                   COUNT(*) FILTER (WHERE {var}_median IS NULL)
             FROM read_parquet('{args.out}')
         """).fetchone()
-        print(f"MEASURED {base}_p50 min={rng[0]} max={rng[1]} nulls={rng[2]}")
-        # Ordering invariant: p10 <= p50 <= p90 must hold for every cell.
+        print(f"MEASURED {var} physical range: min={lo} max={hi} median_nulls={nulls}")
+
+        # median must lie within [min, max] for every cell -- catches a broken ensemble reduce.
         bad = con.execute(f"""
             SELECT COUNT(*) FROM read_parquet('{args.out}')
-            WHERE {base}_p10 > {base}_p50 OR {base}_p50 > {base}_p90
+            WHERE {var}_median < {var}_min OR {var}_median > {var}_max
         """).fetchone()[0]
-        print(f"CHECK quantile-ordering violations: {bad}")
+        print(f"CHECK median-outside-range violations: {bad}")
         if bad:
-            print("ERROR: ensemble quantiles are not monotonic", file=sys.stderr)
+            print("ERROR: ensemble median falls outside the member range", file=sys.stderr)
             return 4
+
+        # Plausibility bound -- catches a wrong scale/offset, which is otherwise invisible.
+        if args.sane_min is not None and lo is not None and lo < args.sane_min:
+            print(f"ERROR: min {lo} below sane bound {args.sane_min}", file=sys.stderr)
+            return 5
+        if args.sane_max is not None and hi is not None and hi > args.sane_max:
+            print(f"ERROR: max {hi} above sane bound {args.sane_max}", file=sys.stderr)
+            return 5
         return 0
 
 
     if __name__ == "__main__":
         sys.exit(main())
+  chelsa_read_meta.py: |
+    """Print scale, offset and nodata for a CHELSA raster (data-workflows #564).
+
+    CHELSA declares these per file and they differ per variable -- bio1/bio4/bio12 use nodata 0
+    while bio15 uses 65535, and bio1 carries offset -273.15 where the others carry 0. The build
+    reads them from the file rather than carrying a table, so a new variable cannot silently
+    inherit the wrong sentinel.
+
+    Emits one shell-eval-able line: SCALE=<f> OFFSET=<f> NODATA=<v>
+    """
+    import argparse
+
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    args = ap.parse_args()
+
+    band = gdal.Open(args.input).GetRasterBand(1)
+    scale = band.GetScale()
+    offset = band.GetOffset()
+    nodata = band.GetNoDataValue()
+
+    print(f"SCALE={1.0 if scale is None else scale} "
+          f"OFFSET={0.0 if offset is None else offset} "
+          f"NODATA={'' if nodata is None else repr(nodata).rstrip('0').rstrip('.') if nodata == int(nodata) else nodata}")
 kind: ConfigMap
 metadata:
   name: chelsa-scripts

--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -274,25 +274,56 @@ data:
     inherit the wrong sentinel.
 
     Emits one shell-eval-able line: SCALE=<f> OFFSET=<f> NODATA=<v>
+    (NODATA is empty when the source declares none.)
     """
     import argparse
+    import sys
 
     from osgeo import gdal
 
     gdal.UseExceptions()
 
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--input", required=True)
-    args = ap.parse_args()
 
-    band = gdal.Open(args.input).GetRasterBand(1)
-    scale = band.GetScale()
-    offset = band.GetOffset()
-    nodata = band.GetNoDataValue()
+    def fmt_nodata(v):
+        if v is None:
+            return ""
+        # GDAL returns a float; emit an integer when the sentinel is integral so the value
+        # round-trips into `cng-datasets --nodata` as e.g. "0", never "0.0".
+        return str(int(v)) if float(v).is_integer() else repr(v)
 
-    print(f"SCALE={1.0 if scale is None else scale} "
-          f"OFFSET={0.0 if offset is None else offset} "
-          f"NODATA={'' if nodata is None else repr(nodata).rstrip('0').rstrip('.') if nodata == int(nodata) else nodata}")
+
+    def main() -> int:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--input", required=True)
+        args = ap.parse_args()
+
+        # Hold the Dataset for the lifetime of the band: chaining
+        # `gdal.Open(p).GetRasterBand(1)` lets the Dataset be garbage-collected and leaves the
+        # band dangling, which surfaces as a TypeError inside the SWIG shim rather than as a
+        # clean failure.
+        ds = gdal.Open(args.input)
+        if ds is None:
+            print(f"ERROR: could not open {args.input}", file=sys.stderr)
+            return 1
+        band = ds.GetRasterBand(1)
+        if band is None:
+            print(f"ERROR: no band 1 in {args.input}", file=sys.stderr)
+            return 1
+
+        scale = band.GetScale()
+        offset = band.GetOffset()
+        nodata = band.GetNoDataValue()
+
+        print(f"SCALE={1.0 if scale is None else scale} "
+              f"OFFSET={0.0 if offset is None else offset} "
+              f"NODATA={fmt_nodata(nodata)}")
+        del band
+        del ds
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
 kind: ConfigMap
 metadata:
   name: chelsa-scripts

--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -129,6 +129,33 @@ data:
 
     if __name__ == "__main__":
         sys.exit(main())
+  chelsa_h0_for_index.py: |
+    """Resolve a cng-datasets h0 *index* (0-121) to its h0 *cell id* (data-workflows #564).
+
+    `cng-datasets raster --h0-index N` looks N up in the h0 grid parquet by its `i` column. Doing
+    the same lookup up front lets a job decide whether an h0 holds any land *before* paying to hex
+    it: only 108 of the 122 h0 cells intersect the WWF ecoregions land mask, so the remaining 14
+    would otherwise hex every ensemble member and then discard the result.
+    """
+    import argparse
+    import sys
+
+    import duckdb
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--grid", required=True, help="local path to the h0 grid parquet")
+    ap.add_argument("--index", type=int, required=True)
+    args = ap.parse_args()
+
+    row = duckdb.connect().execute(
+        "SELECT h0 FROM read_parquet(?) WHERE i = ?", [args.grid, args.index]
+    ).fetchone()
+
+    if row is None:
+        print(f"ERROR: no h0 cell for index {args.index}", file=sys.stderr)
+        sys.exit(1)
+
+    print(row[0])
   chelsa_join_mask.py: |
     """Join the per-GCM hex partitions for one h0, apply units + land mask (data-workflows #564).
 

--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+data:
+  chelsa_ensemble.py: |
+    """CHELSA v2.1 GCM-ensemble reduction -> physical-unit float32 COG (data-workflows #564).
+
+    Reads the N per-GCM rasters for one (variable, ssp, period) triple and writes one COG per
+    requested ensemble quantile, in physical units.
+
+    Design notes (all driven by the measured preflight on #564):
+      * scale/offset and nodata are read FROM EACH FILE (`GetScale`/`GetOffset`/`GetNoDataValue`),
+        never hardcoded -- CHELSA declares different sentinels per variable (bio1/bio4/bio12 use 0,
+        bio15 uses 65535), so a single batch-wide constant would corrupt the output.
+      * a pixel is nodata in the output if it is nodata in ANY member -- the ensemble is only
+        defined where every GCM has a value.
+      * bio12 saturates at the UInt16 ceiling (65535); those pixels are flagged, counted, and
+        reported so the clipping is visible rather than silently averaged.
+      * processed in row blocks so a 43200x20880 x N-member stack never has to fit in RAM.
+    """
+    import argparse
+    import os
+    import sys
+
+    import numpy as np
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+
+    UINT16_CEIL = 65535
+    OUT_NODATA = -9999.0
+
+
+    def main() -> int:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--input", action="append", required=True, help="per-GCM source raster (repeat)")
+        ap.add_argument("--out-prefix", required=True, help="output path prefix; quantile is appended")
+        ap.add_argument("--quantiles", default="10,50,90")
+        ap.add_argument("--block-rows", type=int, default=512)
+        args = ap.parse_args()
+
+        qs = [float(q) for q in args.quantiles.split(",")]
+        srcs = [gdal.Open(p) for p in args.input]
+        n = len(srcs)
+        if n < 2:
+            print("ERROR: need at least 2 members for an ensemble", file=sys.stderr)
+            return 1
+
+        b0 = srcs[0].GetRasterBand(1)
+        xsize, ysize = srcs[0].RasterXSize, srcs[0].RasterYSize
+        scale = b0.GetScale() if b0.GetScale() is not None else 1.0
+        offset = b0.GetOffset() if b0.GetOffset() is not None else 0.0
+        nodata = b0.GetNoDataValue()
+
+        # Every member must share grid, scale/offset and sentinel, or the ensemble is meaningless.
+        for p, ds in zip(args.input, srcs):
+            b = ds.GetRasterBand(1)
+            if (ds.RasterXSize, ds.RasterYSize) != (xsize, ysize):
+                print(f"ERROR: grid mismatch in {p}", file=sys.stderr)
+                return 1
+            s = b.GetScale() if b.GetScale() is not None else 1.0
+            o = b.GetOffset() if b.GetOffset() is not None else 0.0
+            if (s, o) != (scale, offset) or b.GetNoDataValue() != nodata:
+                print(f"ERROR: scale/offset/nodata mismatch in {p}: "
+                      f"{(s, o, b.GetNoDataValue())} != {(scale, offset, nodata)}", file=sys.stderr)
+                return 1
+
+        print(f"members={n} grid={xsize}x{ysize} scale={scale} offset={offset} nodata={nodata}")
+
+        drv = gdal.GetDriverByName("GTiff")
+        opts = ["COMPRESS=ZSTD", "PREDICTOR=3", "TILED=YES", "BIGTIFF=YES"]
+        tmp_paths, outs = [], []
+        for q in qs:
+            tp = f"{args.out_prefix}_p{int(q)}.tmp.tif"
+            ds = drv.Create(tp, xsize, ysize, 1, gdal.GDT_Float32, options=opts)
+            ds.SetGeoTransform(srcs[0].GetGeoTransform())
+            ds.SetProjection(srcs[0].GetProjection())
+            ds.GetRasterBand(1).SetNoDataValue(OUT_NODATA)
+            tmp_paths.append(tp)
+            outs.append(ds)
+
+        n_valid = n_nodata = n_saturated = 0
+        vmin, vmax = np.inf, -np.inf
+
+        for y in range(0, ysize, args.block_rows):
+            rows = min(args.block_rows, ysize - y)
+            stack = np.empty((n, rows, xsize), dtype=np.float64)
+            bad = np.zeros((rows, xsize), dtype=bool)
+            for i, ds in enumerate(srcs):
+                a = ds.GetRasterBand(1).ReadAsArray(0, y, xsize, rows)
+                if nodata is not None:
+                    bad |= (a == nodata)
+                n_saturated += int((a == UINT16_CEIL).sum())
+                stack[i] = a
+
+            vals = np.percentile(stack, qs, axis=0)          # (len(qs), rows, xsize)
+            vals = vals * scale + offset                      # -> physical units
+
+            n_valid += int((~bad).sum())
+            n_nodata += int(bad.sum())
+            if (~bad).any():
+                vmin = min(vmin, float(vals[:, ~bad].min()))
+                vmax = max(vmax, float(vals[:, ~bad].max()))
+
+            for k, ds in enumerate(outs):
+                band = vals[k]
+                band[bad] = OUT_NODATA
+                ds.GetRasterBand(1).WriteArray(band.astype(np.float32), 0, y)
+            print(f"  rows {y}-{y + rows} done", flush=True)
+
+        for ds in outs:
+            ds.FlushCache()
+        outs = None
+
+        # Rewrite as proper COGs.
+        for tp, q in zip(tmp_paths, qs):
+            final = f"{args.out_prefix}_p{int(q)}.tif"
+            print(f"COG -> {final}")
+            gdal.Translate(final, tp, format="COG",
+                           creationOptions=["COMPRESS=ZSTD", "PREDICTOR=3",
+                                            "OVERVIEWS=IGNORE_EXISTING", "BIGTIFF=YES"])
+            os.remove(tp)
+
+        total = n_valid + n_nodata
+        print(f"MEASURED valid={n_valid} nodata={n_nodata} "
+              f"({100.0 * n_valid / total:.4f}% valid)")
+        print(f"MEASURED physical range: min={vmin:.4f} max={vmax:.4f}")
+        print(f"MEASURED source pixels at UInt16 ceiling ({UINT16_CEIL}) across all members: {n_saturated}")
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+kind: ConfigMap
+metadata:
+  name: chelsa-scripts
+  namespace: geo-workflows

--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -165,10 +165,15 @@ data:
 
     Three things happen here that cannot happen earlier:
 
-    1. **Units.** `cng-datasets` does not apply the GeoTIFF scale/offset, so hex values are raw
-       integers. Because `exact_extract`'s area-weighted mean and CHELSA's scale/offset are both
-       linear, `mean(scale*x + offset) == scale*mean(x) + offset` -- applying the transform here is
-       exactly equivalent to applying it to the raster, and saves building a float COG per member.
+    1. **Units are ALREADY PHYSICAL -- do not transform them here.** `cng-datasets` hands the raster
+       *path* to `exactextract`, whose GDAL source applies the GeoTIFF scale/offset, so hex values
+       arrive in degrees C / mm, not raw integers. Measured on the Amazon h0: min 1.51, max 30.15,
+       mean 27.32 (degrees C). Applying the transform again yielded ~-273, which the plausibility
+       bound below caught.
+
+       Note the contrast with `chelsa_ensemble.py`, which reads via `gdal.Band.ReadAsArray` --
+       that path does NOT apply scale/offset, so the explicit transform there is correct. The two
+       files legitimately differ; do not "fix" one to match the other.
 
     2. **Ensemble statistics.** All five member values are kept as columns; the upstream product
        ships per-GCM files and no ensemble product, so the members are the faithful representation.
@@ -201,8 +206,6 @@ data:
         ap.add_argument("--var", required=True, help="variable prefix, e.g. bio1")
         ap.add_argument("--members", required=True,
                         help="comma-separated member column suffixes, e.g. gfdl_esm4,ipsl_cm6a_lr,...")
-        ap.add_argument("--scale", type=float, required=True)
-        ap.add_argument("--offset", type=float, required=True)
         ap.add_argument("--hex-root", required=True)
         ap.add_argument("--mask", required=True)
         ap.add_argument("--out", required=True)
@@ -228,10 +231,8 @@ data:
             print("WARNING: member partitions differ in row count; join keeps the intersection")
 
         base = members[0]
-        # Physical units: raw * scale + offset, applied per member.
-        phys = [f"({base}t.{var}_{base} * {args.scale} + {args.offset})" if m == base
-                else f"({m}t.{var}_{m} * {args.scale} + {args.offset})"
-                for m in members]
+        # Values are already in physical units (see module docstring) -- pass them straight through.
+        phys = [f"{m}t.{var}_{m}" for m in members]
         sel_members = ", ".join(f"{e} AS {var}_{m}" for e, m in zip(phys, members))
         arr = "[" + ", ".join(phys) + "]"
 

--- a/catalog/bioclimate/k8s/chelsa/pilot-ensemble.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-ensemble.yaml
@@ -1,0 +1,77 @@
+# PILOT (data-workflows #564): bio1, ssp370, 2041-2070 -> p10/p50/p90 physical-unit COGs.
+# One pod: reads the 5 GCM members from s3://public-bioclimate/raw/, reduces, uploads 3 COGs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chelsa-pilot-ensemble
+  namespace: geo-workflows
+  labels: {k8s-app: chelsa-pilot-ensemble}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: chelsa-pilot-ensemble}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+              - {key: kubernetes.io/hostname, operator: NotIn, values: [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org]}
+      containers:
+      - name: ensemble
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,           value: /usr/share/gdal}
+        - {name: PYTHONPATH,          value: /usr/lib/python3/dist-packages}
+        - {name: GDAL_CACHEMAX,       value: '2048'}
+        - {name: VAR,                 value: '1'}
+        - {name: SSP,                 value: ssp370}
+        - {name: PERIOD,              value: 2041-2070}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: scripts, mountPath: /opt/scripts, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          GCMS="GFDL-ESM4 IPSL-CM6A-LR MPI-ESM1-2-HR MRI-ESM2-0 UKESM1-0-LL"
+          mkdir -p /tmp/in /tmp/out && cd /tmp/in
+          ARGS=""
+          for G in $GCMS; do
+            GL=$(echo "$G" | tr 'A-Z' 'a-z')
+            F="CHELSA_bio${VAR}_${PERIOD}_${GL}_${SSP}_V.2.1.tif"
+            echo "localizing $G/$F"
+            rclone copyto "nrp:public-bioclimate/raw/chelsa-2-1/${PERIOD}/${G}/${SSP}/${F}" "/tmp/in/${G}.tif" \
+              --retries 5 --low-level-retries 20 --retries-sleep 10s
+            ARGS="$ARGS --input /tmp/in/${G}.tif"
+          done
+          ls -la /tmp/in
+          python3 /opt/scripts/chelsa_ensemble.py $ARGS \
+            --out-prefix "/tmp/out/bio${VAR}_${SSP}_${PERIOD}" --quantiles 10,50,90
+          ls -la /tmp/out
+          for q in 10 50 90; do
+            SRC="/tmp/out/bio${VAR}_${SSP}_${PERIOD}_p${q}.tif"
+            DST="nrp:public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/bio${VAR}-p${q}-cog.tif"
+            echo "uploading -> $DST"
+            rclone copyto "$SRC" "$DST" -P --retries 5 --low-level-retries 20 --retries-sleep 10s
+          done
+          echo "PILOT ENSEMBLE COMPLETE"
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: scripts, configMap: {name: chelsa-scripts}}

--- a/catalog/bioclimate/k8s/chelsa/pilot-ensemble.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-ensemble.yaml
@@ -64,7 +64,7 @@ spec:
           ls -la /tmp/out
           for q in 10 50 90; do
             SRC="/tmp/out/bio${VAR}_${SSP}_${PERIOD}_p${q}.tif"
-            DST="nrp:public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/bio${VAR}-p${q}-cog.tif"
+            DST="nrp:public-bioclimate/chelsa-2-1/${SSP}-${PERIOD}/bio${VAR}-median-cog.tif"
             echo "uploading -> $DST"
             rclone copyto "$SRC" "$DST" -P --retries 5 --low-level-retries 20 --retries-sleep 10s
           done

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -1,9 +1,12 @@
-# PILOT hex (data-workflows #564): bio1 ssp370 2041-2070, p10/p50/p90, res 8, parents 5,4,0.
-# 366 completions = 3 quantiles x 122 h0.  Index -> (quantile, h0): QI=idx/122, H0=idx%122.
+# PILOT hex (data-workflows #564): bio1, ssp370, 2041-2070 -> ONE wide hex, res 8, parents 5,4,0.
+#
+# 122 completions = one pod per h0. Each pod hexes all three ensemble quantiles and joins them
+# locally on h8, so the wide hex is produced directly — no cross-pod merge job and no 195M-row
+# distributed join. The full build generalizes this to 7 variables x 3 quantiles per pod.
 #
 # Land mask: CHELSA is a full-globe surface (VALID_PERCENT 99.999, real values over ocean), so
-# each h0 partition is semi-joined against the WWF Terrestrial Ecoregions h8 hex before upload.
-# h0 cells with no land have no ecoregion partition -> nothing is written (no empty partitions).
+# the joined partition is semi-joined against the WWF Terrestrial Ecoregions h8 hex before
+# upload. An h0 with no ecoregion partition is all-ocean and writes nothing (no empty partitions).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,11 +14,11 @@ metadata:
   namespace: geo-workflows
   labels: {k8s-app: chelsa-pilot-hex}
 spec:
-  completions: 366
+  completions: 122
   parallelism: 24
   completionMode: Indexed
   backoffLimitPerIndex: 3
-  maxFailedIndexes: 40
+  maxFailedIndexes: 15
   ttlSecondsAfterFinished: 86400
   template:
     metadata: {labels: {k8s-app: chelsa-pilot-hex}}
@@ -43,42 +46,43 @@ spec:
         - {name: GDAL_DATA,           value: /usr/share/gdal}
         - {name: PYTHONPATH,          value: /usr/lib/python3/dist-packages}
         - {name: CNG_HEX_WORKERS,     value: '8'}
+        - {name: VAR,                 value: bio1}
         - {name: SSP,                 value: ssp370}
         - {name: PERIOD,              value: 2041-2070}
         volumeMounts:
         - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: scripts, mountPath: /opt/scripts, readOnly: true}
         command:
         - bash
         - -c
         - |
           set -euo pipefail
-          QUANTS=(10 50 90)
-          IDX=${JOB_COMPLETION_INDEX}
-          QI=$(( IDX / 122 )); H0IDX=$(( IDX % 122 ))
-          Q=${QUANTS[$QI]}
-          COL="bio1_p${Q}"
-          echo "=== idx $IDX -> quantile p${Q}, h0-index $H0IDX ==="
+          H0IDX=${JOB_COMPLETION_INDEX}
+          PREFIX="public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}"
+          rm -rf /tmp/hex /tmp/mask /tmp/cache && mkdir -p /tmp/hex /tmp/mask /tmp/cache
+          echo "=== h0-index ${H0IDX}, ${VAR} ${SSP} ${PERIOD} ==="
 
-          rm -rf /tmp/hex && mkdir -p /tmp/hex /tmp/mask
-          cng-datasets raster \
-            --input "s3://public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/bio1-p${Q}-cog.tif" \
-            --output-parquet /tmp/hex \
-            --h0-index ${H0IDX} \
-            --resolution 8 --parent-resolutions 5,4,0 \
-            --value-column "${COL}" \
-            --hex-resampling mean \
-            --nodata "-9999" \
-            --local-cache-dir /tmp/cache
+          for Q in 10 50 90; do
+            echo "--- hexing p${Q}"
+            cng-datasets raster \
+              --input "s3://${PREFIX}/${VAR}-p${Q}-cog.tif" \
+              --output-parquet "/tmp/hex/p${Q}" \
+              --h0-index ${H0IDX} \
+              --resolution 8 --parent-resolutions 5,4,0 \
+              --value-column "${VAR}_p${Q}" \
+              --hex-resampling mean \
+              --nodata "-9999" \
+              --local-cache-dir /tmp/cache
+          done
 
-          PART=$(ls -d /tmp/hex/h0=* 2>/dev/null | head -1 || true)
+          PART=$(ls -d /tmp/hex/p50/h0=* 2>/dev/null | head -1 || true)
           if [ -z "$PART" ]; then
-            echo "no hex output for h0-index ${H0IDX} (raster does not cover it) — nothing to do"
+            echo "no hex output for h0-index ${H0IDX} — raster does not cover it, nothing to do"
             exit 0
           fi
           H0=$(basename "$PART" | sed 's/^h0=//')
-          echo "h0 cell = $H0"
+          echo "h0 cell = ${H0}"
 
-          # Land mask: pull this h0's ecoregion partition. Absent => no land in this h0.
           if ! rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
                /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null; then
             echo "no ecoregion (land) partition for h0=${H0} — all-ocean, skipping"
@@ -86,36 +90,21 @@ spec:
           fi
 
           set +e
-          python3 - <<'PY'
-          import duckdb, glob, os, sys
-          src = glob.glob('/tmp/hex/h0=*/data_0.parquet')[0]
-          con = duckdb.connect()
-          before = con.execute(f"SELECT COUNT(*) FROM read_parquet('{src}')").fetchone()[0]
-          con.execute(f"""
-              COPY (
-                  SELECT r.* FROM read_parquet('{src}') r
-                  SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('/tmp/mask/eco.parquet')) m
-                  ON r.h8 = m.h8
-              ) TO '/tmp/masked.parquet'
-              (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
-          """)
-          after = con.execute("SELECT COUNT(*) FROM read_parquet('/tmp/masked.parquet')").fetchone()[0]
-          print(f"MASK rows_before={before} rows_after={after} kept={100.0*after/before if before else 0:.2f}%")
-          if after == 0:
-              print("EMPTY after mask — not uploading")
-              sys.exit(3)
-          PY
+          python3 /opt/scripts/chelsa_join_mask.py \
+            --h0 "${H0}" --var "${VAR}" \
+            --hex-root /tmp/hex --mask /tmp/mask/eco.parquet --out /tmp/final.parquet
           rc=$?
           set -e
-          if [ "$rc" -eq 3 ]; then echo "skipping empty partition (all-ocean after mask)"; exit 0; fi
-          if [ "$rc" -ne 0 ]; then echo "mask step failed rc=$rc"; exit "$rc"; fi
+          if [ "$rc" -eq 3 ]; then echo "empty after land mask — skipping h0=${H0}"; exit 0; fi
+          if [ "$rc" -ne 0 ]; then echo "join/mask failed rc=${rc}"; exit "$rc"; fi
 
-          rclone copyto /tmp/masked.parquet \
-            "nrp:public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/hex-staging/bio1-p${Q}/h0=${H0}/data_0.parquet" \
+          rclone copyto /tmp/final.parquet \
+            "nrp:${PREFIX}/hex/h0=${H0}/data_0.parquet" \
             --retries 5 --low-level-retries 20 --retries-sleep 10s
-          echo "index $IDX complete"
+          echo "h0=${H0} complete"
         resources:
-          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 40Gi}
-          limits:   {cpu: '8', memory: 64Gi, ephemeral-storage: 40Gi}
+          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 45Gi}
+          limits:   {cpu: '8', memory: 64Gi, ephemeral-storage: 45Gi}
       volumes:
       - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: scripts, configMap: {name: chelsa-scripts}}

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -88,6 +88,19 @@ spec:
           NODATA_ARG=""
           if [ -n "${NODATA:-}" ]; then NODATA_ARG="--nodata ${NODATA}"; fi
 
+          # Skip an all-ocean h0 BEFORE hexing: resolve the index to its h0 cell and look for a
+          # land partition. Only 108 of 122 h0 cells intersect the land mask, so this avoids
+          # hexing five members for a result that would be discarded.
+          rclone copyto nrp:public-grids/hex/h0-valid.parquet /tmp/h0grid.parquet \
+            --retries 5 --low-level-retries 20 --retries-sleep 10s
+          H0=$(python3 /opt/scripts/chelsa_h0_for_index.py --grid /tmp/h0grid.parquet --index ${H0IDX})
+          echo "h0-index ${H0IDX} -> h0 cell ${H0}"
+          if ! rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
+               /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null; then
+            echo "no ecoregion (land) partition for h0=${H0} — all-ocean, skipping before hexing"
+            exit 0
+          fi
+
           for i in 0 1 2 3 4; do
             G=${GCMS[$i]}; C=${COLS[$i]}
             GL=$(echo "$G" | tr 'A-Z' 'a-z')
@@ -108,13 +121,10 @@ spec:
             echo "no hex output for h0-index ${H0IDX} — raster does not cover it, nothing to do"
             exit 0
           fi
-          H0=$(basename "$PART" | sed 's/^h0=//')
-          echo "h0 cell = ${H0}"
-
-          if ! rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
-               /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null; then
-            echo "no ecoregion (land) partition for h0=${H0} — all-ocean, skipping"
-            exit 0
+          H0_OUT=$(basename "$PART" | sed 's/^h0=//')
+          if [ "$H0_OUT" != "$H0" ]; then
+            echo "ERROR: hex wrote h0=${H0_OUT} but the grid says index ${H0IDX} is h0=${H0}" >&2
+            exit 1
           fi
 
           MEMBER_LIST=$(IFS=,; echo "${COLS[*]}")

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -1,0 +1,121 @@
+# PILOT hex (data-workflows #564): bio1 ssp370 2041-2070, p10/p50/p90, res 8, parents 5,4,0.
+# 366 completions = 3 quantiles x 122 h0.  Index -> (quantile, h0): QI=idx/122, H0=idx%122.
+#
+# Land mask: CHELSA is a full-globe surface (VALID_PERCENT 99.999, real values over ocean), so
+# each h0 partition is semi-joined against the WWF Terrestrial Ecoregions h8 hex before upload.
+# h0 cells with no land have no ecoregion partition -> nothing is written (no empty partitions).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chelsa-pilot-hex
+  namespace: geo-workflows
+  labels: {k8s-app: chelsa-pilot-hex}
+spec:
+  completions: 366
+  parallelism: 24
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 40
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: chelsa-pilot-hex}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+              - {key: kubernetes.io/hostname, operator: NotIn, values: [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org]}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,           value: /usr/share/gdal}
+        - {name: PYTHONPATH,          value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS,     value: '8'}
+        - {name: SSP,                 value: ssp370}
+        - {name: PERIOD,              value: 2041-2070}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          QUANTS=(10 50 90)
+          IDX=${JOB_COMPLETION_INDEX}
+          QI=$(( IDX / 122 )); H0IDX=$(( IDX % 122 ))
+          Q=${QUANTS[$QI]}
+          COL="bio1_p${Q}"
+          echo "=== idx $IDX -> quantile p${Q}, h0-index $H0IDX ==="
+
+          rm -rf /tmp/hex && mkdir -p /tmp/hex /tmp/mask
+          cng-datasets raster \
+            --input "s3://public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/bio1-p${Q}-cog.tif" \
+            --output-parquet /tmp/hex \
+            --h0-index ${H0IDX} \
+            --resolution 8 --parent-resolutions 5,4,0 \
+            --value-column "${COL}" \
+            --hex-resampling mean \
+            --nodata "-9999" \
+            --local-cache-dir /tmp/cache
+
+          PART=$(ls -d /tmp/hex/h0=* 2>/dev/null | head -1 || true)
+          if [ -z "$PART" ]; then
+            echo "no hex output for h0-index ${H0IDX} (raster does not cover it) — nothing to do"
+            exit 0
+          fi
+          H0=$(basename "$PART" | sed 's/^h0=//')
+          echo "h0 cell = $H0"
+
+          # Land mask: pull this h0's ecoregion partition. Absent => no land in this h0.
+          if ! rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
+               /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null; then
+            echo "no ecoregion (land) partition for h0=${H0} — all-ocean, skipping"
+            exit 0
+          fi
+
+          set +e
+          python3 - <<'PY'
+          import duckdb, glob, os, sys
+          src = glob.glob('/tmp/hex/h0=*/data_0.parquet')[0]
+          con = duckdb.connect()
+          before = con.execute(f"SELECT COUNT(*) FROM read_parquet('{src}')").fetchone()[0]
+          con.execute(f"""
+              COPY (
+                  SELECT r.* FROM read_parquet('{src}') r
+                  SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('/tmp/mask/eco.parquet')) m
+                  ON r.h8 = m.h8
+              ) TO '/tmp/masked.parquet'
+              (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+          """)
+          after = con.execute("SELECT COUNT(*) FROM read_parquet('/tmp/masked.parquet')").fetchone()[0]
+          print(f"MASK rows_before={before} rows_after={after} kept={100.0*after/before if before else 0:.2f}%")
+          if after == 0:
+              print("EMPTY after mask — not uploading")
+              sys.exit(3)
+          PY
+          rc=$?
+          set -e
+          if [ "$rc" -eq 3 ]; then echo "skipping empty partition (all-ocean after mask)"; exit 0; fi
+          if [ "$rc" -ne 0 ]; then echo "mask step failed rc=$rc"; exit "$rc"; fi
+
+          rclone copyto /tmp/masked.parquet \
+            "nrp:public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/hex-staging/bio1-p${Q}/h0=${H0}/data_0.parquet" \
+            --retries 5 --low-level-retries 20 --retries-sleep 10s
+          echo "index $IDX complete"
+        resources:
+          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '8', memory: 64Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -82,9 +82,9 @@ spec:
           META=$(python3 /opt/scripts/chelsa_read_meta.py --input "$META_URL")
           echo "source metadata: $META"
           eval "$META"
-          if [ -z "${SCALE:-}" ] || [ -z "${OFFSET:-}" ]; then
-            echo "ERROR: could not read scale/offset from source" >&2; exit 1
-          fi
+          # SCALE/OFFSET are informational only: exactextract applies them when cng-datasets
+          # reads the raster, so hex values arrive already in physical units. NODATA is the
+          # value actually used below.
           NODATA_ARG=""
           if [ -n "${NODATA:-}" ]; then NODATA_ARG="--nodata ${NODATA}"; fi
 
@@ -131,7 +131,6 @@ spec:
           set +e
           python3 /opt/scripts/chelsa_join_mask.py \
             --h0 "${H0}" --var "${VAR}" --members "${MEMBER_LIST}" \
-            --scale "${SCALE}" --offset "${OFFSET}" \
             --hex-root /tmp/hex --mask /tmp/mask/eco.parquet --out /tmp/final.parquet \
             --sane-min "${SANE_MIN}" --sane-max "${SANE_MAX}"
           rc=$?

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -140,7 +140,7 @@ spec:
           if [ "$rc" -ne 0 ]; then echo "join/mask failed rc=${rc}"; exit "$rc"; fi
 
           rclone copyto /tmp/final.parquet \
-            "nrp:public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/hex/h0=${H0}/data_0.parquet" \
+            "nrp:public-bioclimate/chelsa-2-1/${SSP}-${PERIOD}/hex/h0=${H0}/data_0.parquet" \
             --retries 5 --low-level-retries 20 --retries-sleep 10s
           echo "h0=${H0} complete"
         resources:

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -95,11 +95,15 @@ spec:
             --retries 5 --low-level-retries 20 --retries-sleep 10s
           H0=$(python3 /opt/scripts/chelsa_h0_for_index.py --grid /tmp/h0grid.parquet --index ${H0IDX})
           echo "h0-index ${H0IDX} -> h0 cell ${H0}"
-          if ! rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
-               /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null; then
+          # NOTE: `rclone copyto` exits 0 when the source does not exist, so its exit code
+          # cannot be used to detect a missing partition — test for the file itself.
+          rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
+            /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null || true
+          if [ ! -s /tmp/mask/eco.parquet ]; then
             echo "no ecoregion (land) partition for h0=${H0} — all-ocean, skipping before hexing"
             exit 0
           fi
+          echo "land mask for h0=${H0}: $(stat -c %s /tmp/mask/eco.parquet) bytes"
 
           for i in 0 1 2 3 4; do
             G=${GCMS[$i]}; C=${COLS[$i]}

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -1,12 +1,20 @@
-# PILOT hex (data-workflows #564): bio1, ssp370, 2041-2070 -> ONE wide hex, res 8, parents 5,4,0.
+# PILOT hex (data-workflows #564): bio1, ssp370, 2041-2070 -> one wide hex, res 8, parents 5,4,0.
 #
-# 122 completions = one pod per h0. Each pod hexes all three ensemble quantiles and joins them
-# locally on h8, so the wide hex is produced directly — no cross-pod merge job and no 195M-row
-# distributed join. The full build generalizes this to 7 variables x 3 quantiles per pod.
+# 122 completions = one pod per h0. Each pod hexes all FIVE GCM members straight from the staged
+# raw rasters and joins them locally on h8, producing the wide hex directly -- no per-member COG
+# and no cross-pod merge.
+#
+# Columns per cell: the five members (upstream-faithful; CHELSA ships per-GCM files and no
+# ensemble product) plus median/min/max. A five-member ensemble is summarised by its median and
+# full range; percentiles need a larger ensemble to mean anything.
+#
+# Units: cng-datasets does not apply the GeoTIFF scale/offset, so it is applied in the join.
+# exact_extract's area-weighted mean and the scale/offset are both linear, so
+# mean(scale*x + offset) == scale*mean(x) + offset -- equivalent, and avoids building float COGs.
 #
 # Land mask: CHELSA is a full-globe surface (VALID_PERCENT 99.999, real values over ocean), so
-# the joined partition is semi-joined against the WWF Terrestrial Ecoregions h8 hex before
-# upload. An h0 with no ecoregion partition is all-ocean and writes nothing (no empty partitions).
+# the joined partition is semi-joined against the WWF Terrestrial Ecoregions h8 hex. An h0 with
+# no ecoregion partition is all-ocean and writes nothing (no empty partitions).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -49,6 +57,10 @@ spec:
         - {name: VAR,                 value: bio1}
         - {name: SSP,                 value: ssp370}
         - {name: PERIOD,              value: 2041-2070}
+        # Plausibility bounds for annual mean temperature in degrees C. A wrong scale/offset is
+        # otherwise invisible -- raw integers look like perfectly ordinary numbers.
+        - {name: SANE_MIN,            value: '-95'}
+        - {name: SANE_MAX,            value: '60'}
         volumeMounts:
         - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
         - {name: scripts, mountPath: /opt/scripts, readOnly: true}
@@ -57,25 +69,41 @@ spec:
         - -c
         - |
           set -euo pipefail
+          GCMS=(GFDL-ESM4 IPSL-CM6A-LR MPI-ESM1-2-HR MRI-ESM2-0 UKESM1-0-LL)
+          COLS=(gfdl_esm4 ipsl_cm6a_lr mpi_esm1_2_hr mri_esm2_0 ukesm1_0_ll)
           H0IDX=${JOB_COMPLETION_INDEX}
-          PREFIX="public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}"
+          RAW="public-bioclimate/raw/chelsa-2-1/${PERIOD}"
           rm -rf /tmp/hex /tmp/mask /tmp/cache && mkdir -p /tmp/hex /tmp/mask /tmp/cache
           echo "=== h0-index ${H0IDX}, ${VAR} ${SSP} ${PERIOD} ==="
 
-          for Q in 10 50 90; do
-            echo "--- hexing p${Q}"
+          # scale/offset/nodata read FROM THE FILE -- they differ per variable upstream.
+          FIRST_GL=$(echo "${GCMS[0]}" | tr 'A-Z' 'a-z')
+          META_URL="/vsicurl/https://${AWS_PUBLIC_ENDPOINT}/${RAW}/${GCMS[0]}/${SSP}/CHELSA_${VAR}_${PERIOD}_${FIRST_GL}_${SSP}_V.2.1.tif"
+          META=$(python3 /opt/scripts/chelsa_read_meta.py --input "$META_URL")
+          echo "source metadata: $META"
+          eval "$META"
+          if [ -z "${SCALE:-}" ] || [ -z "${OFFSET:-}" ]; then
+            echo "ERROR: could not read scale/offset from source" >&2; exit 1
+          fi
+          NODATA_ARG=""
+          if [ -n "${NODATA:-}" ]; then NODATA_ARG="--nodata ${NODATA}"; fi
+
+          for i in 0 1 2 3 4; do
+            G=${GCMS[$i]}; C=${COLS[$i]}
+            GL=$(echo "$G" | tr 'A-Z' 'a-z')
+            echo "--- hexing member $G -> ${VAR}_${C}"
             cng-datasets raster \
-              --input "s3://${PREFIX}/${VAR}-p${Q}-cog.tif" \
-              --output-parquet "/tmp/hex/p${Q}" \
+              --input "s3://${RAW}/${G}/${SSP}/CHELSA_${VAR}_${PERIOD}_${GL}_${SSP}_V.2.1.tif" \
+              --output-parquet "/tmp/hex/${VAR}_${C}" \
               --h0-index ${H0IDX} \
               --resolution 8 --parent-resolutions 5,4,0 \
-              --value-column "${VAR}_p${Q}" \
+              --value-column "${VAR}_${C}" \
               --hex-resampling mean \
-              --nodata "-9999" \
+              ${NODATA_ARG} \
               --local-cache-dir /tmp/cache
           done
 
-          PART=$(ls -d /tmp/hex/p50/h0=* 2>/dev/null | head -1 || true)
+          PART=$(ls -d /tmp/hex/${VAR}_${COLS[0]}/h0=* 2>/dev/null | head -1 || true)
           if [ -z "$PART" ]; then
             echo "no hex output for h0-index ${H0IDX} — raster does not cover it, nothing to do"
             exit 0
@@ -89,17 +117,20 @@ spec:
             exit 0
           fi
 
+          MEMBER_LIST=$(IFS=,; echo "${COLS[*]}")
           set +e
           python3 /opt/scripts/chelsa_join_mask.py \
-            --h0 "${H0}" --var "${VAR}" \
-            --hex-root /tmp/hex --mask /tmp/mask/eco.parquet --out /tmp/final.parquet
+            --h0 "${H0}" --var "${VAR}" --members "${MEMBER_LIST}" \
+            --scale "${SCALE}" --offset "${OFFSET}" \
+            --hex-root /tmp/hex --mask /tmp/mask/eco.parquet --out /tmp/final.parquet \
+            --sane-min "${SANE_MIN}" --sane-max "${SANE_MAX}"
           rc=$?
           set -e
           if [ "$rc" -eq 3 ]; then echo "empty after land mask — skipping h0=${H0}"; exit 0; fi
           if [ "$rc" -ne 0 ]; then echo "join/mask failed rc=${rc}"; exit "$rc"; fi
 
           rclone copyto /tmp/final.parquet \
-            "nrp:${PREFIX}/hex/h0=${H0}/data_0.parquet" \
+            "nrp:public-bioclimate/chelsa-2-1/${SSP}/${PERIOD}/hex/h0=${H0}/data_0.parquet" \
             --retries 5 --low-level-retries 20 --retries-sleep 10s
           echo "h0=${H0} complete"
         resources:

--- a/catalog/bioclimate/k8s/chelsa/setup-bucket.yaml
+++ b/catalog/bioclimate/k8s/chelsa/setup-bucket.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bioclimate-setup-bucket
+  namespace: geo-workflows
+  labels: {k8s-app: bioclimate-setup-bucket}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata: {labels: {k8s-app: bioclimate-setup-bucket}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: BUCKET,              value: public-bioclimate}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets storage setup-bucket --bucket "${BUCKET}" --remote nrp --verify
+          echo "Bucket setup complete"
+        resources:
+          requests: {cpu: '1', memory: 2Gi}
+          limits:   {cpu: '1', memory: 2Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/bioclimate/k8s/chelsa/stage-raw.yaml
+++ b/catalog/bioclimate/k8s/chelsa/stage-raw.yaml
@@ -1,0 +1,80 @@
+# Stage all CHELSA v2.1 bioclim source rasters to s3://public-bioclimate/raw/ (data-workflows #564).
+# 322 files = 7 vars x (5 GCM x 3 ssp x 3 period) futures + 7 baseline, ~92.5 GB.
+# Index maps to one (period, GCM, ssp) triple = 7 files; index 45 is the 1981-2010 baseline.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chelsa-stage-raw
+  namespace: geo-workflows
+  labels: {k8s-app: chelsa-stage-raw}
+spec:
+  completions: 46           # 45 future triples (3 periods x 5 GCMs x 3 ssps) + 1 baseline
+  parallelism: 10
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 6
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: chelsa-stage-raw}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+              - {key: kubernetes.io/hostname, operator: NotIn, values: [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org]}
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          U=https://os.zhdk.cloud.switch.ch/chelsav2/GLOBAL/climatologies
+          VARS="1 4 5 6 12 15 17"
+          PERIODS=(2011-2040 2041-2070 2071-2100)
+          GCMS=(GFDL-ESM4 IPSL-CM6A-LR MPI-ESM1-2-HR MRI-ESM2-0 UKESM1-0-LL)
+          SSPS=(ssp126 ssp370 ssp585)
+          IDX=${JOB_COMPLETION_INDEX}
+          mkdir -p /tmp/stage && cd /tmp/stage
+          if [ "$IDX" -eq 45 ]; then
+            echo "=== baseline 1981-2010 ==="
+            for v in $VARS; do
+              f="CHELSA_bio${v}_1981-2010_V.2.1.tif"
+              echo "-> $f"
+              curl -sS --fail --retry 5 --retry-delay 10 -o "$f" "$U/1981-2010/bio/$f"
+            done
+            rclone copy /tmp/stage nrp:public-bioclimate/raw/chelsa-2-1/1981-2010/ \
+              -P --retries 5 --low-level-retries 20 --retries-sleep 10s
+          else
+            PI=$(( IDX / 15 )); R=$(( IDX % 15 )); GI=$(( R / 3 )); SI=$(( R % 3 ))
+            P=${PERIODS[$PI]}; G=${GCMS[$GI]}; S=${SSPS[$SI]}
+            GL=$(echo "$G" | tr 'A-Z' 'a-z')
+            echo "=== idx $IDX -> period=$P gcm=$G ssp=$S ==="
+            for v in $VARS; do
+              f="CHELSA_bio${v}_${P}_${GL}_${S}_V.2.1.tif"
+              echo "-> $f"
+              curl -sS --fail --retry 5 --retry-delay 10 -o "$f" "$U/$P/$G/$S/bio/$f"
+            done
+            rclone copy /tmp/stage "nrp:public-bioclimate/raw/chelsa-2-1/${P}/${G}/${S}/" \
+              -P --retries 5 --low-level-retries 20 --retries-sleep 10s
+          fi
+          echo "index $IDX staged OK"
+        resources:
+          requests: {cpu: '2', memory: 4Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '2', memory: 4Gi, ephemeral-storage: 20Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/bioclimate/scripts/chelsa_ensemble.py
+++ b/catalog/bioclimate/scripts/chelsa_ensemble.py
@@ -1,0 +1,128 @@
+"""CHELSA v2.1 GCM-ensemble reduction -> physical-unit float32 COG (data-workflows #564).
+
+Reads the N per-GCM rasters for one (variable, ssp, period) triple and writes one COG per
+requested ensemble quantile, in physical units.
+
+Design notes (all driven by the measured preflight on #564):
+  * scale/offset and nodata are read FROM EACH FILE (`GetScale`/`GetOffset`/`GetNoDataValue`),
+    never hardcoded -- CHELSA declares different sentinels per variable (bio1/bio4/bio12 use 0,
+    bio15 uses 65535), so a single batch-wide constant would corrupt the output.
+  * a pixel is nodata in the output if it is nodata in ANY member -- the ensemble is only
+    defined where every GCM has a value.
+  * bio12 saturates at the UInt16 ceiling (65535); those pixels are flagged, counted, and
+    reported so the clipping is visible rather than silently averaged.
+  * processed in row blocks so a 43200x20880 x N-member stack never has to fit in RAM.
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+from osgeo import gdal
+
+gdal.UseExceptions()
+
+UINT16_CEIL = 65535
+OUT_NODATA = -9999.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", action="append", required=True, help="per-GCM source raster (repeat)")
+    ap.add_argument("--out-prefix", required=True, help="output path prefix; quantile is appended")
+    ap.add_argument("--quantiles", default="10,50,90")
+    ap.add_argument("--block-rows", type=int, default=512)
+    args = ap.parse_args()
+
+    qs = [float(q) for q in args.quantiles.split(",")]
+    srcs = [gdal.Open(p) for p in args.input]
+    n = len(srcs)
+    if n < 2:
+        print("ERROR: need at least 2 members for an ensemble", file=sys.stderr)
+        return 1
+
+    b0 = srcs[0].GetRasterBand(1)
+    xsize, ysize = srcs[0].RasterXSize, srcs[0].RasterYSize
+    scale = b0.GetScale() if b0.GetScale() is not None else 1.0
+    offset = b0.GetOffset() if b0.GetOffset() is not None else 0.0
+    nodata = b0.GetNoDataValue()
+
+    # Every member must share grid, scale/offset and sentinel, or the ensemble is meaningless.
+    for p, ds in zip(args.input, srcs):
+        b = ds.GetRasterBand(1)
+        if (ds.RasterXSize, ds.RasterYSize) != (xsize, ysize):
+            print(f"ERROR: grid mismatch in {p}", file=sys.stderr)
+            return 1
+        s = b.GetScale() if b.GetScale() is not None else 1.0
+        o = b.GetOffset() if b.GetOffset() is not None else 0.0
+        if (s, o) != (scale, offset) or b.GetNoDataValue() != nodata:
+            print(f"ERROR: scale/offset/nodata mismatch in {p}: "
+                  f"{(s, o, b.GetNoDataValue())} != {(scale, offset, nodata)}", file=sys.stderr)
+            return 1
+
+    print(f"members={n} grid={xsize}x{ysize} scale={scale} offset={offset} nodata={nodata}")
+
+    drv = gdal.GetDriverByName("GTiff")
+    opts = ["COMPRESS=ZSTD", "PREDICTOR=3", "TILED=YES", "BIGTIFF=YES"]
+    tmp_paths, outs = [], []
+    for q in qs:
+        tp = f"{args.out_prefix}_p{int(q)}.tmp.tif"
+        ds = drv.Create(tp, xsize, ysize, 1, gdal.GDT_Float32, options=opts)
+        ds.SetGeoTransform(srcs[0].GetGeoTransform())
+        ds.SetProjection(srcs[0].GetProjection())
+        ds.GetRasterBand(1).SetNoDataValue(OUT_NODATA)
+        tmp_paths.append(tp)
+        outs.append(ds)
+
+    n_valid = n_nodata = n_saturated = 0
+    vmin, vmax = np.inf, -np.inf
+
+    for y in range(0, ysize, args.block_rows):
+        rows = min(args.block_rows, ysize - y)
+        stack = np.empty((n, rows, xsize), dtype=np.float64)
+        bad = np.zeros((rows, xsize), dtype=bool)
+        for i, ds in enumerate(srcs):
+            a = ds.GetRasterBand(1).ReadAsArray(0, y, xsize, rows)
+            if nodata is not None:
+                bad |= (a == nodata)
+            n_saturated += int((a == UINT16_CEIL).sum())
+            stack[i] = a
+
+        vals = np.percentile(stack, qs, axis=0)          # (len(qs), rows, xsize)
+        vals = vals * scale + offset                      # -> physical units
+
+        n_valid += int((~bad).sum())
+        n_nodata += int(bad.sum())
+        if (~bad).any():
+            vmin = min(vmin, float(vals[:, ~bad].min()))
+            vmax = max(vmax, float(vals[:, ~bad].max()))
+
+        for k, ds in enumerate(outs):
+            band = vals[k]
+            band[bad] = OUT_NODATA
+            ds.GetRasterBand(1).WriteArray(band.astype(np.float32), 0, y)
+        print(f"  rows {y}-{y + rows} done", flush=True)
+
+    for ds in outs:
+        ds.FlushCache()
+    outs = None
+
+    # Rewrite as proper COGs.
+    for tp, q in zip(tmp_paths, qs):
+        final = f"{args.out_prefix}_p{int(q)}.tif"
+        print(f"COG -> {final}")
+        gdal.Translate(final, tp, format="COG",
+                       creationOptions=["COMPRESS=ZSTD", "PREDICTOR=3",
+                                        "OVERVIEWS=IGNORE_EXISTING", "BIGTIFF=YES"])
+        os.remove(tp)
+
+    total = n_valid + n_nodata
+    print(f"MEASURED valid={n_valid} nodata={n_nodata} "
+          f"({100.0 * n_valid / total:.4f}% valid)")
+    print(f"MEASURED physical range: min={vmin:.4f} max={vmax:.4f}")
+    print(f"MEASURED source pixels at UInt16 ceiling ({UINT16_CEIL}) across all members: {n_saturated}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/catalog/bioclimate/scripts/chelsa_h0_for_index.py
+++ b/catalog/bioclimate/scripts/chelsa_h0_for_index.py
@@ -1,0 +1,26 @@
+"""Resolve a cng-datasets h0 *index* (0-121) to its h0 *cell id* (data-workflows #564).
+
+`cng-datasets raster --h0-index N` looks N up in the h0 grid parquet by its `i` column. Doing
+the same lookup up front lets a job decide whether an h0 holds any land *before* paying to hex
+it: only 108 of the 122 h0 cells intersect the WWF ecoregions land mask, so the remaining 14
+would otherwise hex every ensemble member and then discard the result.
+"""
+import argparse
+import sys
+
+import duckdb
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--grid", required=True, help="local path to the h0 grid parquet")
+ap.add_argument("--index", type=int, required=True)
+args = ap.parse_args()
+
+row = duckdb.connect().execute(
+    "SELECT h0 FROM read_parquet(?) WHERE i = ?", [args.grid, args.index]
+).fetchone()
+
+if row is None:
+    print(f"ERROR: no h0 cell for index {args.index}", file=sys.stderr)
+    sys.exit(1)
+
+print(row[0])

--- a/catalog/bioclimate/scripts/chelsa_join_mask.py
+++ b/catalog/bioclimate/scripts/chelsa_join_mask.py
@@ -6,10 +6,15 @@ share an h8 key -- this joins them into one wide row per cell.
 
 Three things happen here that cannot happen earlier:
 
-1. **Units.** `cng-datasets` does not apply the GeoTIFF scale/offset, so hex values are raw
-   integers. Because `exact_extract`'s area-weighted mean and CHELSA's scale/offset are both
-   linear, `mean(scale*x + offset) == scale*mean(x) + offset` -- applying the transform here is
-   exactly equivalent to applying it to the raster, and saves building a float COG per member.
+1. **Units are ALREADY PHYSICAL -- do not transform them here.** `cng-datasets` hands the raster
+   *path* to `exactextract`, whose GDAL source applies the GeoTIFF scale/offset, so hex values
+   arrive in degrees C / mm, not raw integers. Measured on the Amazon h0: min 1.51, max 30.15,
+   mean 27.32 (degrees C). Applying the transform again yielded ~-273, which the plausibility
+   bound below caught.
+
+   Note the contrast with `chelsa_ensemble.py`, which reads via `gdal.Band.ReadAsArray` --
+   that path does NOT apply scale/offset, so the explicit transform there is correct. The two
+   files legitimately differ; do not "fix" one to match the other.
 
 2. **Ensemble statistics.** All five member values are kept as columns; the upstream product
    ships per-GCM files and no ensemble product, so the members are the faithful representation.
@@ -42,8 +47,6 @@ def main() -> int:
     ap.add_argument("--var", required=True, help="variable prefix, e.g. bio1")
     ap.add_argument("--members", required=True,
                     help="comma-separated member column suffixes, e.g. gfdl_esm4,ipsl_cm6a_lr,...")
-    ap.add_argument("--scale", type=float, required=True)
-    ap.add_argument("--offset", type=float, required=True)
     ap.add_argument("--hex-root", required=True)
     ap.add_argument("--mask", required=True)
     ap.add_argument("--out", required=True)
@@ -69,10 +72,8 @@ def main() -> int:
         print("WARNING: member partitions differ in row count; join keeps the intersection")
 
     base = members[0]
-    # Physical units: raw * scale + offset, applied per member.
-    phys = [f"({base}t.{var}_{base} * {args.scale} + {args.offset})" if m == base
-            else f"({m}t.{var}_{m} * {args.scale} + {args.offset})"
-            for m in members]
+    # Values are already in physical units (see module docstring) -- pass them straight through.
+    phys = [f"{m}t.{var}_{m}" for m in members]
     sel_members = ", ".join(f"{e} AS {var}_{m}" for e, m in zip(phys, members))
     arr = "[" + ", ".join(phys) + "]"
 

--- a/catalog/bioclimate/scripts/chelsa_join_mask.py
+++ b/catalog/bioclimate/scripts/chelsa_join_mask.py
@@ -1,0 +1,92 @@
+"""Join the per-quantile hex partitions for one h0 and apply the land mask (data-workflows #564).
+
+Each ensemble quantile is hexed separately by `cng-datasets raster` into
+`<hex-root>/p<q>/h0=<cell>/data_0.parquet`. They share a grid, a resolution and an h0, so they
+share an h8 key — this joins them into one wide row per cell and then restricts to land.
+
+The land mask is the WWF Terrestrial Ecoregions h8 hex (chosen over Overture countries, which is
+a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica).
+
+Exit 3 means "nothing survived the mask" — the caller treats that as a skip, not a failure.
+"""
+import argparse
+import glob
+import sys
+
+import duckdb
+
+QUANTILES = (10, 50, 90)
+
+
+def part(hex_root: str, q: int, h0: str) -> str:
+    hits = glob.glob(f"{hex_root}/p{q}/h0={h0}/data_0.parquet")
+    if not hits:
+        raise SystemExit(f"ERROR: missing hex partition for p{q} h0={h0}")
+    return hits[0]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--h0", required=True)
+    ap.add_argument("--var", required=True)
+    ap.add_argument("--hex-root", required=True)
+    ap.add_argument("--mask", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    con = duckdb.connect()
+    paths = {q: part(args.hex_root, q, args.h0) for q in QUANTILES}
+
+    counts = {q: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
+              for q, p in paths.items()}
+    print(f"rows per quantile: {counts}")
+    if len(set(counts.values())) != 1:
+        # Not fatal -- an inner join keeps only cells present in all three -- but it should not
+        # happen for rasters that share a grid and mask, so make it visible.
+        print("WARNING: quantile partitions differ in row count; join will keep the intersection")
+
+    base = args.var
+    sel = ", ".join(f"p{q}.{base}_p{q}" for q in QUANTILES)
+    joins = " ".join(
+        f"JOIN read_parquet('{paths[q]}') p{q} ON p{q}.h8 = p50.h8"
+        for q in QUANTILES if q != 50
+    )
+
+    con.execute(f"""
+        COPY (
+            SELECT p50.h8, p50.h5, p50.h4, p50.h0, {sel}
+            FROM read_parquet('{paths[50]}') p50
+            {joins}
+            SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) m
+              ON p50.h8 = m.h8
+        ) TO '{args.out}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+    """)
+
+    after = con.execute(f"SELECT COUNT(*) FROM read_parquet('{args.out}')").fetchone()[0]
+    before = counts[50]
+    print(f"MASK h0={args.h0} rows_before={before} rows_after={after} "
+          f"kept={100.0 * after / before if before else 0:.2f}%")
+    if after == 0:
+        print("EMPTY after land mask")
+        return 3
+
+    rng = con.execute(f"""
+        SELECT MIN({base}_p50), MAX({base}_p50), COUNT(*) FILTER (WHERE {base}_p50 IS NULL)
+        FROM read_parquet('{args.out}')
+    """).fetchone()
+    print(f"MEASURED {base}_p50 min={rng[0]} max={rng[1]} nulls={rng[2]}")
+    # Ordering invariant: p10 <= p50 <= p90 must hold for every cell.
+    bad = con.execute(f"""
+        SELECT COUNT(*) FROM read_parquet('{args.out}')
+        WHERE {base}_p10 > {base}_p50 OR {base}_p50 > {base}_p90
+    """).fetchone()[0]
+    print(f"CHECK quantile-ordering violations: {bad}")
+    if bad:
+        print("ERROR: ensemble quantiles are not monotonic", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/catalog/bioclimate/scripts/chelsa_join_mask.py
+++ b/catalog/bioclimate/scripts/chelsa_join_mask.py
@@ -1,13 +1,26 @@
-"""Join the per-quantile hex partitions for one h0 and apply the land mask (data-workflows #564).
+"""Join the per-GCM hex partitions for one h0, apply units + land mask (data-workflows #564).
 
-Each ensemble quantile is hexed separately by `cng-datasets raster` into
-`<hex-root>/p<q>/h0=<cell>/data_0.parquet`. They share a grid, a resolution and an h0, so they
-share an h8 key — this joins them into one wide row per cell and then restricts to land.
+Each ensemble member is hexed separately by `cng-datasets raster` into
+`<hex-root>/<member>/h0=<cell>/data_0.parquet`. They share a grid, resolution and h0, so they
+share an h8 key -- this joins them into one wide row per cell.
 
-The land mask is the WWF Terrestrial Ecoregions h8 hex (chosen over Overture countries, which is
-a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica).
+Three things happen here that cannot happen earlier:
 
-Exit 3 means "nothing survived the mask" — the caller treats that as a skip, not a failure.
+1. **Units.** `cng-datasets` does not apply the GeoTIFF scale/offset, so hex values are raw
+   integers. Because `exact_extract`'s area-weighted mean and CHELSA's scale/offset are both
+   linear, `mean(scale*x + offset) == scale*mean(x) + offset` -- applying the transform here is
+   exactly equivalent to applying it to the raster, and saves building a float COG per member.
+
+2. **Ensemble statistics.** All five member values are kept as columns; the upstream product
+   ships per-GCM files and no ensemble product, so the members are the faithful representation.
+   `median`/`min`/`max` are materialised alongside them because a five-member ensemble is
+   summarised by its median and full range (percentiles need a larger ensemble), and because
+   these are the expressions a consumer is most likely to get wrong across five columns.
+
+3. **Land mask.** WWF Terrestrial Ecoregions h8 hex -- chosen over Overture countries, which is
+   a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica.
+
+Exit 3 means "nothing survived the mask" -- the caller treats that as a skip, not a failure.
 """
 import argparse
 import glob
@@ -15,76 +28,106 @@ import sys
 
 import duckdb
 
-QUANTILES = (10, 50, 90)
 
-
-def part(hex_root: str, q: int, h0: str) -> str:
-    hits = glob.glob(f"{hex_root}/p{q}/h0={h0}/data_0.parquet")
+def part(hex_root: str, member_col: str, h0: str) -> str:
+    hits = glob.glob(f"{hex_root}/{member_col}/h0={h0}/data_0.parquet")
     if not hits:
-        raise SystemExit(f"ERROR: missing hex partition for p{q} h0={h0}")
+        raise SystemExit(f"ERROR: missing hex partition for member {member_col} h0={h0}")
     return hits[0]
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--h0", required=True)
-    ap.add_argument("--var", required=True)
+    ap.add_argument("--var", required=True, help="variable prefix, e.g. bio1")
+    ap.add_argument("--members", required=True,
+                    help="comma-separated member column suffixes, e.g. gfdl_esm4,ipsl_cm6a_lr,...")
+    ap.add_argument("--scale", type=float, required=True)
+    ap.add_argument("--offset", type=float, required=True)
     ap.add_argument("--hex-root", required=True)
     ap.add_argument("--mask", required=True)
     ap.add_argument("--out", required=True)
+    ap.add_argument("--sane-min", type=float, default=None,
+                    help="fail if any physical value falls below this")
+    ap.add_argument("--sane-max", type=float, default=None,
+                    help="fail if any physical value rises above this")
     args = ap.parse_args()
 
+    members = [m.strip() for m in args.members.split(",") if m.strip()]
+    if len(members) < 2:
+        print("ERROR: need at least 2 ensemble members", file=sys.stderr)
+        return 1
+
+    var = args.var
     con = duckdb.connect()
-    paths = {q: part(args.hex_root, q, args.h0) for q in QUANTILES}
+    paths = {m: part(args.hex_root, f"{var}_{m}", args.h0) for m in members}
 
-    counts = {q: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
-              for q, p in paths.items()}
-    print(f"rows per quantile: {counts}")
+    counts = {m: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
+              for m, p in paths.items()}
+    print(f"rows per member: {counts}")
     if len(set(counts.values())) != 1:
-        # Not fatal -- an inner join keeps only cells present in all three -- but it should not
-        # happen for rasters that share a grid and mask, so make it visible.
-        print("WARNING: quantile partitions differ in row count; join will keep the intersection")
+        print("WARNING: member partitions differ in row count; join keeps the intersection")
 
-    base = args.var
-    sel = ", ".join(f"p{q}.{base}_p{q}" for q in QUANTILES)
+    base = members[0]
+    # Physical units: raw * scale + offset, applied per member.
+    phys = [f"({base}t.{var}_{base} * {args.scale} + {args.offset})" if m == base
+            else f"({m}t.{var}_{m} * {args.scale} + {args.offset})"
+            for m in members]
+    sel_members = ", ".join(f"{e} AS {var}_{m}" for e, m in zip(phys, members))
+    arr = "[" + ", ".join(phys) + "]"
+
     joins = " ".join(
-        f"JOIN read_parquet('{paths[q]}') p{q} ON p{q}.h8 = p50.h8"
-        for q in QUANTILES if q != 50
+        f"JOIN read_parquet('{paths[m]}') {m}t ON {m}t.h8 = {base}t.h8"
+        for m in members if m != base
     )
 
     con.execute(f"""
         COPY (
-            SELECT p50.h8, p50.h5, p50.h4, p50.h0, {sel}
-            FROM read_parquet('{paths[50]}') p50
+            SELECT {base}t.h8, {base}t.h5, {base}t.h4, {base}t.h0,
+                   {sel_members},
+                   list_sort({arr})[{(len(members) + 1) // 2}] AS {var}_median,
+                   list_min({arr})  AS {var}_min,
+                   list_max({arr})  AS {var}_max
+            FROM read_parquet('{paths[base]}') {base}t
             {joins}
-            SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) m
-              ON p50.h8 = m.h8
+            SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) msk
+              ON {base}t.h8 = msk.h8
         ) TO '{args.out}'
         (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
     """)
 
     after = con.execute(f"SELECT COUNT(*) FROM read_parquet('{args.out}')").fetchone()[0]
-    before = counts[50]
+    before = counts[base]
     print(f"MASK h0={args.h0} rows_before={before} rows_after={after} "
           f"kept={100.0 * after / before if before else 0:.2f}%")
     if after == 0:
         print("EMPTY after land mask")
         return 3
 
-    rng = con.execute(f"""
-        SELECT MIN({base}_p50), MAX({base}_p50), COUNT(*) FILTER (WHERE {base}_p50 IS NULL)
+    lo, hi, nulls = con.execute(f"""
+        SELECT MIN({var}_min), MAX({var}_max),
+               COUNT(*) FILTER (WHERE {var}_median IS NULL)
         FROM read_parquet('{args.out}')
     """).fetchone()
-    print(f"MEASURED {base}_p50 min={rng[0]} max={rng[1]} nulls={rng[2]}")
-    # Ordering invariant: p10 <= p50 <= p90 must hold for every cell.
+    print(f"MEASURED {var} physical range: min={lo} max={hi} median_nulls={nulls}")
+
+    # median must lie within [min, max] for every cell -- catches a broken ensemble reduce.
     bad = con.execute(f"""
         SELECT COUNT(*) FROM read_parquet('{args.out}')
-        WHERE {base}_p10 > {base}_p50 OR {base}_p50 > {base}_p90
+        WHERE {var}_median < {var}_min OR {var}_median > {var}_max
     """).fetchone()[0]
-    print(f"CHECK quantile-ordering violations: {bad}")
+    print(f"CHECK median-outside-range violations: {bad}")
     if bad:
-        print("ERROR: ensemble quantiles are not monotonic", file=sys.stderr)
+        print("ERROR: ensemble median falls outside the member range", file=sys.stderr)
         return 4
+
+    # Plausibility bound -- catches a wrong scale/offset, which is otherwise invisible.
+    if args.sane_min is not None and lo is not None and lo < args.sane_min:
+        print(f"ERROR: min {lo} below sane bound {args.sane_min}", file=sys.stderr)
+        return 5
+    if args.sane_max is not None and hi is not None and hi > args.sane_max:
+        print(f"ERROR: max {hi} above sane bound {args.sane_max}", file=sys.stderr)
+        return 5
     return 0
 
 

--- a/catalog/bioclimate/scripts/chelsa_read_meta.py
+++ b/catalog/bioclimate/scripts/chelsa_read_meta.py
@@ -1,0 +1,27 @@
+"""Print scale, offset and nodata for a CHELSA raster (data-workflows #564).
+
+CHELSA declares these per file and they differ per variable -- bio1/bio4/bio12 use nodata 0
+while bio15 uses 65535, and bio1 carries offset -273.15 where the others carry 0. The build
+reads them from the file rather than carrying a table, so a new variable cannot silently
+inherit the wrong sentinel.
+
+Emits one shell-eval-able line: SCALE=<f> OFFSET=<f> NODATA=<v>
+"""
+import argparse
+
+from osgeo import gdal
+
+gdal.UseExceptions()
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--input", required=True)
+args = ap.parse_args()
+
+band = gdal.Open(args.input).GetRasterBand(1)
+scale = band.GetScale()
+offset = band.GetOffset()
+nodata = band.GetNoDataValue()
+
+print(f"SCALE={1.0 if scale is None else scale} "
+      f"OFFSET={0.0 if offset is None else offset} "
+      f"NODATA={'' if nodata is None else repr(nodata).rstrip('0').rstrip('.') if nodata == int(nodata) else nodata}")

--- a/catalog/bioclimate/scripts/chelsa_read_meta.py
+++ b/catalog/bioclimate/scripts/chelsa_read_meta.py
@@ -6,22 +6,53 @@ reads them from the file rather than carrying a table, so a new variable cannot 
 inherit the wrong sentinel.
 
 Emits one shell-eval-able line: SCALE=<f> OFFSET=<f> NODATA=<v>
+(NODATA is empty when the source declares none.)
 """
 import argparse
+import sys
 
 from osgeo import gdal
 
 gdal.UseExceptions()
 
-ap = argparse.ArgumentParser()
-ap.add_argument("--input", required=True)
-args = ap.parse_args()
 
-band = gdal.Open(args.input).GetRasterBand(1)
-scale = band.GetScale()
-offset = band.GetOffset()
-nodata = band.GetNoDataValue()
+def fmt_nodata(v):
+    if v is None:
+        return ""
+    # GDAL returns a float; emit an integer when the sentinel is integral so the value
+    # round-trips into `cng-datasets --nodata` as e.g. "0", never "0.0".
+    return str(int(v)) if float(v).is_integer() else repr(v)
 
-print(f"SCALE={1.0 if scale is None else scale} "
-      f"OFFSET={0.0 if offset is None else offset} "
-      f"NODATA={'' if nodata is None else repr(nodata).rstrip('0').rstrip('.') if nodata == int(nodata) else nodata}")
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    args = ap.parse_args()
+
+    # Hold the Dataset for the lifetime of the band: chaining
+    # `gdal.Open(p).GetRasterBand(1)` lets the Dataset be garbage-collected and leaves the
+    # band dangling, which surfaces as a TypeError inside the SWIG shim rather than as a
+    # clean failure.
+    ds = gdal.Open(args.input)
+    if ds is None:
+        print(f"ERROR: could not open {args.input}", file=sys.stderr)
+        return 1
+    band = ds.GetRasterBand(1)
+    if band is None:
+        print(f"ERROR: no band 1 in {args.input}", file=sys.stderr)
+        return 1
+
+    scale = band.GetScale()
+    offset = band.GetOffset()
+    nodata = band.GetNoDataValue()
+
+    print(f"SCALE={1.0 if scale is None else scale} "
+          f"OFFSET={0.0 if offset is None else offset} "
+          f"NODATA={fmt_nodata(nodata)}")
+    del band
+    del ds
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Standing protocol change requested while scoping the CMIP6 climate work (#564, #565).

## Why

Native H3 resolution for a raster is a **measurement of the source pixel**, not the `h8`
vector default. AGENTS.md said this already, but only in passing inside the *Re-hexing an
existing raster* checklist — so it read as campaign-specific advice rather than standard
protocol, and it had no guidance at all for the coarse end (anything past ~1 km).

That gap matters now: a 0.25° CMIP6 pixel hexed at `h8` would be an **~850× oversample** —
850 identical rows per real value, ~7× cost per resolution step, and a published hex whose
apparent detail is a lie about the source.

## What changed

New `####` section under the H3 resolution & parent convention:

- Resolution table from 30 m through 1°, carrying the existing anchors (100 m → 9, 500 m → 8,
  1 km → 8) and extending to the coarse end the catalog had never covered (5 km → 6,
  0.25° → 5, 0.5° → 4, 1° → 3).
- An explicit note that the anchors are **not** a single formula — the fine end deliberately
  puts several source pixels per cell so an area-weighted reduce has something to average,
  while the coarse end lands within a factor of ~2–3 either way.
- The guardrail that actually generalizes: `pixel_area ÷ cell_area > ~10` means the
  resolution is wrong.
- States that coarse-pixel sources legitimately carry **no `h8`**, and that this must be said
  in the hex asset `description` — otherwise an agent hunting for the catalog's universal
  join key concludes the dataset is broken.
- Notes that undersampling is a deliberate choice too, never a default.

Two cross-references added so the existing mentions point here instead of restating it.

Docs only — no manifests, no STAC, no data.