### PR TITLE
fix(#509): robust nwi-v2 hex config (small chunks + surfacing retries)

### DIFF
--- a/catalog/wetlands/k8s/nwi-v2/nwi-v2-hex.yaml
+++ b/catalog/wetlands/k8s/nwi-v2/nwi-v2-hex.yaml
@@ -5,10 +5,22 @@ metadata:
   labels:
     k8s-app: nwi-v2-hex
 spec:
-  completions: 200
-  parallelism: 50
+  # completions = ceil(feature_count / chunk-size) = ceil(38,065,251 / 5000) = 7614.
+  # The original 200 completions x chunk-size 190327 SILENTLY dropped any chunk that
+  # OOMed or was preempted (backoffLimit: 0), losing 190k features per failure —
+  # 70% of NWI went unhexed and was published incomplete (#509/#563). Small 5000-feature
+  # chunks + per-index retries that SURFACE failures are the robust replacement.
+  completions: 7614
+  parallelism: 80
   completionMode: Indexed
-  backoffLimit: 0
+  # Never backoffLimit: 0 — a dropped index must retry, then fail loudly, not vanish.
+  # With backoffLimitPerIndex set, per-index retries are governed by it and job-level
+  # failure by maxFailedIndexes; keep backoffLimit high so it never fails the job first
+  # (an unset backoffLimit defaults to 6, which would kill this 7614-index job early).
+  backoffLimit: 2147483647
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 400
+  podReplacementPolicy: Failed
   podFailurePolicy:
     rules:
     - action: Ignore
@@ -55,16 +67,16 @@ spec:
         - -c
         - |-
           set -e
-          cng-datasets vector --input s3://public-wetlands/nwi-v2.parquet --output s3://public-wetlands/nwi-v2/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 190327 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+          cng-datasets vector --input s3://public-wetlands/nwi-v2.parquet --output s3://public-wetlands/nwi-v2/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 5000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
         resources:
           requests:
             cpu: '4'
-            memory: 32Gi
-            ephemeral-storage: 10Gi
+            memory: 48Gi
+            ephemeral-storage: 20Gi
           limits:
             cpu: '4'
-            memory: 32Gi
-            ephemeral-storage: 10Gi
+            memory: 48Gi
+            ephemeral-storage: 20Gi
       priorityClassName: opportunistic
       affinity:
         nodeAffinity:


### PR DESCRIPTION
## Problem
The committed `catalog/wetlands/k8s/nwi-v2/nwi-v2-hex.yaml` shipped with `completions: 200` × `--chunk-size 190327` and `backoffLimit: 0`. Any chunk that OOMed on a large wetland complex or got preempted **silently dropped 190,327 features**. Result: the published hex held **11.27M of 38.07M** features (~70% missing) yet looked complete. Root cause and rebuild playbook in #563; part of the #509 sweep.

## Fix
Commit the config the rebuild (`nwi-v2-hex-rebuild`) was actually verified on, so the next clone/headless run doesn't reproduce the data loss:

| field | before | after |
|---|---|---|
| completions | 200 | **7614** (= ceil(38,065,251 / 5000)) |
| `--chunk-size` | 190327 | **5000** |
| failure handling | `backoffLimit: 0` | **`backoffLimitPerIndex: 3` + `maxFailedIndexes: 400` + `podReplacementPolicy: Failed`** (retry, then fail loudly) |
| memory | 32Gi | **48Gi** |
| ephemeral-storage | 10Gi | **20Gi** |

`backoffLimit` is kept high (2147483647) so it never fails the 7614-index job before `maxFailedIndexes` does (an unset value defaults to 6).

## Verification (against the rebuilt hex on S3)
- `COUNT(DISTINCT _cng_fid)` = **38,065,251** = flat parquet feature count — exact `_cng_fid` set identity (0 in-flat-not-hex, 0 in-hex-not-flat).
- Zero NULLs in `h10`/`h9`/`h8`/`h0`; 10 h0 partitions (CONUS + AK + HI); 123.4M feature-cell rows.
- `scripts/verify-stac.py --bucket public-wetlands --dataset nwi` → PASS (0 hard findings).

Closes the last large #509 rebuild. Refs #563.