### PR TITLE
Move procedural detail from AGENTS.md into portable .claude/skills/ (#569)

### DIFF
--- a/.claude/skills/dataset-recipes/SKILL.md
+++ b/.claude/skills/dataset-recipes/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: dataset-recipes
+description: >-
+  Worked end-to-end examples of dataset ingests to copy from: PAD-US multi-layer GDB, Census TIGER per-state zips with a preprocess job, a single-COG carbon raster, reading one small table out of a huge remote zip via GDAL range reads, and preprocessing multi-file zipped sources. Use as a starting template when a new ingest resembles one of these shapes.
+---
+
+# Dataset Recipes
+
+Copy the closest-shaped recipe rather than deriving a pipeline from scratch.
+
+## 💡 Read one small table out of a HUGE remote zip — range reads, no localize (#518)
+
+To inspect a schema, a lookup/domain table, or one layer's coverage inside a multi-GB zipped
+GDB, do **not** localize the archive (a PVC + 30 GB download for a 126-row table). GDAL's
+`/vsizip//vsicurl/` reads the zip central directory plus only the bytes it needs over HTTP
+range requests — a small cluster job, seconds to a couple of minutes:
+
+```bash
+# authoritative coded domain out of the archived 30 GB national GDB (internal endpoint)
+SRC="/vsizip//vsicurl/http://rook-ceph-rgw-nautiluss3.rook/public-usgs-nhd/raw/NHD_H_National_GDB.zip/NHD_H_National_GDB.gdb"
+ogr2ogr -f CSV /vsistdout/ "$SRC" NHDFCode          # 126 rows, ~25 s, no PVC
+ogrinfo -ro -q "$SRC" -dialect SQLITE \
+  -sql "SELECT COUNT(*), SUM(StreamOrde > 0) FROM NHDPlusFlowlineVAA"
+```
+
+- Works on a **public** source URL too (`/vsizip//vsicurl/https://prd-tnm.s3.amazonaws.com/...`) —
+  ideal for pre-flighting a candidate import before committing to a build.
+- Use `-dialect SQLITE`: **OGR SQL has no `CASE`**, and keep the SQL on **one line** (a folded
+  YAML block mangles multi-line SQL). `SUM(cond)` works in the SQLITE dialect.
+- Full-table `COUNT(*)` over range reads is slow (minutes) because it decodes every feature;
+  schema reads and small tables are fast. Aggregate on the small table, not the geometry layer.
+- Working manifests: `catalog/usgs-nhd/k8s/extract-fcode-domain.yaml`,
+  `catalog/usgs-nhd/k8s/preflight-nhdplus-hr-vaa.yaml`.
+- ⛔ Never hand-write a coded domain from memory (#294) — this is how you get the real one.
+
+## Step 1c: Preprocessing multi-file zipped datasets
+
+**`cng-convert-to-parquet` rejects multiple .zip URLs.** For per-state/per-region zips, preprocess: download in parallel, unzip, pass shapefiles (the tool merges them automatically):
+```bash
+for id in 01 02 03; do curl -sS -O "https://example.com/data_${id}.zip" & done
+wait && unzip -q -o "*.zip"
+cng-convert-to-parquet /tmp/data/*.shp s3://bucket/output.parquet
+```
+See `catalog/census/k8s/tract/preprocess-tract.yaml` for a complete k8s job.
+
+## Reference Examples
+
+### PAD-US (multi-layer GDB, 5 spatial layers)
+```bash
+# One-time raw upload
+rclone copy PADUS4_1Geodatabase.gdb nrp:public-padus/raw/PADUS4_1Geodatabase.gdb -P
+
+# Generate per-layer workflows
+for args in \
+  "padus-4-1/fee PADUS4_1Fee" \
+  "padus-4-1/easement PADUS4_1Easement" \
+  "padus-4-1/proclamation PADUS4_1Proclamation" \
+  "padus-4-1/marine PADUS4_1Marine" \
+  "padus-4-1/combined PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement"; do
+  set -- $args
+  cng-datasets workflow --dataset "$1" \
+    --source-url https://s3-west.nrp-nautilus.io/public-padus/raw/PADUS4_1Geodatabase.gdb \
+    --bucket public-padus --layer "$2" \
+    --h3-resolution 10 --hex-memory 32Gi --max-completions 200 --max-parallelism 50 \
+    --parent-resolutions "9,8,0" \
+    --output-dir "catalog/pad-us/k8s/$(echo $1 | cut -d/ -f2)"
+done
+
+kubectl apply -f catalog/pad-us/k8s/fee/workflow-rbac.yaml   # once
+for layer in fee easement proclamation marine combined; do
+  kubectl apply -f catalog/pad-us/k8s/$layer/configmap.yaml -f catalog/pad-us/k8s/$layer/workflow.yaml
+done
+```
+Non-spatial lookup tables: see `catalog/pad-us/k8s/extract-lookup-tables.yaml` and `catalog/pad-us/lookup-tables.md`.
+
+### Census 2024 (per-state zips → preprocess → pipeline)
+TIGER/Line ships per-state. Discover pattern:
+```bash
+curl -I https://www2.census.gov/geo/tiger/TIGER2024/TRACT/
+curl -s https://www2.census.gov/geo/tiger/TIGER2024/TRACT/ | grep '.zip' | head
+# tl_2024_01_tract.zip, tl_2024_02_tract.zip, ...
+```
+Preprocess job (`catalog/census/k8s/tract/preprocess-tract.yaml`) parallel-downloads, unzips, and calls `cng-convert-to-parquet /tmp/tracts/*.shp s3://...` (tool merges). ~3 min for 56 files. Then:
+```bash
+cng-datasets workflow --dataset census-2024/tract \
+  --source-url s3://public-census/census-2024/tract.parquet --bucket public-census \
+  --h3-resolution 10 --parent-resolutions "9,8,0" \
+  --hex-memory 16Gi --max-completions 200 --max-parallelism 50 \
+  --output-dir catalog/census/k8s/tract
+kubectl apply -f catalog/census/k8s/tract/census-2024-tract-hex.yaml
+kubectl apply -f catalog/census/k8s/tract/census-2024-tract-pmtiles.yaml
+# after hex:
+kubectl apply -f catalog/census/k8s/tract/census-2024-tract-repartition.yaml
+```
+Result: ~85,000 tracts.
+
+### Carbon raster (single COG already on S3)
+```bash
+cng-datasets raster-workflow --dataset irrecoverable-carbon-2022 \
+  --source-url s3://public-carbon/v2/cogs/irrecoverable_c_total_2022.tif \
+  --bucket public-carbon --h3-resolution 8 --parent-resolutions "0" \
+  --value-column carbon --hex-memory 32Gi --max-parallelism 61 \
+  --output-dir catalog/carbon/k8s/v2/irrecoverable-carbon-2022
+
+kubectl apply -f catalog/carbon/k8s/v2/irrecoverable-carbon-2022/workflow-rbac.yaml
+kubectl apply -f catalog/carbon/k8s/v2/irrecoverable-carbon-2022/configmap.yaml \
+              -f catalog/carbon/k8s/v2/irrecoverable-carbon-2022/workflow.yaml
+```
+Hex job runs `cng-datasets raster` once per h0 cell (122 indexed pods), writing `hex/h0={cell}/data_0.parquet`. Empty cells skipped silently. No repartition step — output goes directly to its final partition.

--- a/.claude/skills/hex-tuning/SKILL.md
+++ b/.claude/skills/hex-tuning/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: hex-tuning
+description: >-
+  Tune H3 hex generation for vector datasets: the memory and chunking mental model (peak RAM is driven by the largest single feature, not dataset size), H3 native and parent resolution conventions for join compatibility across the catalog, vector workflow parameters, and reprocessing failed chunks. Use when a hex job OOMs, when choosing resolutions, or when sizing chunks and completions.
+---
+
+# Hex Tuning
+
+How to size a vector hex job, and how to choose resolutions that stay joinable to the rest of the catalog.
+
+## Memory and Chunking Mental Model
+
+**RAM is driven by the H3 cell count of the single largest feature in a chunk — not dataset size or bounding box.**
+
+Hex generation is two passes:
+1. For each feature polygon, compute covering H3 cells (large array per feature)
+2. Unnest arrays row-by-row; **peak RAM = size of the largest single feature's cell array**
+
+Counterintuitive result: 10,000 small features at 8Gi can be fine, while a single continent-scale polygon OOMs at 32Gi. What drives RAM:
+- H3 resolution (exponential: res 8 ≈ 1/170th the cells of res 10 for the same area)
+- Area of the largest single feature in the chunk
+- Geometry complexity affects Pass 1 runtime, not Pass 2 RAM
+
+**Right approach:** start with default (8Gi vector), then tune from OOM signals.
+1. Use Armada with `--chunk-size 1` for variable feature sizes (each feature its own pod)
+2. On OOM: identify the large polygon(s) and either lower resolution, raise `--hex-memory`, or re-run that chunk alone (see Reprocessing Failed Chunks)
+3. OOMs are expected — a tuning signal, not failure.
+
+**Resolution guidance:**
+
+| Dataset type | Resolution | Rationale |
+|---|---|---|
+| Countries, continents | 8 | Continent-scale features |
+| States, provinces | 8 | Still very large |
+| Counties, districts | 8–10 | Mostly OK at 10; watch outliers |
+| Census tracts, parcels | 10 | Small features |
+| Points | 10 | Each point → one cell; coarser = aggregation |
+| Lines | 8 | Buffered by H3 circumradius; default 8 auto-detected |
+
+#### ⭐ H3 resolution & parent convention (join compatibility — pick native res AND parents deliberately)
+
+Native resolution alone is not the whole decision — the **parent-resolution set** is what
+makes a dataset joinable to the rest of the catalog. Two datasets join cheaply only at a
+resolution they **both physically carry** (`h<N> = h<N>`); otherwise a consumer must
+`h3_cell_to_parent()` on the fly, which LLM agents do unreliably (wrong direction, skipped,
+empty joins). So encode the joins into the data, don't hope the model derives them.
+
+- **`h8` is the catalog's universal join key. Default native resolution is 8**, and **every
+  dataset finer than 8 (native `h9`/`h10`) MUST carry `h8`** as a parent. Rationale: raster
+  hexes (carbon, GHS-POP, richness) are native `h8`, and vector hexes (native `h10`) carry
+  `h8` — so nearly everything meets at `h8`. A one-off native `h7` (e.g. the gHM 1 km raster
+  before this rule) is an **outlier with no `h8`** and silently breaks those joins — don't do it.
+- **`h0` always** — it is the hive partition key and the coarsest common join; every hex asset
+  carries it (it must be in `--parent-resolutions`).
+- **`h10` is currently our finest.** Small features (parcels, tracts, points) → native `h10`,
+  parents `9,8,0` (the generator default) so they carry `h8`.
+- **Coarser than 8 only when features are genuinely huge** — continent- or ocean-scale polygons
+  (e.g. large marine areas hexed at `h5`) to keep hex cell-count/RAM sane. Such a dataset
+  *cannot* carry `h8` (finer than native); consumers roll finer data **up** to `h5` to join it.
+  Use a coarse native res because the feature size forces it, never as a cost shortcut on data
+  that should be `h8`.
+- **A dataset may declare a *set* of parents** (e.g. native `h8` with `--parent-resolutions
+  "5,4,0"` → columns `h8,h5,h4,h0`) so it joins at several standard resolutions at once. Pick the
+  parent set from the resolutions of the datasets it will be joined against.
+- Always record the chosen native + parents in the issue (scope) and in the hex asset's
+  `h3:native_resolution` / `h3:parent_resolutions` (STAC).
+
+### Vector workflow parameters
+
+| Param | Default | When to change |
+|---|---|---|
+| `--h3-resolution` | 10 | Lower (8, 6) for large polygons. Halving res ≈ 6× fewer cells. |
+| `--hex-memory` | 8Gi | Tune from OOM signals. Start low. |
+| `--max-completions` | 200 | Number of hex chunks. With armada: set to feature count for chunk-size 1. **⛔ Not a hard cap — a silent coverage limit (data-workflows #494):** the k8s hex uses a FIXED `--chunk-size 1000`, so total features hexed = `max-completions × 1000`. The default 200 silently caps a build at **200,000 features** — anything beyond that is never hexed and the repartition/STAC look "complete." For any dataset **>200k features**, set `--max-completions ≥ ceil(feature_count / 1000)` (e.g. 711,583 → 720). The generator can't count features in a zip/parquet source, so it can't warn you. **Always** confirm coverage post-build: `COUNT(DISTINCT _cng_fid)` on the hex must equal the flat parquet's feature count (not just that h0 partitions exist). |
+| `--max-parallelism` | 50 | k8s only — capped by pod quota. Unused with armada. |
+| `--parent-resolutions` | "9,8,0" | Use `"0"` when `--h3-resolution 8` (9/8 would duplicate target). |
+| `--intermediate-chunk-size` | 10 | Decrease if hex OOMs during unnest — try this before raising memory. |
+
+## Reprocessing Failed Chunks
+
+For chunks that fail (e.g. DuckDB parquet page-size limits on complex geometries), reprocess at coarser H3:
+1. Identify failed IDs: `kubectl get pods | grep <name>-hex | grep -E "Error|Failed"`
+2. Copy `<name>-hex.yaml` → `<name>-hex-rechunk.yaml`, rename the job, set `completions: <N-failed>`, and replace the command with a CHUNK_MAP:
+   ```yaml
+   args:
+   - |
+     set -e
+     CHUNK_MAP=(0 1 2 94)
+     CHUNK_ID=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
+     cng-datasets vector \
+       --input s3://<bucket>/<dataset>.parquet \
+       --output s3://<bucket>/<dataset>/chunks \
+       --chunk-id $CHUNK_ID --chunk-size <same> --intermediate-chunk-size <same> \
+       --resolution 8 --parent-resolutions 9,8,0
+   ```
+3. Apply, then run `<name>-repartition.yaml`. Repartition merges both resolutions from `chunks/` → `hex/` by h0.

--- a/.claude/skills/job-troubleshooting/SKILL.md
+++ b/.claude/skills/job-troubleshooting/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: job-troubleshooting
+description: >-
+  Diagnose failing or stuck Kubernetes jobs and DuckDB parquet errors: OOMKilled, evictions, ContainerStatusUnknown, flaky-node hangs, ephemeral-storage limits and PVC scratch, pod quota errors, 404s on convert, blank PMTiles in MapLibre, and the DuckDB httpfs stoi crash on oversized parquet column chunks. Use when a job fails or hangs, or when a published parquet will not read.
+---
+
+# Job Troubleshooting
+
+Diagnose before resubmitting — a failing job re-run unchanged fails the same way.
+
+## ⛔ Serialization standard: DuckDB httpfs `stoi` crash on oversized column chunks
+
+The MCP can abort with **`SQL Error: stoi`** when reading GeoParquet over S3/httpfs. The root cause is a **DuckDB httpfs bug on large Parquet column chunks** — not the CRS tag, writer, or geometry content. Fully diagnosed in datasets [#106](https://github.com/boettiger-lab/datasets/issues/106).
+
+### What triggers it
+
+A single Parquet column chunk in the **~2.8–2.88 GB compressed / ~3.73–3.84 GB uncompressed** range causes the httpfs reader to abort with `stoi`. No spatial function needed — `SELECT COUNT(geom)` (which decodes the column) is sufficient to crash; `SELECT COUNT(*)` (footer only, no decode) is fine. **Local file reads always work** — this is exclusively an httpfs path bug.
+
+```sql
+SELECT COUNT(*)  FROM read_parquet('https://…/repro-100000.parquet');   -- ✅ OK
+SELECT COUNT(geom) FROM read_parquet('https://…/repro-100000.parquet'); -- ❌ stoi
+```
+
+The crash appears "plan-dependent" because queries that skip decoding the geometry column (e.g. filtered reads that never touch the oversized chunk) avoid it. Every individual row is valid; the data is not corrupt.
+
+### What does NOT matter
+
+| Hypothesis | Verdict |
+|---|---|
+| `creator: geopandas` | ❌ cng-convert-written file crashes identically |
+| `OGC:CRS84` vs `EPSG:4326` CRS tag | ❌ re-tagging as `EPSG:4326` still crashes |
+| Plain DuckDB `COPY` re-write | ❌ still crashes |
+| A single pathological geometry | ❌ local read of same file returns all rows |
+
+### Prevention (the real fix)
+
+**Keep row groups small enough that no single geometry column chunk exceeds ~1 GB compressed.** For large-feature geometry (complex multipolygons, national-scale data), the default `--row-group-size 100000` can pack a single chunk well past the 2.8 GB cliff. Use `--row-group-size 2000` as a safe default for geometry-heavy datasets, or estimate `avg(octet_length(ST_AsWKB(geom)))` on a sample and size accordingly. Tracked in cng-datasets [#106](https://github.com/boettiger-lab/datasets/issues/106).
+
+### Mitigation if a published file already crashes
+
+Use `s3://` (internal endpoint, not `https://`) inside cluster jobs — the httpfs path is the public endpoint only. For MCP queries (which always go over https), re-publish the file with smaller row groups via a cluster DuckDB job:
+
+```sql
+COPY (SELECT * FROM read_parquet('s3://bucket/file.parquet'))
+TO 's3://bucket/file-rg2000.parquet'
+(FORMAT PARQUET, ROW_GROUP_SIZE 2000, COMPRESSION ZSTD);
+```
+
+### geopandas-written files
+
+Still avoid publishing geopandas-written GeoParquet — use the cng-datasets DuckDB-native path. But the failure mode is different (geoarrow extension type, any DuckDB version; upstream [duckdb/duckdb#21691](https://github.com/duckdb/duckdb/issues/21691)) and orthogonal to the httpfs chunk-size crash above.
+
+## Troubleshooting
+
+**404 on convert → verify source URLs** with `curl -I` and directory listings (most common failure — always verify BEFORE generating YAMLs).
+
+**"Cannot mix .zip files with multiple source URLs"** → preprocess job: download in parallel, unzip, pass shapefiles to `cng-convert-to-parquet`.
+
+**Check convert logs:** `kubectl logs job/<name>-convert`
+
+**Repeated preemptions on shared nodes → pin to Berkeley node** `stratus1.nrp-espm.berkeley.edu` (currently carries `nautilus.io/issue` taint):
+```yaml
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
+      tolerations:
+      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
+```
+
+⛔ **This pin is a *reactive last resort* for observed, recurring preemption — NEVER a default.** By default let the k8s scheduler place pods. Many nodes across the cluster can service big requests (256/512 GB, multi-cpu) — the Berkeley node is only one of them. **Pinning a large-memory job to one node serializes it:** a 256Gi/8cpu pod fills the node, so `parallelism: N` becomes 1-at-a-time while the rest sit `Pending: Insufficient cpu` (this turned a CONUS res-10 hex from hours into 30-50h — #307). The cluster headroom is there to *request when a job genuinely needs it*; reach for `backoffLimitPerIndex` retries to absorb the occasional preemption before you ever reach for a node pin.
+
+✅ **You do NOT need to exclude GPU nodes for CPU-only jobs.** The generated `nodeAffinity` excludes GPU nodes (`feature.node.kubernetes.io/pci-10de.present NotIn true`), but GPU nodes usually have plenty of **spare CPU/RAM** that our hex/convert/COG jobs can use. Dropping the GPU exclusion **widens the schedulable pool**, which finishes fan-out jobs faster and — importantly — reduces the chance of pods piling onto a flaky node. Keep the exclusion only if a job genuinely needs to avoid GPU-host contention.
+
+⚠️ **Flaky-node hangs — and ⛔ NEVER `--force`-delete pods.** Some shared nodes (observed: `hpc-nrp-g1.nmsu.edu`, `service-02.nrp.mghpcc.org`) have broken egress/S3 connectivity: pods schedule but **hang on `rclone` localize / external download** ("Localizing input →" with no progress; "Could not resolve host") or sit `Pending` with the container never starting. A `backoffLimit: 0` job never recovers (pod Running/Pending, not Failed) and blocks the whole run.
+
+- ⛔ **Never `kubectl delete pod --grace-period=0 --force`.** It drops the API object while the container may still be running on an unreachable node → split-brain / duplicate S3 writes. (Standing rule from the user.)
+- ✅ **Let the control plane reap it — the safe equivalent.** A graceful `kubectl delete pod` (no `--force`) plus the node-lifecycle controller's eviction marks pods on an unreachable node `Failed` after the eviction timeout (~5 min); with `podReplacementPolicy: Failed` (the default once `backoffLimitPerIndex` is set) the Job then recreates that index on a healthy node. Net cost of *not* forcing is ~5 min, **not** a block — verified: a 4-index hang on `service-02` self-healed to 122/122 with zero force-deletes.
+- **Defenses, in order (prevention beats cure):** (1) exclude known-bad hosts via a `kubernetes.io/hostname NotIn [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org, …]` nodeAffinity term so pods never land there; (2) `activeDeadlineSeconds` on the **pod template** (turns a running-hang into a Failure the Job can retry); (3) `backoffLimitPerIndex` + `maxFailedIndexes` (retry the index elsewhere). Note `activeDeadlineSeconds` only helps a *Running* hang — a `Pending` pod (container never started) is cleared only by control-plane eviction, so (1) is the real fix.
+
+**Pod keeps getting evicted (`ContainerStatusUnknown`) → diagnose BEFORE resubmitting.** Never resubmit a failing job without `kubectl describe pod <pod>` — same resources will fail the same way.
+```bash
+kubectl -n geo-workflows describe pod <pod-name> | grep -A5 "Reason:\|Message:\|Events:"
+```
+
+| Message | Cause | Fix |
+|---|---|---|
+| `ephemeral local storage usage exceeds the total limit` | DuckDB sort spill | Raise memory AND ephemeral-storage |
+| `OOMKilled` | Insufficient RAM | Raise memory |
+| `ContainerStatusUnknown` on shared nodes | Preemption | Pin to Berkeley node |
+
+**DuckDB sort jobs need both big RAM and big ephemeral-storage.** `ORDER BY` over large data spills to disk; low RAM spills more. For 1–15 GB compressed partitions: 120Gi RAM, 50Gi ephemeral-storage. Namespace max for ephemeral-storage is **50Gi** — always request the max for sort-heavy jobs.
+
+**When scratch exceeds 50Gi, mount a PVC — do NOT fight the ephemeral cap.** Ephemeral-storage is hard-capped at 50Gi namespace-wide, so any job whose local scratch exceeds that — a raw download bigger than ~45 GB (e.g. the 35 GB RAP CONUS COG), a multi-tile `preprocess-cog` mosaic, a `raster --local-cache-dir` localization of a large COG — must use a **PersistentVolumeClaim**, not a bigger ephemeral request (which the quota will reject). A shared scratch PVC already exists: **`rechunk-scratch`** (2Ti, `RWX` rook-cephfs) — list with `kubectl -n geo-workflows get pvc`.
+- Mount it and redirect the tool's scratch onto it; keep ephemeral small (~10Gi):
+  ```yaml
+  volumeMounts:
+  - {name: scratch, mountPath: /scratch, subPath: <job-name>}   # subPath → per-job isolation on the shared PVC
+  volumes:
+  - {name: scratch, persistentVolumeClaim: {claimName: rechunk-scratch}}
+  env:
+  - {name: TMPDIR, value: /scratch}        # Python tempfile.mkdtemp (mosaic temp) honors TMPDIR
+  # and pass: cng-datasets raster --local-cache-dir /scratch ...   (input localization; CLI default is /tmp/cng-raster-cache)
+  ```
+- **`RWX` + concurrency caveat:** `rechunk-scratch` is ReadWriteMany, but `--local-cache-dir` localizes to a fixed basename, so **N concurrent pods sharing one mountPath collide on the same file**. Use a per-pod `subPath` (or per-pod cache subdir) for fan-out jobs. The 122-pod raster **hex** step localizes a multi-GB COG per pod and is best left on **per-pod ephemeral** (the mosaic COG fits in 50Gi); reserve the PVC for the **single-pod** `preprocess-cog`/download/stage steps where the file genuinely exceeds 50Gi.
+
+**Hex OOM** → regenerate with `--hex-memory 64Gi` and/or more `--max-completions`, delete failed job, reapply.
+
+**503 SlowDown (S3 throttle)** → transient, retry.
+
+**PMTiles renders blank in MapLibre → wrong `source-layer`.** It's the last path segment of `--dataset`, NOT the GDB/source layer name. For `--dataset padus-4-1/fee`, it's `fee` (not `PADUS4_1Fee`).
+
+**Workflow stuck:** `kubectl logs job/<name>-workflow` and `kubectl get jobs | grep <name>`.
+
+**`exceeded quota: reached-quota`** → pod limit hit. Delete running hex jobs and resubmit sequentially (see Namespace Pod Quota):
+```bash
+kubectl get jobs | grep -E 'dataset-a|dataset-b' | awk '{print $1}' | xargs kubectl delete job
+```

--- a/.claude/skills/raster-hexing/SKILL.md
+++ b/.claude/skills/raster-hexing/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: raster-hexing
+description: >-
+  Build and hex raster datasets: choosing the native H3 resolution from the source pixel, selecting the --hex-resampling reducer (sum, mean, mode, max, min), mosaicking a many-tile source into one COG, raster-workflow parameters, and the campaign checklist for re-hexing an existing raster. Use for any GeoTIFF or COG ingest, or any re-hex of published raster data.
+---
+
+# Raster Hexing
+
+Raster ingest produces **COG + H3 hex only** — no GeoParquet, no PMTiles. Always create the WGS84 COG first, then hex from that COG on NRP S3 (never from the original source URL).
+
+## Generating a raster workflow
+```bash
+cng-datasets raster-workflow \
+  --dataset <name> --source-url <cog-url> --bucket <bucket> \
+  --h3-resolution 8 --parent-resolutions "0" --value-column <band_name> \
+  --hex-memory 32Gi --max-parallelism 61 \
+  --output-dir catalog/<dataset>/k8s/<name>
+```
+
+Differences from vector:
+- Command: `raster-workflow`
+- Completions always 122 (one per h0 cell) — not configurable
+- Defaults: `--h3-resolution` 8, `--parent-resolutions "0"`, `--hex-memory 32Gi`, `--max-parallelism 61`
+- `--value-column` — raster band name in output (default `value`)
+- `--nodata` — value to exclude (auto from metadata)
+- `--hex-resampling` — **how pixels aggregate into each cell (`sum`/`mean`/`mode`/`max`/`min`, default `mean`). Picking the wrong one silently corrupts the data — see "Choosing the aggregation reducer" below. As important as `--value-column`.**
+- Always creates a WGS84 COG on NRP S3 first; hex reads from that COG
+
+**Multi-tile rasters** (e.g. multiple UTM zones): repeat `--source-url`. Adds `preprocess-cog` step that mosaics into one WGS84 COG:
+```bash
+cng-datasets raster-workflow --dataset wyoming/rap-arte \
+  --source-url s3://.../rap_arte_zone12.tif \
+  --source-url s3://.../rap_arte_zone13.tif \
+  --bucket public-wyoming \
+  --target-extent "-111.1,40.9,-104.0,45.0" --band 1 --value-column arte \
+  --output-dir catalog/wyoming/k8s/rap-arte
+```
+Extra options: `--target-extent "xmin,ymin,xmax,ymax"` (EPSG:4326 clip), `--target-resolution <degrees>`, `--band <n>` (1-indexed), `--output-cog-name <key>`.
+
+## ⚠️ Mosaicking a MANY-tile source (thousands of 1° tiles) into one global COG — two traps
+
+For a source shipped as thousands of small tiles (Copernicus GLO-30/90 DEM = 26,475 tiles; many
+global rasters), repeating `--source-url` is unusable and the naïve single-job mosaic fails two ways.
+Both were hit and fixed on the DEM import (data-workflows #426; manifests at
+`catalog/dem/k8s/copernicus-glo90/` are the working pattern):
+
+1. **rook-cephfs metadata latency kills the file-opens, NOT bandwidth.** Localizing 26k tiles to the
+   `rechunk-scratch` **cephfs** PVC and running `gdalbuildvrt` over them crawled — each file open pays
+   a network-metadata RTT (~150 ms), so 26k opens = 60+ min *each* for the localize and the VRT build,
+   at idle CPU. Local NVMe opens the same files in <1 s. **Fix: localize to LOCAL ephemeral (`/tmp`),
+   not the PVC.** 66 GB > the 50Gi ephemeral cap, so split into N balanced **contiguous longitude
+   bands** (integer-degree cuts → tile-aligned, seamless), one indexed pod per band on local NVMe →
+   regional COGs, then a tiny merge job stitches the few regional COGs into the global COG (a handful
+   of large-file opens is fine on cephfs). ~35 min total vs "never finished." Reserve the cephfs PVC
+   for the *merge* (few big files), never the many-small-file localize.
+2. **`gdalbuildvrt` default `-resolution average` silently downsamples.** Tiles whose pixel size in
+   *degrees* varies (Copernicus DEM narrows column counts toward the poles to hold ~90 m ground
+   spacing) get averaged to a bogus middle X-resolution — the equator was squished ~2.5× (Everest read
+   8146 m instead of ~8700). **Always pass `-resolution highest`** (→ the uniform finest grid) for a
+   lat/lon global mosaic. Sanity-check a known peak's pixel value against the raw source tile.
+
+Also: `gdalinfo -stats` writes a `.tif.aux.xml` sidecar and **reads cached stats from it on a rerun** —
+if you rebuild the COG in the same scratch dir, a stale `.aux.xml` reports the OLD min/max/mean. `rm`
+the `.aux.xml` too, or verify values with a fresh `gdallocationinfo`/`ComputeStatistics`, not the sidecar.
+
+## ⚠️ Choosing the aggregation reducer (`--hex-resampling`)
+
+`--hex-resampling` controls how source pixels collapse into each H3 cell. **The right reducer depends entirely on what the pixel value *means*, and the wrong one silently produces nonsense** (summing land-cover class codes, averaging species counts). Decide this per dataset, every time. Supported: `sum`, `mean`, `mode`, `max`, `min` (default `mean`).
+
+| Pixel value is… | Reducer | Examples |
+|---|---|---|
+| **Amount already integrated *per pixel*** — each pixel holds the whole-pixel total | `sum` | population *per pixel* (GHS-POP persons/cell), fishing-effort hours per cell, counts |
+| **Density / intensity / rate / fraction** — a *per-area* or normalized quantity | `mean` | carbon **density** (Mg C **ha⁻¹** — Noon irrecoverable/vulnerable/manageable carbon), NDVI, % cover (RAP), depth (GEBCO), indices (NCP) |
+| **Categorical** — discrete class codes | `mode` | land cover (CGLS-LC100, NLCD), wetland class (GLWD) |
+
+**⛔ The density-vs-amount trap (the #1 way `sum` goes wrong) — check the source UNITS before choosing the reducer.** `sum` is correct *only* when each pixel value is an amount **already integrated over the pixel** (GHS-POP stores persons *per pixel*, so `sum` recovers the population total). If the value is a **density** — a per-area quantity like Mg C **ha⁻¹**, t km⁻², persons km⁻² — then `sum` produces a meaningless *sum of densities*, off from the true total by roughly the pixel area (carbon was ~7× low; data-workflows #171/#202). **A stock can be a density:** "carbon stock" is conceptually extensive, but the Noon et al. carbon rasters store Mg C **per hectare**, so they need area-integration, *not* `sum`. The reducer follows the **units**, not the conceptual quantity — read the source READMEs / band metadata / paper to confirm whether a value is per-pixel or per-area.
+
+To get a **total from a density raster**: use `mean` (area-weighted mean density per cell), then multiply by the H3 cell ground area downstream — `total = mean_density × cell_area` (h3 `cell_area`; cells are ~equal-area per resolution). There is no one-step density→total reducer yet ([`boettiger-lab/datasets#105`](https://github.com/boettiger-lab/datasets/issues/105)). For an existing density-`sum` build, the equivalent correction is `value × pixel_area_ha` per cell (pixel area is latitude-dependent on a WGS84 grid, ≈ `9·cos(lat)` ha for a ~300 m grid).
+
+**Correctness check:** for an amount-per-pixel `sum`, the catalog-wide `SUM(value)` over the hex parquet MUST equal the source COG's pixel sum within sub-pixel rounding (compute the COG sum with a GDAL block-sum job; query the hex sum via the MCP). **For a density layer, the COG pixel-sum is itself *not* a total — validate the area-corrected `SUM` against the published global total instead** (e.g. irrecoverable carbon 2018 ≈ 137 Gt vs Noon et al. 139.1 Gt). `mean`/`mode` have no global invariant — spot-check the hex against the COG over a known region.
+
+**Species richness / "peak" quantities** (MOBI, IUCN richness): the correct reducer is `max` — **not** `sum` (double-counts species) and **not** `mean` (averages away hotspots). `max` (and `min`) are supported as of [`boettiger-lab/datasets#95`](https://github.com/boettiger-lab/datasets/issues/95) (closed 2026-06-01); MOBI and IUCN-richness were rebuilt with `max` at res 8/5 (data-workflows #194). Validate: hex `MAX(value)` == COG max, and every cell value within `[COG min, COG max]` (roll up to coarser resolutions with `GROUP BY h<parent> + MAX`, never `AVG`/`SUM`).
+
+**`mode` keeps only the *dominant* class** per cell; the class mix is discarded. Fine for "dominant class" maps, but **inadequate for area-accounting** ("how much wetland?"), which then undercounts to plurality cells only. Per-class fractional coverage (one column per class) is not produced by the current pipeline — flag it if a use case needs class areas.
+
+**Reducer choice is independent of geometry correctness.** The raster pipeline integrates each cell's true footprint, including the antimeridian/poles (fixed in `cng-datasets` #88/#92). But any **global** raster hexed before that fix is inflated at the ±180/pole seam and must be re-hexed regardless of reducer.
+
+## Raster workflow parameters
+
+| Param | Default | When to change |
+|---|---|---|
+| `--h3-resolution` | auto (from pixel size) | Override if auto is wrong |
+| `--hex-memory` | 32Gi | Raise if OOM. **Res-8 hex of a 300 m global raster needs 64Gi** — `exact_extract` on the densest h0 cells (~5.76 M cells/h0) OOMs at 32Gi (`exit 137`); with `backoffLimit: 0` it silently retries forever, with `backoffLimitPerIndex` it can blow `maxFailedIndexes` and **fail the job** (observed on nci-frontiers `flii`/forestry). Use 64Gi for res-8 300 m layers; coarser res or coarser source can stay at 32Gi. |
+| `--max-parallelism` | 61 | k8s only; reduce on quota hit; cap 122 |
+| `--parent-resolutions` | "0" | Add intermediate (e.g. `"7,0"`) if needed |
+| `--value-column` | "value" | Use meaningful name (`carbon`, `arte`, `nlcd`) |
+| `--nodata` | auto | Override if metadata nodata is wrong/missing |
+
+Raster completions are always **122** — not configurable.
+
+## Re-hexing an existing raster (campaign-style reprocessing)
+
+Most rework here comes from skipped pre-flight checks, not hard problems. Do, in order:
+
+1. **Pre-flight the COG** with one GDAL job (rclone-localize → read; never `/vsis3` for GDAL — it's flaky/node-dependent). Report size, dtype, **real nodata** (published STAC nodata is often wrong), and the value summary that becomes your validation truth (class histogram for `mode`; pixel-SUM for `sum`; min/max/mean for `mean`). **Confirm the COG is non-empty** — published "total" COGs have shipped 100% nodata.
+2. **Resolution = match the source pixel** (≈100 m → res 9; ≈500 m → res 8). Don't bump blindly; res finer than the pixel is 7× cost for no gain.
+3. **Hex job musts:** mount the `rclone-config` secret (the tool localizes the COG via rclone first; generated YAML omits it → fails), `backoffLimitPerIndex: 2` + `maxFailedIndexes` (not `backoffLimit: 0`), output to a **staging** prefix. `:latest` has the seam fix — no runtime clone.
+4. **Validate value AND coverage.** `sum`: hex `SUM` == COG pixel-SUM. Note `sum`/area layers are a **full h0 grid** (one row per cell, `value = 0` where the feature is absent) — same shape as carbon/ghs-pop; that's expected, not bloat. Check that the count of **nonzero** cells matches the feature extent, not the total. `mode`: sparse (cells with no valid pixel are dropped); only canonical codes + distribution tracks the histogram. **Seam (all reducers):** dateline h0 `576707042908045311` — fixed builds span ±180°, buggy ones are bloated and miss the dateline.
+   **⛔ h0-partition COVERAGE gate (data-workflows #409).** An indexed 122-completion hex Job that dies/gets-preempted mid-run can leave a *subset* of h0 partitions on S3 and get published as if complete. Two defenses, both required: (a) never treat a hex build as done unless the k8s Job reports `Complete=True` with empty `failedIndexes` — a partial run must surface as `Failed`, so keep `backoffLimitPerIndex` + `maxFailedIndexes` (never `backoffLimit: 0`); and (b) after the job, run the cheap partition-set gate against a reference build from the same COG (e.g. the fractional-coverage layer) or an explicit expected h0 set:
+   ```bash
+   scripts/check-hex-coverage.sh nrp:<bucket>/<dataset>/hex/ \
+       --reference nrp:<bucket>/<dataset>/hex-fractions/   # or --expect-count N / --expect-h0 h0a,h0b,...
+   ```
+   It is a metadata listing (rclone `lsf` sizes of `h0=*`), not a big-data scan — safe on a laptop. **⚠️ Compare POPULATED partitions, not directories.** A `mode` (sparse) reducer writes a partition only where valid pixels exist; a `sum`/coverage reducer writes a *full grid* — a `data_0.parquet` for every h0 it touches, including empty (0-row, ~214 B) partitions for all-nodata h0. So a raw `h0=*` directory count of a full-grid layer is a **superset** of its data extent, and a naive dir-vs-dir comparison across reducers reports **phantom gaps** — exactly what made NLCD mode look like "6 of 11" when its 6 populated h0 were complete and the fractions reference merely had 5 extra empty dirs (the #409/#410 false alarm). The gate therefore filters both sides to partitions whose bytes exceed `--min-bytes` (default 4096; a real partition is MB–GB). Exit non-zero + the missing h0 set means genuinely-missing populated partitions; re-run before publishing/validating values. The gate **also reports any empty partitions it finds under the target** as purge candidates (advisory by default; `--fail-on-empty` makes their presence a hard failure) — purge them (`rclone purge …/h0=<cell>/` then re-verify empty) so they don't pollute `**` globs or fake gaps for the next reader.
+5. **Flip: purge-and-VERIFY-empty, then sync.** `cng-datasets raster` overwrites the partition for each h0 it produces, but does **not** remove partitions for h0s that now yield no data — so reprocessing to a smaller/different domain (e.g. all-land → wetland-only) leaves **stale partitions** behind that corrupt aggregates. And `rclone purge` can silently no-op under S3 load. So purge staging **and confirm it's empty** before any re-hex. `kubectl apply` on a completed Job is a no-op; `delete`+`apply` to rerun. Jobs TTL-GC 3 h after completion — validate before then.

--- a/.claude/skills/stac-authoring/SKILL.md
+++ b/.claude/skills/stac-authoring/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: stac-authoring
+description: >-
+  Author and verify STAC collection metadata for a published dataset: the verify-stac.py gate, the user-facing description register, table:columns placement, SPDX license rules, categorical values arrays, hex per-feature duplication notes, h3:* resolution declarations, and registering a collection in its parent sub-catalog. Use whenever writing or editing a stac-collection.json or a dataset README.
+---
+
+# STAC Authoring
+
+Everything needed for **Step 5 (Document)** and **Step 6 (Register in the parent sub-catalog)**.
+
+Write STAC and README to `/tmp/` and upload with `rclone` — this repo never contains STAC JSON or README files (AGENTS.md Hard Boundary 1).
+
+### ⛔ Verify the STAC — don't hand-check the rules
+
+Every STAC rule below is enforced by **`scripts/verify-stac.py`** (license, nav links,
+asset keys, hex glob, `h3:*` resolutions, `vector:layers`, `table:columns` placement,
+per-feature-dup warnings, categorical completeness + PMTiles fields via the two
+sibling linters, and a **data-backed `values` == ingested `DISTINCT`** check via the
+MCP that automates the #114/#294 lesson). Do not re-verify these by hand or by
+spending agent context on MCP `SELECT DISTINCT` sweeps — run the gate.
+
+```bash
+# 1. PRE-PUBLISH (static, against the /tmp file you just wrote):
+scripts/verify-stac.py --no-data /tmp/stac-collection.json
+#    Fix every HARD finding before rclone copyto. (Data checks need the data live, so
+#    they run post-publish; --no-data skips them here.)
+
+# 2. POST-CLUSTER (full, against the live S3 STAC, once data + STAC are published):
+scripts/verify-stac.py --bucket <bucket> --dataset <dataset>
+#    Must exit 0 (no HARD findings). ADVISORY lines are informational.
+```
+
+CI runs the same verifier on the PR (`.github/workflows/verify-stac.yml`), deriving the
+collection(s) from the `s3://` paths in the changed `catalog/**` YAMLs. **The gate
+evaluates the produced artifact, not the proposal:** the cluster run lands after the PR
+opens, so a RED check at PR-open (STAC not published yet) is correct — don't merge
+before the recipe has actually produced valid output. GitHub status checks don't
+auto-refresh from S3, so **after your cluster jobs finish, re-fire the check** (Actions
+→ Verify STAC → *Run workflow*, or it re-runs on the next push). Merge requires it green.
+
+**README.md MUST include:**
+- A MapLibre GL JS example with the correct `source-layer` (= last segment of `--dataset`), documented prominently
+- A DuckDB example with the full public parquet URL
+
+### ✍️ Descriptions are USER-FACING COPY — agents quote them to end users
+
+Asset, column and collection `description` fields are not internal documentation. The geo-agent
+reads them and **quotes them, nearly verbatim, into answers for end users** — for ca-30x30 that is
+state-agency staff and conservation partners, often non-spatial. Write them as product copy, not as
+notes to the next engineer (data-workflows#512, where issue prose reached a user as
+"joining at res-8 avoids the ~11 pp overstatement that a coarse `GROUP BY` would introduce").
+
+**Say:** what the asset is, what it is for, what resolution it is at, and the one thing a consumer
+must know to use it correctly. Spell things out — "resolution 8", not "res-8".
+
+**Do NOT put in a description:**
+- issue or PR numbers, repo names (`data-workflows#506`) — those belong in the issue and the commit;
+- defect magnitudes or what a previous consumer got wrong ("overstates conserved share by ~11pp");
+- unexplained abbreviations (`pp`), bare column/asset keys as the subject of a sentence;
+- shouted imperatives (`ALREADY A MEAN`, `do NOT re-aggregate`, `NEVER SUM`) — they read as
+  scolding when quoted, and prose imperatives are exactly what leaks into an answer.
+
+**Express a real constraint as a short SQL example instead** — it is clearer than an imperative and
+does not leak as prose:
+
+```sql
+-- correct: combine cells weighted by land area
+SELECT SUM((w1 + w2) * land_area_km2) / SUM(land_area_km2) FROM …
+-- wrong: weighting by a cell COUNT assumes equal-area cells — H3 cells are not equal-area
+-- wrong: taking the largest or any single cell's value overstates the share
+```
+
+> The count-weighted version of that example (`… * nland) / SUM(nland`) was what this file
+> recommended until #522, and it is latitude-biased: over California (32.5N-42N) it returned a
+> 25.684% conserved share against an area-weighted 26.135%. If a rollup asset exposes only a
+> child-cell *count*, ship the child-cell *area* alongside it — the correct query should be the
+> short one, not the one requiring an `h3_cell_area()` call the consumer has to remember.
+
+The mechanical rules elsewhere in this file still apply on top of this: per-column text stays
+**identical across assets** (the mcp-data-server#303 fold), the hex per-feature-duplication note
+still has to be present and still has to match what `verify-stac.py` looks for (phrases like
+"repeated on every … cell"), and the H3 area recipe still must not be inlined (#389). Plain register,
+same guarantees.
+
+**Publishing lags by ~15 minutes.** `mcp-data-server` refreshes its STAC cache on a **~15-minute**
+cycle, so right after `rclone copyto` the agent (and the app) still read the previous text — verified
+during #512, where `verify-stac.py` (which fetches S3 directly) saw the new copy while
+`get_stac_details` returned the old, then agreed after the refresh. So: verify prose against the S3
+URL for correctness, and wait out the cycle before judging what an agent or the app will quote. **No
+cache-invalidation or restart is needed** — do not go reaching into the MCP's namespace for one.
+
+**One text per column NAME per collection.** The `#303` fold is per column *name* across every asset
+in the collection, and **first-seen wins**, so a column documented differently on two assets loses
+one version silently. Two traps, both hit in #512:
+- Adding a new hex-like asset with its own wording for `h10`/`h9`/`h8`/`h0` meant the older asset's
+  text won — and that text said "one row per (feature, h10) pair", which was true there and **false**
+  for the new per-cell assets. Keep shared H3 columns grain-neutral and identical; state grain in the
+  asset `description`, which is always rendered.
+- Appending a hex-only clause to a column that also exists on the flat GeoParquet (e.g. "…repeated on
+  every hex cell — dedup first") makes the two differ, so the clause is dropped. Put that note in the
+  hex asset's `description` instead. After editing, check no column name carries two different texts
+  within the collection — `verify-stac.py` reports this as `column-description-divergent`
+  (ADVISORY today; it becomes HARD once the pre-gate catalog is fold-clean, #509).
+
+**The title and description state the FOOTPRINT, not which tranche you ingested.** A set of
+whole administrative or hydrologic units is **never** a state extent, and a consumer — human or
+model — trusts the title over the geometry. `usgs-nhdplus-hr-flowline` was titled *"(California)"*
+and said *"COVERAGE IS CALIFORNIA ONLY"*, both true about which VPUs had been ingested and both
+read as claims about the footprint, which is 13 whole HU4 units with **30.3% of its stream length
+in Nevada, Utah, Oregon and Arizona**. A model skipped the California mask and its headline number
+was 8.5 points wrong — the same mechanism as the pinyon-juniper defect (#505). So:
+
+- **Title the unit set** — "…(13 California hydrologic units)", not "…(California)". Same for
+  counties, ecoregions, watersheds, and every later tranche of a national build.
+- **State the footprint near the top of the description**: what the units are, that they are not
+  clipped to the region, how much lies outside, and the mask a region-level statistic needs
+  (for California, join `h8` + `h0` against the `ca30x30-ecoregion` hex). Give the mask as a short
+  SQL example, per the register rules above.
+- **Never write "X ONLY" for "only the X tranche is ingested so far"** — say the ingest scope and
+  the footprint as two separate facts.
+- The `bbox` is usually already correct; it is the prose that lies. `verify-stac.py` flags a title
+  naming one US state whose bbox reaches >1° outside it with no footprint sentence
+  (`title-names-state-but-bbox-exceeds-it`, ADVISORY) — the fix is the sentence, not a narrower bbox.
+
+**stac-collection.json MUST include:**
+
+- **License — REQUIRED on every collection.** Set the top-level STAC `license` field to the **SPDX identifier** of the upstream data license (e.g. `CC-BY-4.0`, `CC-BY-NC-4.0`, `CC-BY-SA-4.0`, `CDLA-Permissive-2.0`, `public-domain`). Use `"other"` **only** when no SPDX id applies, and `"various"` **only** for a meta-collection whose children genuinely differ — never as a lazy default. For `other`/`various` (and recommended for all), add a license link: `{"rel": "license", "href": "<canonical terms URL>", "type": "text/html"}`. **Exception — a meta-collection (one with `child` links) may use `various`/`other` WITHOUT a license link:** its real licenses live on the child collections (each carrying + verified for its own license), and redistribution gating (source.coop excludes, etc.) keys on those per-child licenses, not the parent. A single parent-level link would misrepresent genuinely mixed children. `verify-stac.py` enforces the link only on **leaf** collections (and always for `proprietary`). **Verify the real upstream terms — do not guess `proprietary`.** The license drives redistribution decisions (e.g. whether a dataset may be mirrored to source.coop); a wrong value is a compliance risk. NonCommercial / ShareAlike licenses are fine but MUST be recorded as such (`CC-BY-NC-*`, `CC-BY-SA-*`) so downstream users aren't misled. US federal works = `public-domain`.
+
+- **Temporal extent — RFC 3339, or the dataset vanishes from the served catalog.** Every
+  `extent.temporal.interval` endpoint must be a full RFC 3339 date-time with a timezone
+  (`"1920-05-15T00:00:00Z"`), or `null` for a genuinely open start/end. This is not
+  cosmetic: pystac parses these **eagerly** when it loads a collection, so one malformed
+  value makes the entire collection fail to load for every MCP consumer — the dataset
+  simply isn't there, with nothing but a warning in the server log. Seven BLM MLRS
+  mineral collections shipped this way and were invisible for weeks.
+  **When composing the string from a query result, slice the date part explicitly**
+  (`str(v)[:10]`): the MCP `query` tool renders a DuckDB `DATE` as
+  `"1974-03-01T00:00:00.000000"`, so appending `"T00:00:00Z"` to the raw value produces a
+  doubled time component. `verify-stac.py` HARD-fails a non-RFC-3339 endpoint, a missing
+  interval, and a start that is after its end.
+
+- **Navigation links — every collection needs all four:**
+
+  ```json
+  "links": [
+    {"rel": "self",   "href": "https://s3-west.nrp-nautilus.io/<bucket>/<path>/stac-collection.json", "type": "application/json"},
+    {"rel": "root",   "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",        "type": "application/json"},
+    {"rel": "parent", "href": "<URL of the collection that links to this one as a child>",             "type": "application/json"},
+    {"rel": "child",  "href": "<URL of each sub-collection>",                                          "type": "application/json"}
+  ]
+  ```
+
+  Rules:
+  - `self` = the collection's own S3 URL.
+  - `root` = always the NRP root catalog (`public-data/stac/catalog.json`).
+  - `parent` = the collection that holds this one as a `child` link. For top-level bucket collections this is the root catalog. For nested sub-collections (e.g. `public-rivers/american-rivers/dam-removal/`) this is the domain collection (`public-rivers/american-rivers/stac-collection.json`), **not** the root.
+  - `child` = `"rel": "child"` (not `"item"`) for every sub-collection. `"rel": "item"` is for individual STAC Items (features), not Collections.
+  - **Without `self`/`root`/`parent`, geo-agent cannot traverse the tree and the collection won't expand.**
+
+- **Asset keys encode the dataset, not the format.** Never use generic keys (`pmtiles`, `geoparquet`, `h3-parquet`, `parquet`, `hex`) — they collide and break downstream apps. Use `{last-segment}-{format}`:
+
+  | Asset | Pattern | Example (`--dataset census-2025/sldl`) |
+  |---|---|---|
+  | GeoParquet | `{name}-parquet` | `sldl-parquet` |
+  | PMTiles | `{name}-pmtiles` | `sldl-pmtiles` |
+  | H3 hex | `{name}-hex` | `sldl-hex` |
+  | COG | `{name}-cog` | `sldl-cog` |
+
+  Multi-layer collections: prefix with collection context (`cpad-holdings-parquet`, `cpad-units-hex`).
+
+- **Hex asset `href` MUST use the Hive-partitioned glob — never a bare directory:**
+  - ❌ `.../census-2025/sldl/hex/`
+  - ✅ `.../census-2025/sldl/hex/h0=*/data_0.parquet`
+
+- **Any vector asset with named layers** (PMTiles, GDB, GPKG, etc.) MUST include `"vector:layers": ["<name>"]`. For PMTiles the layer name = last segment of `--dataset`.
+
+- **`table:columns` goes on each parquet asset — NOT at the collection level.** Put it inside the asset object for the GeoParquet and hex assets. Do not add a top-level `table:columns` to the collection. `verify-stac.py` HARD-fails a collection-level `table:columns`.
+
+  **Every queryable parquet asset is fully self-describing** — it carries the full per-column schema (name, type, description, `values`), the SAME text on the flat GeoParquet and the hex. This is deliberate: the mcp-data-server renderer dedups identical per-column descriptions across assets at read time (mcp-data-server#303), so full-both costs nothing to the LLM; and a consumer targeting a single asset directly still gets the full schema. That last point is not optional — **raster-derived datasets have a hex but no GeoParquet**, so the hex must stand alone. The single authority is the **build/relocation tool** (one source schema written identically to every asset), never a hand-edit of one asset — identical text means the #303 "first-seen wins" merge never drops anything.
+
+  Each parquet asset documents exactly the columns it contains:
+  - **GeoParquet asset** (vector, when present): include the geometry column (`Shape`, `geom`, or `geometry`).
+  - **Hex asset**: full per-column descriptions identical to the flat (minus the geometry column); include the H3 index columns (`h0`, `h8`, `h9`, `h10` etc.) and `_cng_fid`/`bbox`. The hex is the primary query target (and the sole one for rasters), so it is never "lean."
+  - **COG assets**: no `table:columns` needed (not SQL-queryable).
+
+- **`_cng_fid` is the universal per-feature id — REQUIRED on every vector asset, flat GeoParquet *and* hex (#369).** cng-datasets `convert_to_parquet` synthesizes it on every conversion (always, additive, row-unique), so one uniform key works for dedup / `COUNT(DISTINCT)` across all datasets instead of per-dataset id discovery (the over-count class behind #309). Source ids (`ramsarid`, `tpl_id`, `GEOID`) may accompany it for cross-collection joins but never replace it. `verify-stac.py` **HARD**-fails a vector flat GeoParquet (has a geometry column) or a vector hex that lacks `_cng_fid`; if the data genuinely lacks it, reprocess through cng-datasets. **Exempt:** raster-derived hex (a raster reduce into H3, not a feature conversion — detected as a hex/`h0=*`-partitioned asset in a collection with no vector source; covers carbon/ghs-pop *and* the richness/cwhr/gbif reductions). A **non-spatial** parquet table (no geometry, not a hex) is **ADVISORY** — it may be a feature fact table that should carry `_cng_fid` (e.g. tpl `…-funding`) or a legit lookup/crosswalk/coefficient/scores table; use judgment.
+
+- **PMTiles assets MUST carry tile-accurate `table:columns` (data-workflows #283/#320), in LEAN form.** The geo-agent (and human app authors) can only learn which fields are stylable/filterable in MapLibre from the PMTiles asset's own schema — an empty `table:columns` forces them to byte-range the `.pmtiles` footer. **Empirically, our tippecanoe step keeps ALL attribute columns: the tile field set is just `GeoParquet attrs − geometry + _cng_fid`** (types coarsened to String/Number/Boolean). So the standard is to **mirror the canonical GeoParquet schema onto the PMTiles asset** — do NOT hand-scrape thin metadata from the footer, and do NOT duplicate the prose:
+  - **Lean columns:** each PMTiles column carries **`name` + `type` + `values`** (the `values` enumeration is the styling-critical part for categoricals) — copied from the GeoParquet column of the same name. **Omit the prose `description`** — it stays CANONICAL on the GeoParquet asset (duplicating it across 3 assets just bloats agent context; the agent reads definitions there).
+  - Drop the geometry column; include `_cng_fid` (present in tiles).
+  - Keep `vector:layers` (the source-layer id list).
+  - **Continuous (choropleth) layers only:** add the **nodata sentinel** and flag the **intended value column** for styling, as a short `description` on that one column (e.g. SVI `RPL_THEMES = -999`) — these are viz-specific and not inferable from the GeoParquet schema.
+  - **Generate it** with `scripts/mirror-pmtiles-columns.py <stac-url>` — it reads the footer to *validate* the field set (and flags the rare genuine-subset case, e.g. SVI, where tippecanoe really did drop columns), mirrors the GeoParquet `name`/`type`/`values`, and writes the updated STAC to `/tmp`. Then `rclone copyto` to S3.
+  - Because PMTiles mirrors the GeoParquet, **fix the GeoParquet/hex categoricals FIRST** (the #303 work), then mirror — otherwise you copy incomplete `values`.
+  - Gate with `scripts/lint-stac-pmtiles-fields.py <stac-collection.json|url>` (companion to `lint-stac-categorical.py`); it requires `name` + `type` and does NOT require descriptions.
+
+- **Hex assets MUST declare their H3 resolutions explicitly** via `h3:native_resolution` and `h3:parent_resolutions` on the asset itself. Column-name presence (`h10`, `h9`, …) is not enough — downstream tools shouldn't have to enumerate `table:columns` to find out what resolutions exist. `h3:native_resolution` is the finest resolution (one row per feature-cell at this res); `h3:parent_resolutions` is the list of rollup resolutions, which MUST include `0` (the partition key).
+
+- **Vector (GeoParquet/PMTiles) assets MUST flag per-feature ROW duplication — and you MUST first decide whether it is *true* duplication or *real* multi-row data.** A source file often stores one logical feature as several rows sharing a feature id (a Ramsar site split into polygon parcels; a ballot measure spanning multiple counties). Two opposite causes demand opposite rules, and confusing them silently corrupts answers (data-workflows #309):
+  - **REPEATED** — the per-feature value is *copied* onto every row (e.g. a measure's total funds repeated on each county row). A raw `SUM` double-counts → **dedup by the key first** (`SELECT DISTINCT key, col …` or `GROUP BY key`), and `COUNT(DISTINCT key)` is the feature count.
+  - **VARIES** — genuinely distinct per-row records that share a key (e.g. one conservation site funded by several *sponsors*, each a *different amount*). Here `SUM` is **correct** and dedup would **undercount** by dropping real rows. A repeated polygon + repeated attributes is NOT proof of duplication — a sponsor split looks identical except the varying amount.
+
+  **Two duplication axes — and `_cng_fid` only fixes one of them.** cng-datasets always assigns `_cng_fid` as a synthetic id that is *one per input row* (never derived from a source id). So:
+  - **Axis 1 — feature → H3 cell** (hexing makes one polygon span many cells). Dedup key = `_cng_fid` (or `h<N>`). `COUNT(DISTINCT _cng_fid)` collapses the cell expansion. This is the standard hex guidance below.
+  - **Axis 2 — upstream source rows** (the *input file* already holds several rows per logical entity). Dedup key = an **upstream domain id** (`ramsarid`, `landvote_id`, WDPA `SITE_ID`). `_cng_fid` is unique per row, so it does NOT collapse this — `COUNT(DISTINCT _cng_fid)` still counts rows/polygons, not entities.
+
+  For most datasets each input row *is* one logical feature, so the two keys coincide and only axis 1 exists — that is why the standard guidance leans on `_cng_fid`. Axis 2 only appears in files with upstream duplication (ramsar, landvote); there the domain id is the dedup key, and **the hex asset must also carry that domain id** or it cannot be deduped to entities (e.g. landvote's hex carries only `_cng_fid`, so it can't be reduced to distinct measures — a gap). Auditing on a per-row id always reports "clean", masking axis 2.
+
+  **The decisive test is data-backed: does the value VARY within the key?** Do NOT guess the key from a column name — a 34%-blank source id (PAD-US `Source_PAID`) or a class label that covers thousands of parcels (Landmark `name`) fakes duplication, and a per-row id (`_cng_fid`) hides it. Run the auditor with the *upstream domain id* as `--key` (it uses the duckdb-geo MCP, not local duckdb):
+  ```bash
+  scripts/audit-feature-dup.py <parquet-url|stac-url --asset KEY> --key <feature-id-col>
+  ```
+  It reports rows vs `COUNT(DISTINCT key)`, warns on blank keys, classifies each column REPEATED vs VARIES, and quantifies raw-vs-deduped `SUM` inflation. Then document the verdict in the asset's `table:columns`: name the key, mark REPEATED columns "dedup before SUM", and (if any) note VARIES columns are safe to SUM. A clean one-row-per-feature file needs no note.
+
+- **Hex assets MUST flag per-feature duplication — at the hex ASSET-description level, NOT per-column.** One hex row = one (feature, cell) pair, so any column that represents a per-feature total — area (`GIS_Acres`, `SHAPE_Area`), length (`SHAPE_Length`), population, count, amount, funding, intensity — is repeated on every cell the feature covers. Put this warning (name the pattern + the **dedup key**, list the affected columns) in the **hex asset's `description`**, because the mcp-data-server#303 renderer keeps per-column descriptions identical across the flat and hex (single authority) and would silently drop a per-column note that differs between them — whereas the per-asset `description` line is always rendered. `verify-stac.py` accepts the note at the asset (or collection) level. (Raster hex: the asset note states reducer semantics instead — e.g. "`sum` reducer, SUM is the catalog total" or "mean density → × cell area for totals".) The two safe patterns:
+  - **SUM after dedup** (the attribute is a real per-feature value): `SELECT DISTINCT <feature_key>, <attr> …` or `ROW_NUMBER() OVER (PARTITION BY <feature_key>)` before aggregating.
+  - **Area/extent from the H3 footprint** (when there is no trustworthy source value): the generic recipe — `SUM(h3_cell_area(h<N>, 'km^2'))` over DISTINCT cells, exact per cell, **never** a nominal per-resolution constant — lives in `mcp-data-server/h3-guide.md`. **Do NOT inline that formula into the column description** — it is generic guidance the geo-agent already reads from the h3-guide, and a copy baked into STAC goes stale and becomes actively harmful (a nominal-constant copy undercounted the ca-30x30 California extent ~6%, mcp-data-server#294 / #389). Just flag the column as a per-feature total not to be SUMmed on hex; the agent derives area from the h3-guide.
+
+  Columns that are safe to aggregate on hex (H3 indexes, `_cng_fid`, `bbox`) don't need a warning. If no column on the hex asset is safe to SUM, say so once in the collection description too.
+
+  ```json
+  "assets": {
+    "sldl-parquet": {
+      "href": "https://…/sldl.parquet",
+      "type": "application/x-parquet",
+      "title": "…",
+      "table:columns": [
+        {"name": "GEOID", "type": "string", "description": "…"},
+        {"name": "ALAND", "type": "int64", "description": "Land area in m² of the source district polygon."},
+        {"name": "geometry", "type": "geometry", "description": "Feature geometry (GeoParquet)"}
+      ]
+    },
+    "sldl-hex": {
+      "href": "https://…/sldl/hex/h0=*/data_0.parquet",
+      "type": "application/x-parquet",
+      "title": "…",
+      "h3:native_resolution": 10,
+      "h3:parent_resolutions": [9, 8, 0],
+      "table:columns": [
+        {"name": "GEOID", "type": "string", "description": "…"},
+        {"name": "ALAND", "type": "int64",
+         "description": "Land area in m² of the source district polygon. **Repeated on every hex row the district covers — never SUM(ALAND) on hex data; dedup first (SELECT DISTINCT GEOID, ALAND).** For area from the H3 footprint see the h3-guide."},
+        {"name": "h10", "type": "uint64", "description": "H3 cell ID at resolution 10 (native resolution; one row per (feature, h10) pair)."},
+        {"name": "h9",  "type": "uint64", "description": "H3 cell ID at resolution 9."},
+        {"name": "h8",  "type": "uint64", "description": "H3 cell ID at resolution 8."},
+        {"name": "h0",  "type": "int64",  "description": "H3 cell ID at resolution 0, used as the partition key for hive-partitioned reads."}
+      ]
+    }
+  }
+  ```
+
+  For **coded categorical** columns, the description MUST list all valid values in `CODE=Definition, …` format and include a `"values"` array. Discover actual values via DuckDB before writing:
+  ```sql
+  SELECT column_name, COUNT(*) AS n FROM read_parquet('s3://…') GROUP BY column_name ORDER BY n DESC
+  ```
+  Example:
+  ```json
+  {"name": "owner_type", "type": "string",
+   "description": "Owner type code. Values: FED=Federal, STAT=State, LOC=Local, NGO=Non-governmental/non-profit, TRIB=Tribal/Indigenous, PVT=Private, UNK=Unknown",
+   "values": ["FED", "STAT", "LOC", "NGO", "TRIB", "PVT", "UNK"]}
+  ```
+  Missing definitions cause LLM agents to guess values (e.g. `WHERE owner_type = 'Federal'` instead of `'FED'`) and return empty results.
+
+- **Categorical rasters (COG assets with discrete pixel-value classes):** the COG asset's `raster:bands[0]` MUST include `classification:classes` (STAC classification extension v2.0.0). Each entry: `{ value, name, description, color_hint }` where `color_hint` is a 6-character RGB hex (no leading `#`). Add `https://stac-extensions.github.io/classification/v2.0.0/schema.json` to `stac_extensions`. Do **not** use the legacy `class_values` field from the raster extension — geo-agent reads `classification:classes` and `color_hint` to build both the discrete legend swatches and the titiler categorical colormap; without those colors the layer falls back to a continuous gradient. Use the dataset's standard published palette where one exists (NLCD MRLC colors, etc.); otherwise pick distinguishable accessible colors and note the choice in the asset description.
+  ```json
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/classification/v2.0.0/schema.json"
+  ],
+  "assets": {
+    "nlcd-cog": {
+      "raster:bands": [{
+        "name": "land_cover_class", "data_type": "uint8", "nodata": 0,
+        "classification:classes": [
+          {"value": 11, "name": "Open Water", "description": "…", "color_hint": "466B9F"},
+          {"value": 41, "name": "Deciduous Forest", "description": "…", "color_hint": "68AB5F"}
+        ]
+      }]
+    }
+  }
+  ```
+
+- **Per-feature row duplication / NULL finest-parent cells / no-data sentinels (data-workflows #309, gated by #311).** Three aggregation traps the geo-agent accuracy sweep surfaced — document each on the relevant asset:
+  - **Repeated features (polygon/point assets).** Handled by the REPEATED-vs-VARIES per-feature row-duplication rule above — run `scripts/audit-feature-dup.py` to get the verdict and document it. `verify-stac.py`'s `polygon-row-dup-candidate` **ADVISORY** is just the automatic CI tripwire that flags a `rows ≫ COUNT(DISTINCT id)` candidate; treat it as a prompt to run that auditor, not a defect on its own (the signal over-flags — the column may be a label or provenance key, not the feature id).
+  - **NULL finest-parent cells.** If the hex build caps very large features at a coarser native resolution (WDPA: `h9` is NULL for the 1,297 biggest features, `h8` is complete), the hex asset description MUST name the complete column and say joins should use the coarsest shared resolution (or `h3_cell_to_parent()`), not the finest. `verify-stac.py` **HARD**-flags an undocumented NULL finest hex column.
+  - **No-data sentinels.** Document sentinel/fill codes (e.g. land-cover `0`/`200`) so consumers `WHERE col NOT IN (...)` before `SUM`/`AVG` — an undocumented sentinel poisons aggregates to `NaN`.
+
+  ⛔ **MEASURE every added column's range and sentinels — never document one from upstream docs or
+  memory.** When a build introduces columns new to this catalog, run one query per new column
+  (`MIN`/`MAX`, `COUNT(*) FILTER (WHERE col < 0)`, distinct count) *before* writing STAC. This is
+  the #518 lesson generalised, and it recurred three times in one session while fixing #518
+  (data-workflows #205/#525):
+  - `-9999` on four NHDPlus VAA columns (and `-9` on a fifth) — **the same 2,745 rows** — was
+    documented nowhere in the first draft; an unfiltered `AVG(slope)`/`MIN(totdasqkm)` is poisoned.
+  - Worse than omission: a sentinel note copied from upstream documentation said "check for
+    negative values", which would have told consumers to discard **real** below-sea-level
+    elevations (10,349 rows, min −85.61 m in Death Valley). **A negative value is not automatically
+    a sentinel** — filter the exact sentinel (`<> -9998`), never a sign test, unless you have
+    measured that no legitimate negatives exist.
+  - A `values` array copied from a sibling collection missed 13 codes actually present. Coded
+    domains come from the authoritative source table (#294), and `values` from the ingest.
+  Record the measured ranges in the dataset's `BUILD.md` so the next reader inherits evidence
+  rather than assumption — see `catalog/usgs-nhd/k8s/nhdplus-hr/BUILD.md` for the pattern.
+
+- **Point datasets:** `description` or `"processing:notes"` MUST state each point resolved to one H3 cell at the processing resolution, and name the resolution. Example: *"Point observations were hexed to H3 resolution 10 (each point → one ~15 000 m² cell). Multiple points within the same cell are not deduplicated."*
+
+## Step 6: Register in the parent sub-catalog
+
+**The STAC catalog is a TREE.** Datasets belong in their domain/bucket sub-catalog, not the root. Root `public-data/stac/catalog.json` only links top-level sub-catalogs (e.g. `public-high-seas`, `public-padus`, `public-census`).
+
+Before linking:
+1. Check for existing sub-catalog: `curl -s https://s3-west.nrp-nautilus.io/<bucket>/stac-collection.json | jq '.links[] | select(.rel=="child")'`
+2. Exists → add child link there.
+3. Brand-new bucket/domain → create bucket-level `stac-collection.json`, register children in it, then link that bucket-level collection from root.
+
+```bash
+curl -s https://s3-west.nrp-nautilus.io/<bucket>/stac-collection.json > /tmp/parent.json
+# Edit /tmp/parent.json to append {"rel": "child", "id": "...", "href": "...", "title": "..."}
+rclone copyto /tmp/parent.json nrp:<bucket>/stac-collection.json
+```
+
+Only touch the root when adding a **new** top-level sub-catalog.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ Thumbs.db
 .claude/*
 !.claude/settings.json
 !.claude/hooks/
+# skills are shared instructions - they MUST ship with the repo (#569)
+!.claude/skills/
 # git worktrees (relocated out of .claude/)
 .worktrees/
 # Private-dataset STAC/README must never land on public GitHub (canonical copy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,22 @@
 # Agent Instructions: Dataset Processing
 
-You work in `data-workflows`, which uses `cng-datasets` to convert geospatial data into cloud-native formats on Kubernetes. This file tells you everything you need.
+You work in `data-workflows`, which uses `cng-datasets` to convert geospatial data into cloud-native formats on Kubernetes. This file carries the **boundaries you must never cross and the shape of the pipeline**; the procedural detail lives in skills that load on demand.
+
+## Skills — load the one that matches what you are doing
+
+These are `.claude/skills/<name>/SKILL.md` in this repo. They work in Claude Code and opencode
+alike (both read `.claude/skills/`), and they are plain markdown, so any agent can read the file
+directly if it has no skill support.
+
+| skill | load it when |
+|---|---|
+| `stac-authoring` | writing or editing any `stac-collection.json` or dataset README (Steps 5–6) |
+| `raster-hexing` | ingesting or re-hexing a GeoTIFF/COG — resolution, reducer, mosaicking |
+| `hex-tuning` | a hex job OOMs, or choosing native/parent H3 resolutions and chunk sizes |
+| `job-troubleshooting` | a job fails, hangs, or a published parquet will not read |
+| `dataset-recipes` | starting an ingest that resembles a worked example |
+
+Everything below is always in force, skill or no skill.
 
 ## ⛔ HARD BOUNDARY: Scoping decisions live in the GitHub issue, NEVER in memory
 
@@ -21,48 +37,18 @@ For ANY query/scan/aggregation over S3 parquet — catalog data **and** large in
 - The tool is deferred: `ToolSearch select:mcp__duckdb-geo__query` first. **If ToolSearch returns no match the MCP server is disconnected — ask the user to reconnect it; do NOT fall back to the slow RAM-bound path.**
 - Heavy *writes/transforms* the MCP can't do still run as cluster jobs, but over the **internal** endpoint (`rook-ceph-rgw-nautiluss3.rook`, `AWS_HTTPS=false`), never the laptop.
 
-## ⛔ Serialization standard: DuckDB httpfs `stoi` crash on oversized column chunks
+### ⛔ Serialization standard: keep parquet row groups small
 
-The MCP can abort with **`SQL Error: stoi`** when reading GeoParquet over S3/httpfs. The root cause is a **DuckDB httpfs bug on large Parquet column chunks** — not the CRS tag, writer, or geometry content. Fully diagnosed in datasets [#106](https://github.com/boettiger-lab/datasets/issues/106).
+A single parquet column chunk in the **~2.8–2.88 GB compressed** range makes DuckDB's httpfs
+reader abort with **`SQL Error: stoi`** — a reader bug on the `https://` path, not corrupt data
+(fully diagnosed in datasets [#106](https://github.com/boettiger-lab/datasets/issues/106)).
 
-### What triggers it
+**Prevention is the fix: use `--row-group-size 2000` as the default for geometry-heavy
+datasets**, so no geometry column chunk approaches ~1 GB compressed. The default 100000 can pack
+a single chunk past the cliff on national-scale multipolygons.
 
-A single Parquet column chunk in the **~2.8–2.88 GB compressed / ~3.73–3.84 GB uncompressed** range causes the httpfs reader to abort with `stoi`. No spatial function needed — `SELECT COUNT(geom)` (which decodes the column) is sufficient to crash; `SELECT COUNT(*)` (footer only, no decode) is fine. **Local file reads always work** — this is exclusively an httpfs path bug.
-
-```sql
-SELECT COUNT(*)  FROM read_parquet('https://…/repro-100000.parquet');   -- ✅ OK
-SELECT COUNT(geom) FROM read_parquet('https://…/repro-100000.parquet'); -- ❌ stoi
-```
-
-The crash appears "plan-dependent" because queries that skip decoding the geometry column (e.g. filtered reads that never touch the oversized chunk) avoid it. Every individual row is valid; the data is not corrupt.
-
-### What does NOT matter
-
-| Hypothesis | Verdict |
-|---|---|
-| `creator: geopandas` | ❌ cng-convert-written file crashes identically |
-| `OGC:CRS84` vs `EPSG:4326` CRS tag | ❌ re-tagging as `EPSG:4326` still crashes |
-| Plain DuckDB `COPY` re-write | ❌ still crashes |
-| A single pathological geometry | ❌ local read of same file returns all rows |
-
-### Prevention (the real fix)
-
-**Keep row groups small enough that no single geometry column chunk exceeds ~1 GB compressed.** For large-feature geometry (complex multipolygons, national-scale data), the default `--row-group-size 100000` can pack a single chunk well past the 2.8 GB cliff. Use `--row-group-size 2000` as a safe default for geometry-heavy datasets, or estimate `avg(octet_length(ST_AsWKB(geom)))` on a sample and size accordingly. Tracked in cng-datasets [#106](https://github.com/boettiger-lab/datasets/issues/106).
-
-### Mitigation if a published file already crashes
-
-Use `s3://` (internal endpoint, not `https://`) inside cluster jobs — the httpfs path is the public endpoint only. For MCP queries (which always go over https), re-publish the file with smaller row groups via a cluster DuckDB job:
-
-```sql
-COPY (SELECT * FROM read_parquet('s3://bucket/file.parquet'))
-TO 's3://bucket/file-rg2000.parquet'
-(FORMAT PARQUET, ROW_GROUP_SIZE 2000, COMPRESSION ZSTD);
-```
-
-### geopandas-written files
-
-Still avoid publishing geopandas-written GeoParquet — use the cng-datasets DuckDB-native path. But the failure mode is different (geoarrow extension type, any DuckDB version; upstream [duckdb/duckdb#21691](https://github.com/duckdb/duckdb/issues/21691)) and orthogonal to the httpfs chunk-size crash above.
-
+Full diagnosis, what does *not* matter (CRS tag, writer, one bad geometry), and how to rescue an
+already-published file: **skill `job-troubleshooting`**.
 ## ⛔ HARD BOUNDARY 1: NRP S3 is Canonical for STAC and Data
 
 Canonical STAC/data live on NRP S3 (`s3://public-<bucket>/`, public URL `https://s3-west.nrp-nautilus.io/<bucket>/...`). **This repo does NOT contain STAC JSON or README files.** Never create `catalog/*/stac/`, never `git add` STAC JSON or README.
@@ -238,31 +224,9 @@ ogrinfo /vsicurl/<source-url>                                # multi-layer file
 
 Common patterns: Census TIGER = per-state (`tl_2024_{STATEFP}_tract.zip`); protected areas = per-region or national; rasters may be tiled.
 
-#### 💡 Read one small table out of a HUGE remote zip — range reads, no localize (#518)
-
-To inspect a schema, a lookup/domain table, or one layer's coverage inside a multi-GB zipped
-GDB, do **not** localize the archive (a PVC + 30 GB download for a 126-row table). GDAL's
-`/vsizip//vsicurl/` reads the zip central directory plus only the bytes it needs over HTTP
-range requests — a small cluster job, seconds to a couple of minutes:
-
-```bash
-# authoritative coded domain out of the archived 30 GB national GDB (internal endpoint)
-SRC="/vsizip//vsicurl/http://rook-ceph-rgw-nautiluss3.rook/public-usgs-nhd/raw/NHD_H_National_GDB.zip/NHD_H_National_GDB.gdb"
-ogr2ogr -f CSV /vsistdout/ "$SRC" NHDFCode          # 126 rows, ~25 s, no PVC
-ogrinfo -ro -q "$SRC" -dialect SQLITE \
-  -sql "SELECT COUNT(*), SUM(StreamOrde > 0) FROM NHDPlusFlowlineVAA"
-```
-
-- Works on a **public** source URL too (`/vsizip//vsicurl/https://prd-tnm.s3.amazonaws.com/...`) —
-  ideal for pre-flighting a candidate import before committing to a build.
-- Use `-dialect SQLITE`: **OGR SQL has no `CASE`**, and keep the SQL on **one line** (a folded
-  YAML block mangles multi-line SQL). `SUM(cond)` works in the SQLITE dialect.
-- Full-table `COUNT(*)` over range reads is slow (minutes) because it decodes every feature;
-  schema reads and small tables are fast. Aggregate on the small table, not the geometry layer.
-- Working manifests: `catalog/usgs-nhd/k8s/extract-fcode-domain.yaml`,
-  `catalog/usgs-nhd/k8s/preflight-nhdplus-hr-vaa.yaml`.
-- ⛔ Never hand-write a coded domain from memory (#294) — this is how you get the real one.
-
+> 💡 To read a schema, a lookup table, or one layer's coverage out of a multi-GB remote zip,
+> use GDAL range reads (`/vsizip//vsicurl/…`) instead of localizing the archive — a small job,
+> seconds to minutes, no PVC. Worked examples: **skill `dataset-recipes`**.
 ### Step 1b: Copy raw to `s3://<bucket>/raw/` FIRST
 
 External downloads are slow/rate-limited; restart from S3 if conversion fails. Subsequent jobs read `s3://<bucket>/raw/<file>` (or `/vsicurl/https://s3-west.nrp-nautilus.io/<bucket>/raw/<file>` for GDAL).
@@ -283,14 +247,9 @@ command: [bash, -c, |
 
 ### Step 1c: Preprocessing multi-file zipped datasets
 
-**`cng-convert-to-parquet` rejects multiple .zip URLs.** For per-state/per-region zips, preprocess: download in parallel, unzip, pass shapefiles (the tool merges them automatically):
-```bash
-for id in 01 02 03; do curl -sS -O "https://example.com/data_${id}.zip" & done
-wait && unzip -q -o "*.zip"
-cng-convert-to-parquet /tmp/data/*.shp s3://bucket/output.parquet
-```
-See `catalog/census/k8s/tract/preprocess-tract.yaml` for a complete k8s job.
-
+**`cng-convert-to-parquet` rejects multiple `.zip` URLs.** For per-state/per-region zips, run a
+preprocess job that downloads in parallel, unzips, and passes the shapefiles (the tool merges
+them automatically). Worked k8s job: **skill `dataset-recipes`**.
 ### Step 2: Generate the pipeline
 
 #### Vector
@@ -330,6 +289,7 @@ save_armada_yaml(armada_spec, 'armada-<name>-hex.yaml')
 ```
 
 #### Raster
+
 ```bash
 cng-datasets raster-workflow \
   --dataset <name> --source-url <cog-url> --bucket <bucket> \
@@ -338,74 +298,21 @@ cng-datasets raster-workflow \
   --output-dir catalog/<dataset>/k8s/<name>
 ```
 
-Differences from vector:
-- Command: `raster-workflow`
-- Completions always 122 (one per h0 cell) — not configurable
-- Defaults: `--h3-resolution` 8, `--parent-resolutions "0"`, `--hex-memory 32Gi`, `--max-parallelism 61`
-- `--value-column` — raster band name in output (default `value`)
-- `--nodata` — value to exclude (auto from metadata)
-- `--hex-resampling` — **how pixels aggregate into each cell (`sum`/`mean`/`mode`/`max`/`min`, default `mean`). Picking the wrong one silently corrupts the data — see "Choosing the aggregation reducer" below. As important as `--value-column`.**
-- Always creates a WGS84 COG on NRP S3 first; hex reads from that COG
+Rasters produce **COG + hex only** (no GeoParquet/PMTiles); a WGS84 COG is always created on NRP
+S3 first and the hex reads from that COG. Completions are always **122** (one per h0 cell) — not
+configurable.
 
-**Multi-tile rasters** (e.g. multiple UTM zones): repeat `--source-url`. Adds `preprocess-cog` step that mosaics into one WGS84 COG:
-```bash
-cng-datasets raster-workflow --dataset wyoming/rap-arte \
-  --source-url s3://.../rap_arte_zone12.tif \
-  --source-url s3://.../rap_arte_zone13.tif \
-  --bucket public-wyoming \
-  --target-extent "-111.1,40.9,-104.0,45.0" --band 1 --value-column arte \
-  --output-dir catalog/wyoming/k8s/rap-arte
-```
-Extra options: `--target-extent "xmin,ymin,xmax,ymax"` (EPSG:4326 clip), `--target-resolution <degrees>`, `--band <n>` (1-indexed), `--output-cog-name <key>`.
+⛔ **Two choices here silently corrupt the data if you get them wrong, and both are measurements,
+not preferences:**
 
-#### ⚠️ Mosaicking a MANY-tile source (thousands of 1° tiles) into one global COG — two traps
+- **`--h3-resolution` — match the source pixel.** Finer than the source adds no information at
+  ~7× cost per step. Never rely on auto-detection.
+- **`--hex-resampling` — the reducer** (`sum` / `mean` / `mode` / `max` / `min`, default `mean`).
+  Summing a *density* is the recurring error: the reducer follows the source **units**, not the
+  conceptual quantity.
 
-For a source shipped as thousands of small tiles (Copernicus GLO-30/90 DEM = 26,475 tiles; many
-global rasters), repeating `--source-url` is unusable and the naïve single-job mosaic fails two ways.
-Both were hit and fixed on the DEM import (data-workflows #426; manifests at
-`catalog/dem/k8s/copernicus-glo90/` are the working pattern):
-
-1. **rook-cephfs metadata latency kills the file-opens, NOT bandwidth.** Localizing 26k tiles to the
-   `rechunk-scratch` **cephfs** PVC and running `gdalbuildvrt` over them crawled — each file open pays
-   a network-metadata RTT (~150 ms), so 26k opens = 60+ min *each* for the localize and the VRT build,
-   at idle CPU. Local NVMe opens the same files in <1 s. **Fix: localize to LOCAL ephemeral (`/tmp`),
-   not the PVC.** 66 GB > the 50Gi ephemeral cap, so split into N balanced **contiguous longitude
-   bands** (integer-degree cuts → tile-aligned, seamless), one indexed pod per band on local NVMe →
-   regional COGs, then a tiny merge job stitches the few regional COGs into the global COG (a handful
-   of large-file opens is fine on cephfs). ~35 min total vs "never finished." Reserve the cephfs PVC
-   for the *merge* (few big files), never the many-small-file localize.
-2. **`gdalbuildvrt` default `-resolution average` silently downsamples.** Tiles whose pixel size in
-   *degrees* varies (Copernicus DEM narrows column counts toward the poles to hold ~90 m ground
-   spacing) get averaged to a bogus middle X-resolution — the equator was squished ~2.5× (Everest read
-   8146 m instead of ~8700). **Always pass `-resolution highest`** (→ the uniform finest grid) for a
-   lat/lon global mosaic. Sanity-check a known peak's pixel value against the raw source tile.
-
-Also: `gdalinfo -stats` writes a `.tif.aux.xml` sidecar and **reads cached stats from it on a rerun** —
-if you rebuild the COG in the same scratch dir, a stale `.aux.xml` reports the OLD min/max/mean. `rm`
-the `.aux.xml` too, or verify values with a fresh `gdallocationinfo`/`ComputeStatistics`, not the sidecar.
-
-#### ⚠️ Choosing the aggregation reducer (`--hex-resampling`)
-
-`--hex-resampling` controls how source pixels collapse into each H3 cell. **The right reducer depends entirely on what the pixel value *means*, and the wrong one silently produces nonsense** (summing land-cover class codes, averaging species counts). Decide this per dataset, every time. Supported: `sum`, `mean`, `mode`, `max`, `min` (default `mean`).
-
-| Pixel value is… | Reducer | Examples |
-|---|---|---|
-| **Amount already integrated *per pixel*** — each pixel holds the whole-pixel total | `sum` | population *per pixel* (GHS-POP persons/cell), fishing-effort hours per cell, counts |
-| **Density / intensity / rate / fraction** — a *per-area* or normalized quantity | `mean` | carbon **density** (Mg C **ha⁻¹** — Noon irrecoverable/vulnerable/manageable carbon), NDVI, % cover (RAP), depth (GEBCO), indices (NCP) |
-| **Categorical** — discrete class codes | `mode` | land cover (CGLS-LC100, NLCD), wetland class (GLWD) |
-
-**⛔ The density-vs-amount trap (the #1 way `sum` goes wrong) — check the source UNITS before choosing the reducer.** `sum` is correct *only* when each pixel value is an amount **already integrated over the pixel** (GHS-POP stores persons *per pixel*, so `sum` recovers the population total). If the value is a **density** — a per-area quantity like Mg C **ha⁻¹**, t km⁻², persons km⁻² — then `sum` produces a meaningless *sum of densities*, off from the true total by roughly the pixel area (carbon was ~7× low; data-workflows #171/#202). **A stock can be a density:** "carbon stock" is conceptually extensive, but the Noon et al. carbon rasters store Mg C **per hectare**, so they need area-integration, *not* `sum`. The reducer follows the **units**, not the conceptual quantity — read the source READMEs / band metadata / paper to confirm whether a value is per-pixel or per-area.
-
-To get a **total from a density raster**: use `mean` (area-weighted mean density per cell), then multiply by the H3 cell ground area downstream — `total = mean_density × cell_area` (h3 `cell_area`; cells are ~equal-area per resolution). There is no one-step density→total reducer yet ([`boettiger-lab/datasets#105`](https://github.com/boettiger-lab/datasets/issues/105)). For an existing density-`sum` build, the equivalent correction is `value × pixel_area_ha` per cell (pixel area is latitude-dependent on a WGS84 grid, ≈ `9·cos(lat)` ha for a ~300 m grid).
-
-**Correctness check:** for an amount-per-pixel `sum`, the catalog-wide `SUM(value)` over the hex parquet MUST equal the source COG's pixel sum within sub-pixel rounding (compute the COG sum with a GDAL block-sum job; query the hex sum via the MCP). **For a density layer, the COG pixel-sum is itself *not* a total — validate the area-corrected `SUM` against the published global total instead** (e.g. irrecoverable carbon 2018 ≈ 137 Gt vs Noon et al. 139.1 Gt). `mean`/`mode` have no global invariant — spot-check the hex against the COG over a known region.
-
-**Species richness / "peak" quantities** (MOBI, IUCN richness): the correct reducer is `max` — **not** `sum` (double-counts species) and **not** `mean` (averages away hotspots). `max` (and `min`) are supported as of [`boettiger-lab/datasets#95`](https://github.com/boettiger-lab/datasets/issues/95) (closed 2026-06-01); MOBI and IUCN-richness were rebuilt with `max` at res 8/5 (data-workflows #194). Validate: hex `MAX(value)` == COG max, and every cell value within `[COG min, COG max]` (roll up to coarser resolutions with `GROUP BY h<parent> + MAX`, never `AVG`/`SUM`).
-
-**`mode` keeps only the *dominant* class** per cell; the class mix is discarded. Fine for "dominant class" maps, but **inadequate for area-accounting** ("how much wetland?"), which then undercounts to plurality cells only. Per-class fractional coverage (one column per class) is not produced by the current pipeline — flag it if a use case needs class areas.
-
-**Reducer choice is independent of geometry correctness.** The raster pipeline integrates each cell's true footprint, including the antimeridian/poles (fixed in `cng-datasets` #88/#92). But any **global** raster hexed before that fix is inflated at the ±180/pole seam and must be re-hexed regardless of reducer.
-
+Resolution anchors, the reducer decision table, many-tile mosaicking, and the re-hex campaign
+checklist: **skill `raster-hexing`**.
 #### How `--dataset` controls naming
 
 The **last path segment** drives PMTiles `source-layer`, S3 path, and k8s job prefix:
@@ -452,317 +359,26 @@ rclone copyto /tmp/README.md nrp:<bucket>/README.md
 rclone copyto /tmp/stac-collection.json nrp:<bucket>/<dataset>/stac-collection.json
 ```
 
-#### ⛔ Verify the STAC — don't hand-check the rules
-
-Every STAC rule below is enforced by **`scripts/verify-stac.py`** (license, nav links,
-asset keys, hex glob, `h3:*` resolutions, `vector:layers`, `table:columns` placement,
-per-feature-dup warnings, categorical completeness + PMTiles fields via the two
-sibling linters, and a **data-backed `values` == ingested `DISTINCT`** check via the
-MCP that automates the #114/#294 lesson). Do not re-verify these by hand or by
-spending agent context on MCP `SELECT DISTINCT` sweeps — run the gate.
+⛔ **Do not hand-check the STAC rules — run the gate.**
 
 ```bash
-# 1. PRE-PUBLISH (static, against the /tmp file you just wrote):
-scripts/verify-stac.py --no-data /tmp/stac-collection.json
-#    Fix every HARD finding before rclone copyto. (Data checks need the data live, so
-#    they run post-publish; --no-data skips them here.)
-
-# 2. POST-CLUSTER (full, against the live S3 STAC, once data + STAC are published):
-scripts/verify-stac.py --bucket <bucket> --dataset <dataset>
-#    Must exit 0 (no HARD findings). ADVISORY lines are informational.
+scripts/verify-stac.py --no-data /tmp/stac-collection.json       # pre-publish (static)
+scripts/verify-stac.py --bucket <bucket> --dataset <dataset>     # post-cluster (full, data-backed)
 ```
 
-CI runs the same verifier on the PR (`.github/workflows/verify-stac.yml`), deriving the
-collection(s) from the `s3://` paths in the changed `catalog/**` YAMLs. **The gate
-evaluates the produced artifact, not the proposal:** the cluster run lands after the PR
-opens, so a RED check at PR-open (STAC not published yet) is correct — don't merge
-before the recipe has actually produced valid output. GitHub status checks don't
-auto-refresh from S3, so **after your cluster jobs finish, re-fire the check** (Actions
-→ Verify STAC → *Run workflow*, or it re-runs on the next push). Merge requires it green.
+Fix every HARD finding before `rclone copyto`; the post-cluster run must exit 0. CI runs the same
+verifier on the PR, deriving collections from the `s3://` paths in changed `catalog/**` YAMLs — so
+a RED check at PR-open is correct, and you re-fire it after the cluster jobs land.
 
-**README.md MUST include:**
-- A MapLibre GL JS example with the correct `source-layer` (= last segment of `--dataset`), documented prominently
-- A DuckDB example with the full public parquet URL
-
-#### ✍️ Descriptions are USER-FACING COPY — agents quote them to end users
-
-Asset, column and collection `description` fields are not internal documentation. The geo-agent
-reads them and **quotes them, nearly verbatim, into answers for end users** — for ca-30x30 that is
-state-agency staff and conservation partners, often non-spatial. Write them as product copy, not as
-notes to the next engineer (data-workflows#512, where issue prose reached a user as
-"joining at res-8 avoids the ~11 pp overstatement that a coarse `GROUP BY` would introduce").
-
-**Say:** what the asset is, what it is for, what resolution it is at, and the one thing a consumer
-must know to use it correctly. Spell things out — "resolution 8", not "res-8".
-
-**Do NOT put in a description:**
-- issue or PR numbers, repo names (`data-workflows#506`) — those belong in the issue and the commit;
-- defect magnitudes or what a previous consumer got wrong ("overstates conserved share by ~11pp");
-- unexplained abbreviations (`pp`), bare column/asset keys as the subject of a sentence;
-- shouted imperatives (`ALREADY A MEAN`, `do NOT re-aggregate`, `NEVER SUM`) — they read as
-  scolding when quoted, and prose imperatives are exactly what leaks into an answer.
-
-**Express a real constraint as a short SQL example instead** — it is clearer than an imperative and
-does not leak as prose:
-
-```sql
--- correct: combine cells weighted by land area
-SELECT SUM((w1 + w2) * land_area_km2) / SUM(land_area_km2) FROM …
--- wrong: weighting by a cell COUNT assumes equal-area cells — H3 cells are not equal-area
--- wrong: taking the largest or any single cell's value overstates the share
-```
-
-> The count-weighted version of that example (`… * nland) / SUM(nland`) was what this file
-> recommended until #522, and it is latitude-biased: over California (32.5N-42N) it returned a
-> 25.684% conserved share against an area-weighted 26.135%. If a rollup asset exposes only a
-> child-cell *count*, ship the child-cell *area* alongside it — the correct query should be the
-> short one, not the one requiring an `h3_cell_area()` call the consumer has to remember.
-
-The mechanical rules elsewhere in this file still apply on top of this: per-column text stays
-**identical across assets** (the mcp-data-server#303 fold), the hex per-feature-duplication note
-still has to be present and still has to match what `verify-stac.py` looks for (phrases like
-"repeated on every … cell"), and the H3 area recipe still must not be inlined (#389). Plain register,
-same guarantees.
-
-**Publishing lags by ~15 minutes.** `mcp-data-server` refreshes its STAC cache on a **~15-minute**
-cycle, so right after `rclone copyto` the agent (and the app) still read the previous text — verified
-during #512, where `verify-stac.py` (which fetches S3 directly) saw the new copy while
-`get_stac_details` returned the old, then agreed after the refresh. So: verify prose against the S3
-URL for correctness, and wait out the cycle before judging what an agent or the app will quote. **No
-cache-invalidation or restart is needed** — do not go reaching into the MCP's namespace for one.
-
-**One text per column NAME per collection.** The `#303` fold is per column *name* across every asset
-in the collection, and **first-seen wins**, so a column documented differently on two assets loses
-one version silently. Two traps, both hit in #512:
-- Adding a new hex-like asset with its own wording for `h10`/`h9`/`h8`/`h0` meant the older asset's
-  text won — and that text said "one row per (feature, h10) pair", which was true there and **false**
-  for the new per-cell assets. Keep shared H3 columns grain-neutral and identical; state grain in the
-  asset `description`, which is always rendered.
-- Appending a hex-only clause to a column that also exists on the flat GeoParquet (e.g. "…repeated on
-  every hex cell — dedup first") makes the two differ, so the clause is dropped. Put that note in the
-  hex asset's `description` instead. After editing, check no column name carries two different texts
-  within the collection — `verify-stac.py` reports this as `column-description-divergent`
-  (ADVISORY today; it becomes HARD once the pre-gate catalog is fold-clean, #509).
-
-**The title and description state the FOOTPRINT, not which tranche you ingested.** A set of
-whole administrative or hydrologic units is **never** a state extent, and a consumer — human or
-model — trusts the title over the geometry. `usgs-nhdplus-hr-flowline` was titled *"(California)"*
-and said *"COVERAGE IS CALIFORNIA ONLY"*, both true about which VPUs had been ingested and both
-read as claims about the footprint, which is 13 whole HU4 units with **30.3% of its stream length
-in Nevada, Utah, Oregon and Arizona**. A model skipped the California mask and its headline number
-was 8.5 points wrong — the same mechanism as the pinyon-juniper defect (#505). So:
-
-- **Title the unit set** — "…(13 California hydrologic units)", not "…(California)". Same for
-  counties, ecoregions, watersheds, and every later tranche of a national build.
-- **State the footprint near the top of the description**: what the units are, that they are not
-  clipped to the region, how much lies outside, and the mask a region-level statistic needs
-  (for California, join `h8` + `h0` against the `ca30x30-ecoregion` hex). Give the mask as a short
-  SQL example, per the register rules above.
-- **Never write "X ONLY" for "only the X tranche is ingested so far"** — say the ingest scope and
-  the footprint as two separate facts.
-- The `bbox` is usually already correct; it is the prose that lies. `verify-stac.py` flags a title
-  naming one US state whose bbox reaches >1° outside it with no footprint sentence
-  (`title-names-state-but-bbox-exceeds-it`, ADVISORY) — the fix is the sentence, not a narrower bbox.
-
-**stac-collection.json MUST include:**
-
-- **License — REQUIRED on every collection.** Set the top-level STAC `license` field to the **SPDX identifier** of the upstream data license (e.g. `CC-BY-4.0`, `CC-BY-NC-4.0`, `CC-BY-SA-4.0`, `CDLA-Permissive-2.0`, `public-domain`). Use `"other"` **only** when no SPDX id applies, and `"various"` **only** for a meta-collection whose children genuinely differ — never as a lazy default. For `other`/`various` (and recommended for all), add a license link: `{"rel": "license", "href": "<canonical terms URL>", "type": "text/html"}`. **Exception — a meta-collection (one with `child` links) may use `various`/`other` WITHOUT a license link:** its real licenses live on the child collections (each carrying + verified for its own license), and redistribution gating (source.coop excludes, etc.) keys on those per-child licenses, not the parent. A single parent-level link would misrepresent genuinely mixed children. `verify-stac.py` enforces the link only on **leaf** collections (and always for `proprietary`). **Verify the real upstream terms — do not guess `proprietary`.** The license drives redistribution decisions (e.g. whether a dataset may be mirrored to source.coop); a wrong value is a compliance risk. NonCommercial / ShareAlike licenses are fine but MUST be recorded as such (`CC-BY-NC-*`, `CC-BY-SA-*`) so downstream users aren't misled. US federal works = `public-domain`.
-
-- **Temporal extent — RFC 3339, or the dataset vanishes from the served catalog.** Every
-  `extent.temporal.interval` endpoint must be a full RFC 3339 date-time with a timezone
-  (`"1920-05-15T00:00:00Z"`), or `null` for a genuinely open start/end. This is not
-  cosmetic: pystac parses these **eagerly** when it loads a collection, so one malformed
-  value makes the entire collection fail to load for every MCP consumer — the dataset
-  simply isn't there, with nothing but a warning in the server log. Seven BLM MLRS
-  mineral collections shipped this way and were invisible for weeks.
-  **When composing the string from a query result, slice the date part explicitly**
-  (`str(v)[:10]`): the MCP `query` tool renders a DuckDB `DATE` as
-  `"1974-03-01T00:00:00.000000"`, so appending `"T00:00:00Z"` to the raw value produces a
-  doubled time component. `verify-stac.py` HARD-fails a non-RFC-3339 endpoint, a missing
-  interval, and a start that is after its end.
-
-- **Navigation links — every collection needs all four:**
-
-  ```json
-  "links": [
-    {"rel": "self",   "href": "https://s3-west.nrp-nautilus.io/<bucket>/<path>/stac-collection.json", "type": "application/json"},
-    {"rel": "root",   "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json",        "type": "application/json"},
-    {"rel": "parent", "href": "<URL of the collection that links to this one as a child>",             "type": "application/json"},
-    {"rel": "child",  "href": "<URL of each sub-collection>",                                          "type": "application/json"}
-  ]
-  ```
-
-  Rules:
-  - `self` = the collection's own S3 URL.
-  - `root` = always the NRP root catalog (`public-data/stac/catalog.json`).
-  - `parent` = the collection that holds this one as a `child` link. For top-level bucket collections this is the root catalog. For nested sub-collections (e.g. `public-rivers/american-rivers/dam-removal/`) this is the domain collection (`public-rivers/american-rivers/stac-collection.json`), **not** the root.
-  - `child` = `"rel": "child"` (not `"item"`) for every sub-collection. `"rel": "item"` is for individual STAC Items (features), not Collections.
-  - **Without `self`/`root`/`parent`, geo-agent cannot traverse the tree and the collection won't expand.**
-
-- **Asset keys encode the dataset, not the format.** Never use generic keys (`pmtiles`, `geoparquet`, `h3-parquet`, `parquet`, `hex`) — they collide and break downstream apps. Use `{last-segment}-{format}`:
-
-  | Asset | Pattern | Example (`--dataset census-2025/sldl`) |
-  |---|---|---|
-  | GeoParquet | `{name}-parquet` | `sldl-parquet` |
-  | PMTiles | `{name}-pmtiles` | `sldl-pmtiles` |
-  | H3 hex | `{name}-hex` | `sldl-hex` |
-  | COG | `{name}-cog` | `sldl-cog` |
-
-  Multi-layer collections: prefix with collection context (`cpad-holdings-parquet`, `cpad-units-hex`).
-
-- **Hex asset `href` MUST use the Hive-partitioned glob — never a bare directory:**
-  - ❌ `.../census-2025/sldl/hex/`
-  - ✅ `.../census-2025/sldl/hex/h0=*/data_0.parquet`
-
-- **Any vector asset with named layers** (PMTiles, GDB, GPKG, etc.) MUST include `"vector:layers": ["<name>"]`. For PMTiles the layer name = last segment of `--dataset`.
-
-- **`table:columns` goes on each parquet asset — NOT at the collection level.** Put it inside the asset object for the GeoParquet and hex assets. Do not add a top-level `table:columns` to the collection. `verify-stac.py` HARD-fails a collection-level `table:columns`.
-
-  **Every queryable parquet asset is fully self-describing** — it carries the full per-column schema (name, type, description, `values`), the SAME text on the flat GeoParquet and the hex. This is deliberate: the mcp-data-server renderer dedups identical per-column descriptions across assets at read time (mcp-data-server#303), so full-both costs nothing to the LLM; and a consumer targeting a single asset directly still gets the full schema. That last point is not optional — **raster-derived datasets have a hex but no GeoParquet**, so the hex must stand alone. The single authority is the **build/relocation tool** (one source schema written identically to every asset), never a hand-edit of one asset — identical text means the #303 "first-seen wins" merge never drops anything.
-
-  Each parquet asset documents exactly the columns it contains:
-  - **GeoParquet asset** (vector, when present): include the geometry column (`Shape`, `geom`, or `geometry`).
-  - **Hex asset**: full per-column descriptions identical to the flat (minus the geometry column); include the H3 index columns (`h0`, `h8`, `h9`, `h10` etc.) and `_cng_fid`/`bbox`. The hex is the primary query target (and the sole one for rasters), so it is never "lean."
-  - **COG assets**: no `table:columns` needed (not SQL-queryable).
-
-- **`_cng_fid` is the universal per-feature id — REQUIRED on every vector asset, flat GeoParquet *and* hex (#369).** cng-datasets `convert_to_parquet` synthesizes it on every conversion (always, additive, row-unique), so one uniform key works for dedup / `COUNT(DISTINCT)` across all datasets instead of per-dataset id discovery (the over-count class behind #309). Source ids (`ramsarid`, `tpl_id`, `GEOID`) may accompany it for cross-collection joins but never replace it. `verify-stac.py` **HARD**-fails a vector flat GeoParquet (has a geometry column) or a vector hex that lacks `_cng_fid`; if the data genuinely lacks it, reprocess through cng-datasets. **Exempt:** raster-derived hex (a raster reduce into H3, not a feature conversion — detected as a hex/`h0=*`-partitioned asset in a collection with no vector source; covers carbon/ghs-pop *and* the richness/cwhr/gbif reductions). A **non-spatial** parquet table (no geometry, not a hex) is **ADVISORY** — it may be a feature fact table that should carry `_cng_fid` (e.g. tpl `…-funding`) or a legit lookup/crosswalk/coefficient/scores table; use judgment.
-
-- **PMTiles assets MUST carry tile-accurate `table:columns` (data-workflows #283/#320), in LEAN form.** The geo-agent (and human app authors) can only learn which fields are stylable/filterable in MapLibre from the PMTiles asset's own schema — an empty `table:columns` forces them to byte-range the `.pmtiles` footer. **Empirically, our tippecanoe step keeps ALL attribute columns: the tile field set is just `GeoParquet attrs − geometry + _cng_fid`** (types coarsened to String/Number/Boolean). So the standard is to **mirror the canonical GeoParquet schema onto the PMTiles asset** — do NOT hand-scrape thin metadata from the footer, and do NOT duplicate the prose:
-  - **Lean columns:** each PMTiles column carries **`name` + `type` + `values`** (the `values` enumeration is the styling-critical part for categoricals) — copied from the GeoParquet column of the same name. **Omit the prose `description`** — it stays CANONICAL on the GeoParquet asset (duplicating it across 3 assets just bloats agent context; the agent reads definitions there).
-  - Drop the geometry column; include `_cng_fid` (present in tiles).
-  - Keep `vector:layers` (the source-layer id list).
-  - **Continuous (choropleth) layers only:** add the **nodata sentinel** and flag the **intended value column** for styling, as a short `description` on that one column (e.g. SVI `RPL_THEMES = -999`) — these are viz-specific and not inferable from the GeoParquet schema.
-  - **Generate it** with `scripts/mirror-pmtiles-columns.py <stac-url>` — it reads the footer to *validate* the field set (and flags the rare genuine-subset case, e.g. SVI, where tippecanoe really did drop columns), mirrors the GeoParquet `name`/`type`/`values`, and writes the updated STAC to `/tmp`. Then `rclone copyto` to S3.
-  - Because PMTiles mirrors the GeoParquet, **fix the GeoParquet/hex categoricals FIRST** (the #303 work), then mirror — otherwise you copy incomplete `values`.
-  - Gate with `scripts/lint-stac-pmtiles-fields.py <stac-collection.json|url>` (companion to `lint-stac-categorical.py`); it requires `name` + `type` and does NOT require descriptions.
-
-- **Hex assets MUST declare their H3 resolutions explicitly** via `h3:native_resolution` and `h3:parent_resolutions` on the asset itself. Column-name presence (`h10`, `h9`, …) is not enough — downstream tools shouldn't have to enumerate `table:columns` to find out what resolutions exist. `h3:native_resolution` is the finest resolution (one row per feature-cell at this res); `h3:parent_resolutions` is the list of rollup resolutions, which MUST include `0` (the partition key).
-
-- **Vector (GeoParquet/PMTiles) assets MUST flag per-feature ROW duplication — and you MUST first decide whether it is *true* duplication or *real* multi-row data.** A source file often stores one logical feature as several rows sharing a feature id (a Ramsar site split into polygon parcels; a ballot measure spanning multiple counties). Two opposite causes demand opposite rules, and confusing them silently corrupts answers (data-workflows #309):
-  - **REPEATED** — the per-feature value is *copied* onto every row (e.g. a measure's total funds repeated on each county row). A raw `SUM` double-counts → **dedup by the key first** (`SELECT DISTINCT key, col …` or `GROUP BY key`), and `COUNT(DISTINCT key)` is the feature count.
-  - **VARIES** — genuinely distinct per-row records that share a key (e.g. one conservation site funded by several *sponsors*, each a *different amount*). Here `SUM` is **correct** and dedup would **undercount** by dropping real rows. A repeated polygon + repeated attributes is NOT proof of duplication — a sponsor split looks identical except the varying amount.
-
-  **Two duplication axes — and `_cng_fid` only fixes one of them.** cng-datasets always assigns `_cng_fid` as a synthetic id that is *one per input row* (never derived from a source id). So:
-  - **Axis 1 — feature → H3 cell** (hexing makes one polygon span many cells). Dedup key = `_cng_fid` (or `h<N>`). `COUNT(DISTINCT _cng_fid)` collapses the cell expansion. This is the standard hex guidance below.
-  - **Axis 2 — upstream source rows** (the *input file* already holds several rows per logical entity). Dedup key = an **upstream domain id** (`ramsarid`, `landvote_id`, WDPA `SITE_ID`). `_cng_fid` is unique per row, so it does NOT collapse this — `COUNT(DISTINCT _cng_fid)` still counts rows/polygons, not entities.
-
-  For most datasets each input row *is* one logical feature, so the two keys coincide and only axis 1 exists — that is why the standard guidance leans on `_cng_fid`. Axis 2 only appears in files with upstream duplication (ramsar, landvote); there the domain id is the dedup key, and **the hex asset must also carry that domain id** or it cannot be deduped to entities (e.g. landvote's hex carries only `_cng_fid`, so it can't be reduced to distinct measures — a gap). Auditing on a per-row id always reports "clean", masking axis 2.
-
-  **The decisive test is data-backed: does the value VARY within the key?** Do NOT guess the key from a column name — a 34%-blank source id (PAD-US `Source_PAID`) or a class label that covers thousands of parcels (Landmark `name`) fakes duplication, and a per-row id (`_cng_fid`) hides it. Run the auditor with the *upstream domain id* as `--key` (it uses the duckdb-geo MCP, not local duckdb):
-  ```bash
-  scripts/audit-feature-dup.py <parquet-url|stac-url --asset KEY> --key <feature-id-col>
-  ```
-  It reports rows vs `COUNT(DISTINCT key)`, warns on blank keys, classifies each column REPEATED vs VARIES, and quantifies raw-vs-deduped `SUM` inflation. Then document the verdict in the asset's `table:columns`: name the key, mark REPEATED columns "dedup before SUM", and (if any) note VARIES columns are safe to SUM. A clean one-row-per-feature file needs no note.
-
-- **Hex assets MUST flag per-feature duplication — at the hex ASSET-description level, NOT per-column.** One hex row = one (feature, cell) pair, so any column that represents a per-feature total — area (`GIS_Acres`, `SHAPE_Area`), length (`SHAPE_Length`), population, count, amount, funding, intensity — is repeated on every cell the feature covers. Put this warning (name the pattern + the **dedup key**, list the affected columns) in the **hex asset's `description`**, because the mcp-data-server#303 renderer keeps per-column descriptions identical across the flat and hex (single authority) and would silently drop a per-column note that differs between them — whereas the per-asset `description` line is always rendered. `verify-stac.py` accepts the note at the asset (or collection) level. (Raster hex: the asset note states reducer semantics instead — e.g. "`sum` reducer, SUM is the catalog total" or "mean density → × cell area for totals".) The two safe patterns:
-  - **SUM after dedup** (the attribute is a real per-feature value): `SELECT DISTINCT <feature_key>, <attr> …` or `ROW_NUMBER() OVER (PARTITION BY <feature_key>)` before aggregating.
-  - **Area/extent from the H3 footprint** (when there is no trustworthy source value): the generic recipe — `SUM(h3_cell_area(h<N>, 'km^2'))` over DISTINCT cells, exact per cell, **never** a nominal per-resolution constant — lives in `mcp-data-server/h3-guide.md`. **Do NOT inline that formula into the column description** — it is generic guidance the geo-agent already reads from the h3-guide, and a copy baked into STAC goes stale and becomes actively harmful (a nominal-constant copy undercounted the ca-30x30 California extent ~6%, mcp-data-server#294 / #389). Just flag the column as a per-feature total not to be SUMmed on hex; the agent derives area from the h3-guide.
-
-  Columns that are safe to aggregate on hex (H3 indexes, `_cng_fid`, `bbox`) don't need a warning. If no column on the hex asset is safe to SUM, say so once in the collection description too.
-
-  ```json
-  "assets": {
-    "sldl-parquet": {
-      "href": "https://…/sldl.parquet",
-      "type": "application/x-parquet",
-      "title": "…",
-      "table:columns": [
-        {"name": "GEOID", "type": "string", "description": "…"},
-        {"name": "ALAND", "type": "int64", "description": "Land area in m² of the source district polygon."},
-        {"name": "geometry", "type": "geometry", "description": "Feature geometry (GeoParquet)"}
-      ]
-    },
-    "sldl-hex": {
-      "href": "https://…/sldl/hex/h0=*/data_0.parquet",
-      "type": "application/x-parquet",
-      "title": "…",
-      "h3:native_resolution": 10,
-      "h3:parent_resolutions": [9, 8, 0],
-      "table:columns": [
-        {"name": "GEOID", "type": "string", "description": "…"},
-        {"name": "ALAND", "type": "int64",
-         "description": "Land area in m² of the source district polygon. **Repeated on every hex row the district covers — never SUM(ALAND) on hex data; dedup first (SELECT DISTINCT GEOID, ALAND).** For area from the H3 footprint see the h3-guide."},
-        {"name": "h10", "type": "uint64", "description": "H3 cell ID at resolution 10 (native resolution; one row per (feature, h10) pair)."},
-        {"name": "h9",  "type": "uint64", "description": "H3 cell ID at resolution 9."},
-        {"name": "h8",  "type": "uint64", "description": "H3 cell ID at resolution 8."},
-        {"name": "h0",  "type": "int64",  "description": "H3 cell ID at resolution 0, used as the partition key for hive-partitioned reads."}
-      ]
-    }
-  }
-  ```
-
-  For **coded categorical** columns, the description MUST list all valid values in `CODE=Definition, …` format and include a `"values"` array. Discover actual values via DuckDB before writing:
-  ```sql
-  SELECT column_name, COUNT(*) AS n FROM read_parquet('s3://…') GROUP BY column_name ORDER BY n DESC
-  ```
-  Example:
-  ```json
-  {"name": "owner_type", "type": "string",
-   "description": "Owner type code. Values: FED=Federal, STAT=State, LOC=Local, NGO=Non-governmental/non-profit, TRIB=Tribal/Indigenous, PVT=Private, UNK=Unknown",
-   "values": ["FED", "STAT", "LOC", "NGO", "TRIB", "PVT", "UNK"]}
-  ```
-  Missing definitions cause LLM agents to guess values (e.g. `WHERE owner_type = 'Federal'` instead of `'FED'`) and return empty results.
-
-- **Categorical rasters (COG assets with discrete pixel-value classes):** the COG asset's `raster:bands[0]` MUST include `classification:classes` (STAC classification extension v2.0.0). Each entry: `{ value, name, description, color_hint }` where `color_hint` is a 6-character RGB hex (no leading `#`). Add `https://stac-extensions.github.io/classification/v2.0.0/schema.json` to `stac_extensions`. Do **not** use the legacy `class_values` field from the raster extension — geo-agent reads `classification:classes` and `color_hint` to build both the discrete legend swatches and the titiler categorical colormap; without those colors the layer falls back to a continuous gradient. Use the dataset's standard published palette where one exists (NLCD MRLC colors, etc.); otherwise pick distinguishable accessible colors and note the choice in the asset description.
-  ```json
-  "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/classification/v2.0.0/schema.json"
-  ],
-  "assets": {
-    "nlcd-cog": {
-      "raster:bands": [{
-        "name": "land_cover_class", "data_type": "uint8", "nodata": 0,
-        "classification:classes": [
-          {"value": 11, "name": "Open Water", "description": "…", "color_hint": "466B9F"},
-          {"value": 41, "name": "Deciduous Forest", "description": "…", "color_hint": "68AB5F"}
-        ]
-      }]
-    }
-  }
-  ```
-
-- **Per-feature row duplication / NULL finest-parent cells / no-data sentinels (data-workflows #309, gated by #311).** Three aggregation traps the geo-agent accuracy sweep surfaced — document each on the relevant asset:
-  - **Repeated features (polygon/point assets).** Handled by the REPEATED-vs-VARIES per-feature row-duplication rule above — run `scripts/audit-feature-dup.py` to get the verdict and document it. `verify-stac.py`'s `polygon-row-dup-candidate` **ADVISORY** is just the automatic CI tripwire that flags a `rows ≫ COUNT(DISTINCT id)` candidate; treat it as a prompt to run that auditor, not a defect on its own (the signal over-flags — the column may be a label or provenance key, not the feature id).
-  - **NULL finest-parent cells.** If the hex build caps very large features at a coarser native resolution (WDPA: `h9` is NULL for the 1,297 biggest features, `h8` is complete), the hex asset description MUST name the complete column and say joins should use the coarsest shared resolution (or `h3_cell_to_parent()`), not the finest. `verify-stac.py` **HARD**-flags an undocumented NULL finest hex column.
-  - **No-data sentinels.** Document sentinel/fill codes (e.g. land-cover `0`/`200`) so consumers `WHERE col NOT IN (...)` before `SUM`/`AVG` — an undocumented sentinel poisons aggregates to `NaN`.
-
-  ⛔ **MEASURE every added column's range and sentinels — never document one from upstream docs or
-  memory.** When a build introduces columns new to this catalog, run one query per new column
-  (`MIN`/`MAX`, `COUNT(*) FILTER (WHERE col < 0)`, distinct count) *before* writing STAC. This is
-  the #518 lesson generalised, and it recurred three times in one session while fixing #518
-  (data-workflows #205/#525):
-  - `-9999` on four NHDPlus VAA columns (and `-9` on a fifth) — **the same 2,745 rows** — was
-    documented nowhere in the first draft; an unfiltered `AVG(slope)`/`MIN(totdasqkm)` is poisoned.
-  - Worse than omission: a sentinel note copied from upstream documentation said "check for
-    negative values", which would have told consumers to discard **real** below-sea-level
-    elevations (10,349 rows, min −85.61 m in Death Valley). **A negative value is not automatically
-    a sentinel** — filter the exact sentinel (`<> -9998`), never a sign test, unless you have
-    measured that no legitimate negatives exist.
-  - A `values` array copied from a sibling collection missed 13 codes actually present. Coded
-    domains come from the authoritative source table (#294), and `values` from the ingest.
-  Record the measured ranges in the dataset's `BUILD.md` so the next reader inherits evidence
-  rather than assumption — see `catalog/usgs-nhd/k8s/nhdplus-hr/BUILD.md` for the pattern.
-
-- **Point datasets:** `description` or `"processing:notes"` MUST state each point resolved to one H3 cell at the processing resolution, and name the resolution. Example: *"Point observations were hexed to H3 resolution 10 (each point → one ~15 000 m² cell). Multiple points within the same cell are not deduplicated."*
-
+Everything about *what to write* — the user-facing description register, `table:columns`
+placement, SPDX license rules, categorical `values`, hex per-feature duplication notes, `h3:*`
+declarations, point/line notes — is in **skill `stac-authoring`**. Load it before writing or
+editing any `stac-collection.json` or README.
 ### Step 6: Register in the parent sub-catalog
 
-**The STAC catalog is a TREE.** Datasets belong in their domain/bucket sub-catalog, not the root. Root `public-data/stac/catalog.json` only links top-level sub-catalogs (e.g. `public-high-seas`, `public-padus`, `public-census`).
-
-Before linking:
-1. Check for existing sub-catalog: `curl -s https://s3-west.nrp-nautilus.io/<bucket>/stac-collection.json | jq '.links[] | select(.rel=="child")'`
-2. Exists → add child link there.
-3. Brand-new bucket/domain → create bucket-level `stac-collection.json`, register children in it, then link that bucket-level collection from root.
-
-```bash
-curl -s https://s3-west.nrp-nautilus.io/<bucket>/stac-collection.json > /tmp/parent.json
-# Edit /tmp/parent.json to append {"rel": "child", "id": "...", "href": "...", "title": "..."}
-rclone copyto /tmp/parent.json nrp:<bucket>/stac-collection.json
-```
-
-Only touch the root when adding a **new** top-level sub-catalog.
-
+**The STAC catalog is a TREE** — datasets belong in their domain/bucket sub-catalog, not the root.
+Only touch the root when adding a **new** top-level sub-catalog. Procedure: **skill
+`stac-authoring`**.
 ### Step 7: License the collection — you register NOTHING for backup or mirror
 
 Backups and the source.coop mirror are **owned end to end by geo-agent-ops**, in a namespace
@@ -800,103 +416,23 @@ repo creation, no MinIO bucket policy, and never add a MinIO or source.coop remo
 `rclone-backup` secret) to a workflow namespace. You hold none of those credentials, and that is
 the design, not an oversight.
 
-## Memory and Chunking Mental Model
+## Hex sizing and resolution
 
-**RAM is driven by the H3 cell count of the single largest feature in a chunk — not dataset size or bounding box.**
+**RAM is driven by the H3 cell count of the single largest feature in a chunk — not dataset
+size, not bounding box.** 10,000 small features at 8Gi can be fine while one continent-scale
+polygon OOMs at 32Gi. OOMs are a tuning signal, not a failure.
 
-Hex generation is two passes:
-1. For each feature polygon, compute covering H3 cells (large array per feature)
-2. Unnest arrays row-by-row; **peak RAM = size of the largest single feature's cell array**
+**`h8` is the catalog's universal join key.** Default native resolution is **8**; every dataset
+finer than 8 (native `h9`/`h10`) MUST carry `h8` as a parent, and **`h0` always** (it is the hive
+partition key and the coarsest common join). Go coarser than 8 only when feature size or source
+pixel genuinely forces it — such a dataset *cannot* carry `h8`, which is a sanctioned case that
+must be stated in the hex asset description so an agent does not conclude the data is broken.
 
-Counterintuitive result: 10,000 small features at 8Gi can be fine, while a single continent-scale polygon OOMs at 32Gi. What drives RAM:
-- H3 resolution (exponential: res 8 ≈ 1/170th the cells of res 10 for the same area)
-- Area of the largest single feature in the chunk
-- Geometry complexity affects Pass 1 runtime, not Pass 2 RAM
+**Always record the chosen native + parent resolutions in the GitHub issue** (scope) and in the
+hex asset's `h3:native_resolution` / `h3:parent_resolutions`.
 
-**Right approach:** start with default (8Gi vector), then tune from OOM signals.
-1. Use Armada with `--chunk-size 1` for variable feature sizes (each feature its own pod)
-2. On OOM: identify the large polygon(s) and either lower resolution, raise `--hex-memory`, or re-run that chunk alone (see Reprocessing Failed Chunks)
-3. OOMs are expected — a tuning signal, not failure.
-
-**Resolution guidance:**
-
-| Dataset type | Resolution | Rationale |
-|---|---|---|
-| Countries, continents | 8 | Continent-scale features |
-| States, provinces | 8 | Still very large |
-| Counties, districts | 8–10 | Mostly OK at 10; watch outliers |
-| Census tracts, parcels | 10 | Small features |
-| Points | 10 | Each point → one cell; coarser = aggregation |
-| Lines | 8 | Buffered by H3 circumradius; default 8 auto-detected |
-
-#### ⭐ H3 resolution & parent convention (join compatibility — pick native res AND parents deliberately)
-
-Native resolution alone is not the whole decision — the **parent-resolution set** is what
-makes a dataset joinable to the rest of the catalog. Two datasets join cheaply only at a
-resolution they **both physically carry** (`h<N> = h<N>`); otherwise a consumer must
-`h3_cell_to_parent()` on the fly, which LLM agents do unreliably (wrong direction, skipped,
-empty joins). So encode the joins into the data, don't hope the model derives them.
-
-- **`h8` is the catalog's universal join key. Default native resolution is 8**, and **every
-  dataset finer than 8 (native `h9`/`h10`) MUST carry `h8`** as a parent. Rationale: raster
-  hexes (carbon, GHS-POP, richness) are native `h8`, and vector hexes (native `h10`) carry
-  `h8` — so nearly everything meets at `h8`. A one-off native `h7` (e.g. the gHM 1 km raster
-  before this rule) is an **outlier with no `h8`** and silently breaks those joins — don't do it.
-- **`h0` always** — it is the hive partition key and the coarsest common join; every hex asset
-  carries it (it must be in `--parent-resolutions`).
-- **`h10` is currently our finest.** Small features (parcels, tracts, points) → native `h10`,
-  parents `9,8,0` (the generator default) so they carry `h8`.
-- **Coarser than 8 only when features are genuinely huge** — continent- or ocean-scale polygons
-  (e.g. large marine areas hexed at `h5`) to keep hex cell-count/RAM sane. Such a dataset
-  *cannot* carry `h8` (finer than native); consumers roll finer data **up** to `h5` to join it.
-  Use a coarse native res because the feature size forces it, never as a cost shortcut on data
-  that should be `h8`.
-- **A dataset may declare a *set* of parents** (e.g. native `h8` with `--parent-resolutions
-  "5,4,0"` → columns `h8,h5,h4,h0`) so it joins at several standard resolutions at once. Pick the
-  parent set from the resolutions of the datasets it will be joined against.
-- Always record the chosen native + parents in the issue (scope) and in the hex asset's
-  `h3:native_resolution` / `h3:parent_resolutions` (STAC).
-
-### Vector workflow parameters
-
-| Param | Default | When to change |
-|---|---|---|
-| `--h3-resolution` | 10 | Lower (8, 6) for large polygons. Halving res ≈ 6× fewer cells. |
-| `--hex-memory` | 8Gi | Tune from OOM signals. Start low. |
-| `--max-completions` | 200 | Number of hex chunks. With armada: set to feature count for chunk-size 1. **⛔ Not a hard cap — a silent coverage limit (data-workflows #494):** the k8s hex uses a FIXED `--chunk-size 1000`, so total features hexed = `max-completions × 1000`. The default 200 silently caps a build at **200,000 features** — anything beyond that is never hexed and the repartition/STAC look "complete." For any dataset **>200k features**, set `--max-completions ≥ ceil(feature_count / 1000)` (e.g. 711,583 → 720). The generator can't count features in a zip/parquet source, so it can't warn you. **Always** confirm coverage post-build: `COUNT(DISTINCT _cng_fid)` on the hex must equal the flat parquet's feature count (not just that h0 partitions exist). |
-| `--max-parallelism` | 50 | k8s only — capped by pod quota. Unused with armada. |
-| `--parent-resolutions` | "9,8,0" | Use `"0"` when `--h3-resolution 8` (9/8 would duplicate target). |
-| `--intermediate-chunk-size` | 10 | Decrease if hex OOMs during unnest — try this before raising memory. |
-
-### Raster workflow parameters
-
-| Param | Default | When to change |
-|---|---|---|
-| `--h3-resolution` | auto (from pixel size) | Override if auto is wrong |
-| `--hex-memory` | 32Gi | Raise if OOM. **Res-8 hex of a 300 m global raster needs 64Gi** — `exact_extract` on the densest h0 cells (~5.76 M cells/h0) OOMs at 32Gi (`exit 137`); with `backoffLimit: 0` it silently retries forever, with `backoffLimitPerIndex` it can blow `maxFailedIndexes` and **fail the job** (observed on nci-frontiers `flii`/forestry). Use 64Gi for res-8 300 m layers; coarser res or coarser source can stay at 32Gi. |
-| `--max-parallelism` | 61 | k8s only; reduce on quota hit; cap 122 |
-| `--parent-resolutions` | "0" | Add intermediate (e.g. `"7,0"`) if needed |
-| `--value-column` | "value" | Use meaningful name (`carbon`, `arte`, `nlcd`) |
-| `--nodata` | auto | Override if metadata nodata is wrong/missing |
-
-Raster completions are always **122** — not configurable.
-
-### Re-hexing an existing raster (campaign-style reprocessing)
-
-Most rework here comes from skipped pre-flight checks, not hard problems. Do, in order:
-
-1. **Pre-flight the COG** with one GDAL job (rclone-localize → read; never `/vsis3` for GDAL — it's flaky/node-dependent). Report size, dtype, **real nodata** (published STAC nodata is often wrong), and the value summary that becomes your validation truth (class histogram for `mode`; pixel-SUM for `sum`; min/max/mean for `mean`). **Confirm the COG is non-empty** — published "total" COGs have shipped 100% nodata.
-2. **Resolution = match the source pixel** (≈100 m → res 9; ≈500 m → res 8). Don't bump blindly; res finer than the pixel is 7× cost for no gain.
-3. **Hex job musts:** mount the `rclone-config` secret (the tool localizes the COG via rclone first; generated YAML omits it → fails), `backoffLimitPerIndex: 2` + `maxFailedIndexes` (not `backoffLimit: 0`), output to a **staging** prefix. `:latest` has the seam fix — no runtime clone.
-4. **Validate value AND coverage.** `sum`: hex `SUM` == COG pixel-SUM. Note `sum`/area layers are a **full h0 grid** (one row per cell, `value = 0` where the feature is absent) — same shape as carbon/ghs-pop; that's expected, not bloat. Check that the count of **nonzero** cells matches the feature extent, not the total. `mode`: sparse (cells with no valid pixel are dropped); only canonical codes + distribution tracks the histogram. **Seam (all reducers):** dateline h0 `576707042908045311` — fixed builds span ±180°, buggy ones are bloated and miss the dateline.
-   **⛔ h0-partition COVERAGE gate (data-workflows #409).** An indexed 122-completion hex Job that dies/gets-preempted mid-run can leave a *subset* of h0 partitions on S3 and get published as if complete. Two defenses, both required: (a) never treat a hex build as done unless the k8s Job reports `Complete=True` with empty `failedIndexes` — a partial run must surface as `Failed`, so keep `backoffLimitPerIndex` + `maxFailedIndexes` (never `backoffLimit: 0`); and (b) after the job, run the cheap partition-set gate against a reference build from the same COG (e.g. the fractional-coverage layer) or an explicit expected h0 set:
-   ```bash
-   scripts/check-hex-coverage.sh nrp:<bucket>/<dataset>/hex/ \
-       --reference nrp:<bucket>/<dataset>/hex-fractions/   # or --expect-count N / --expect-h0 h0a,h0b,...
-   ```
-   It is a metadata listing (rclone `lsf` sizes of `h0=*`), not a big-data scan — safe on a laptop. **⚠️ Compare POPULATED partitions, not directories.** A `mode` (sparse) reducer writes a partition only where valid pixels exist; a `sum`/coverage reducer writes a *full grid* — a `data_0.parquet` for every h0 it touches, including empty (0-row, ~214 B) partitions for all-nodata h0. So a raw `h0=*` directory count of a full-grid layer is a **superset** of its data extent, and a naive dir-vs-dir comparison across reducers reports **phantom gaps** — exactly what made NLCD mode look like "6 of 11" when its 6 populated h0 were complete and the fractions reference merely had 5 extra empty dirs (the #409/#410 false alarm). The gate therefore filters both sides to partitions whose bytes exceed `--min-bytes` (default 4096; a real partition is MB–GB). Exit non-zero + the missing h0 set means genuinely-missing populated partitions; re-run before publishing/validating values. The gate **also reports any empty partitions it finds under the target** as purge candidates (advisory by default; `--fail-on-empty` makes their presence a hard failure) — purge them (`rclone purge …/h0=<cell>/` then re-verify empty) so they don't pollute `**` globs or fake gaps for the next reader.
-5. **Flip: purge-and-VERIFY-empty, then sync.** `cng-datasets raster` overwrites the partition for each h0 it produces, but does **not** remove partitions for h0s that now yield no data — so reprocessing to a smaller/different domain (e.g. all-land → wetland-only) leaves **stale partitions** behind that corrupt aggregates. And `rclone purge` can silently no-op under S3 load. So purge staging **and confirm it's empty** before any re-hex. `kubectl apply` on a completed Job is a no-op; `delete`+`apply` to rerun. Jobs TTL-GC 3 h after completion — validate before then.
-
+Full memory model, resolution and parent-set decision tables, vector/raster workflow parameters,
+and reprocessing failed chunks: **skill `hex-tuning`** (raster specifics: **`raster-hexing`**).
 ## Pod-count good practice (`geo-workflows`)
 
 **Keep ≤200 simultaneous pods** across all your jobs. `geo-workflows` has **no enforced
@@ -932,91 +468,13 @@ bucket/                                 bucket/
 
 ## Troubleshooting
 
-**404 on convert → verify source URLs** with `curl -I` and directory listings (most common failure — always verify BEFORE generating YAMLs).
+**Diagnose before resubmitting.** `kubectl -n geo-workflows describe pod <pod>` first — the same
+resources will fail the same way. ⛔ **Never `kubectl delete pod --force` / `--grace-period=0`**;
+let the control plane reap it (skill `k8s-never-force-delete`).
 
-**"Cannot mix .zip files with multiple source URLs"** → preprocess job: download in parallel, unzip, pass shapefiles to `cng-convert-to-parquet`.
-
-**Check convert logs:** `kubectl logs job/<name>-convert`
-
-**Repeated preemptions on shared nodes → pin to Berkeley node** `stratus1.nrp-espm.berkeley.edu` (currently carries `nautilus.io/issue` taint):
-```yaml
-spec:
-  template:
-    spec:
-      nodeSelector:
-        kubernetes.io/hostname: stratus1.nrp-espm.berkeley.edu
-      tolerations:
-      - {key: "nautilus.io/issue", operator: Exists, effect: NoSchedule}
-```
-
-⛔ **This pin is a *reactive last resort* for observed, recurring preemption — NEVER a default.** By default let the k8s scheduler place pods. Many nodes across the cluster can service big requests (256/512 GB, multi-cpu) — the Berkeley node is only one of them. **Pinning a large-memory job to one node serializes it:** a 256Gi/8cpu pod fills the node, so `parallelism: N` becomes 1-at-a-time while the rest sit `Pending: Insufficient cpu` (this turned a CONUS res-10 hex from hours into 30-50h — #307). The cluster headroom is there to *request when a job genuinely needs it*; reach for `backoffLimitPerIndex` retries to absorb the occasional preemption before you ever reach for a node pin.
-
-✅ **You do NOT need to exclude GPU nodes for CPU-only jobs.** The generated `nodeAffinity` excludes GPU nodes (`feature.node.kubernetes.io/pci-10de.present NotIn true`), but GPU nodes usually have plenty of **spare CPU/RAM** that our hex/convert/COG jobs can use. Dropping the GPU exclusion **widens the schedulable pool**, which finishes fan-out jobs faster and — importantly — reduces the chance of pods piling onto a flaky node. Keep the exclusion only if a job genuinely needs to avoid GPU-host contention.
-
-⚠️ **Flaky-node hangs — and ⛔ NEVER `--force`-delete pods.** Some shared nodes (observed: `hpc-nrp-g1.nmsu.edu`, `service-02.nrp.mghpcc.org`) have broken egress/S3 connectivity: pods schedule but **hang on `rclone` localize / external download** ("Localizing input →" with no progress; "Could not resolve host") or sit `Pending` with the container never starting. A `backoffLimit: 0` job never recovers (pod Running/Pending, not Failed) and blocks the whole run.
-
-- ⛔ **Never `kubectl delete pod --grace-period=0 --force`.** It drops the API object while the container may still be running on an unreachable node → split-brain / duplicate S3 writes. (Standing rule from the user.)
-- ✅ **Let the control plane reap it — the safe equivalent.** A graceful `kubectl delete pod` (no `--force`) plus the node-lifecycle controller's eviction marks pods on an unreachable node `Failed` after the eviction timeout (~5 min); with `podReplacementPolicy: Failed` (the default once `backoffLimitPerIndex` is set) the Job then recreates that index on a healthy node. Net cost of *not* forcing is ~5 min, **not** a block — verified: a 4-index hang on `service-02` self-healed to 122/122 with zero force-deletes.
-- **Defenses, in order (prevention beats cure):** (1) exclude known-bad hosts via a `kubernetes.io/hostname NotIn [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org, …]` nodeAffinity term so pods never land there; (2) `activeDeadlineSeconds` on the **pod template** (turns a running-hang into a Failure the Job can retry); (3) `backoffLimitPerIndex` + `maxFailedIndexes` (retry the index elsewhere). Note `activeDeadlineSeconds` only helps a *Running* hang — a `Pending` pod (container never started) is cleared only by control-plane eviction, so (1) is the real fix.
-
-**Pod keeps getting evicted (`ContainerStatusUnknown`) → diagnose BEFORE resubmitting.** Never resubmit a failing job without `kubectl describe pod <pod>` — same resources will fail the same way.
-```bash
-kubectl -n geo-workflows describe pod <pod-name> | grep -A5 "Reason:\|Message:\|Events:"
-```
-
-| Message | Cause | Fix |
-|---|---|---|
-| `ephemeral local storage usage exceeds the total limit` | DuckDB sort spill | Raise memory AND ephemeral-storage |
-| `OOMKilled` | Insufficient RAM | Raise memory |
-| `ContainerStatusUnknown` on shared nodes | Preemption | Pin to Berkeley node |
-
-**DuckDB sort jobs need both big RAM and big ephemeral-storage.** `ORDER BY` over large data spills to disk; low RAM spills more. For 1–15 GB compressed partitions: 120Gi RAM, 50Gi ephemeral-storage. Namespace max for ephemeral-storage is **50Gi** — always request the max for sort-heavy jobs.
-
-**When scratch exceeds 50Gi, mount a PVC — do NOT fight the ephemeral cap.** Ephemeral-storage is hard-capped at 50Gi namespace-wide, so any job whose local scratch exceeds that — a raw download bigger than ~45 GB (e.g. the 35 GB RAP CONUS COG), a multi-tile `preprocess-cog` mosaic, a `raster --local-cache-dir` localization of a large COG — must use a **PersistentVolumeClaim**, not a bigger ephemeral request (which the quota will reject). A shared scratch PVC already exists: **`rechunk-scratch`** (2Ti, `RWX` rook-cephfs) — list with `kubectl -n geo-workflows get pvc`.
-- Mount it and redirect the tool's scratch onto it; keep ephemeral small (~10Gi):
-  ```yaml
-  volumeMounts:
-  - {name: scratch, mountPath: /scratch, subPath: <job-name>}   # subPath → per-job isolation on the shared PVC
-  volumes:
-  - {name: scratch, persistentVolumeClaim: {claimName: rechunk-scratch}}
-  env:
-  - {name: TMPDIR, value: /scratch}        # Python tempfile.mkdtemp (mosaic temp) honors TMPDIR
-  # and pass: cng-datasets raster --local-cache-dir /scratch ...   (input localization; CLI default is /tmp/cng-raster-cache)
-  ```
-- **`RWX` + concurrency caveat:** `rechunk-scratch` is ReadWriteMany, but `--local-cache-dir` localizes to a fixed basename, so **N concurrent pods sharing one mountPath collide on the same file**. Use a per-pod `subPath` (or per-pod cache subdir) for fan-out jobs. The 122-pod raster **hex** step localizes a multi-GB COG per pod and is best left on **per-pod ephemeral** (the mosaic COG fits in 50Gi); reserve the PVC for the **single-pod** `preprocess-cog`/download/stage steps where the file genuinely exceeds 50Gi.
-
-**Hex OOM** → regenerate with `--hex-memory 64Gi` and/or more `--max-completions`, delete failed job, reapply.
-
-**503 SlowDown (S3 throttle)** → transient, retry.
-
-**PMTiles renders blank in MapLibre → wrong `source-layer`.** It's the last path segment of `--dataset`, NOT the GDB/source layer name. For `--dataset padus-4-1/fee`, it's `fee` (not `PADUS4_1Fee`).
-
-**Workflow stuck:** `kubectl logs job/<name>-workflow` and `kubectl get jobs | grep <name>`.
-
-**`exceeded quota: reached-quota`** → pod limit hit. Delete running hex jobs and resubmit sequentially (see Namespace Pod Quota):
-```bash
-kubectl get jobs | grep -E 'dataset-a|dataset-b' | awk '{print $1}' | xargs kubectl delete job
-```
-
-### Reprocessing Failed Chunks
-
-For chunks that fail (e.g. DuckDB parquet page-size limits on complex geometries), reprocess at coarser H3:
-1. Identify failed IDs: `kubectl get pods | grep <name>-hex | grep -E "Error|Failed"`
-2. Copy `<name>-hex.yaml` → `<name>-hex-rechunk.yaml`, rename the job, set `completions: <N-failed>`, and replace the command with a CHUNK_MAP:
-   ```yaml
-   args:
-   - |
-     set -e
-     CHUNK_MAP=(0 1 2 94)
-     CHUNK_ID=${CHUNK_MAP[$JOB_COMPLETION_INDEX]}
-     cng-datasets vector \
-       --input s3://<bucket>/<dataset>.parquet \
-       --output s3://<bucket>/<dataset>/chunks \
-       --chunk-id $CHUNK_ID --chunk-size <same> --intermediate-chunk-size <same> \
-       --resolution 8 --parent-resolutions 9,8,0
-   ```
-3. Apply, then run `<name>-repartition.yaml`. Repartition merges both resolutions from `chunks/` → `hex/` by h0.
-
+Causes and fixes — OOMKilled, evictions, `ContainerStatusUnknown`, flaky-node hangs,
+ephemeral-storage limits and PVC scratch, pod-quota errors, 404s on convert, blank PMTiles in
+MapLibre, DuckDB `stoi` — plus how to reprocess failed chunks: **skill `job-troubleshooting`**.
 ## What NOT To Do
 
 - **Do not process data locally.** CLI generates YAML; the cluster does the work.
@@ -1027,69 +485,8 @@ For chunks that fail (e.g. DuckDB parquet page-size limits on complex geometries
 
 ## Reference Examples
 
-### PAD-US (multi-layer GDB, 5 spatial layers)
-```bash
-# One-time raw upload
-rclone copy PADUS4_1Geodatabase.gdb nrp:public-padus/raw/PADUS4_1Geodatabase.gdb -P
-
-# Generate per-layer workflows
-for args in \
-  "padus-4-1/fee PADUS4_1Fee" \
-  "padus-4-1/easement PADUS4_1Easement" \
-  "padus-4-1/proclamation PADUS4_1Proclamation" \
-  "padus-4-1/marine PADUS4_1Marine" \
-  "padus-4-1/combined PADUS4_1Combined_Proclamation_Marine_Fee_Designation_Easement"; do
-  set -- $args
-  cng-datasets workflow --dataset "$1" \
-    --source-url https://s3-west.nrp-nautilus.io/public-padus/raw/PADUS4_1Geodatabase.gdb \
-    --bucket public-padus --layer "$2" \
-    --h3-resolution 10 --hex-memory 32Gi --max-completions 200 --max-parallelism 50 \
-    --parent-resolutions "9,8,0" \
-    --output-dir "catalog/pad-us/k8s/$(echo $1 | cut -d/ -f2)"
-done
-
-kubectl apply -f catalog/pad-us/k8s/fee/workflow-rbac.yaml   # once
-for layer in fee easement proclamation marine combined; do
-  kubectl apply -f catalog/pad-us/k8s/$layer/configmap.yaml -f catalog/pad-us/k8s/$layer/workflow.yaml
-done
-```
-Non-spatial lookup tables: see `catalog/pad-us/k8s/extract-lookup-tables.yaml` and `catalog/pad-us/lookup-tables.md`.
-
-### Census 2024 (per-state zips → preprocess → pipeline)
-TIGER/Line ships per-state. Discover pattern:
-```bash
-curl -I https://www2.census.gov/geo/tiger/TIGER2024/TRACT/
-curl -s https://www2.census.gov/geo/tiger/TIGER2024/TRACT/ | grep '.zip' | head
-# tl_2024_01_tract.zip, tl_2024_02_tract.zip, ...
-```
-Preprocess job (`catalog/census/k8s/tract/preprocess-tract.yaml`) parallel-downloads, unzips, and calls `cng-convert-to-parquet /tmp/tracts/*.shp s3://...` (tool merges). ~3 min for 56 files. Then:
-```bash
-cng-datasets workflow --dataset census-2024/tract \
-  --source-url s3://public-census/census-2024/tract.parquet --bucket public-census \
-  --h3-resolution 10 --parent-resolutions "9,8,0" \
-  --hex-memory 16Gi --max-completions 200 --max-parallelism 50 \
-  --output-dir catalog/census/k8s/tract
-kubectl apply -f catalog/census/k8s/tract/census-2024-tract-hex.yaml
-kubectl apply -f catalog/census/k8s/tract/census-2024-tract-pmtiles.yaml
-# after hex:
-kubectl apply -f catalog/census/k8s/tract/census-2024-tract-repartition.yaml
-```
-Result: ~85,000 tracts.
-
-### Carbon raster (single COG already on S3)
-```bash
-cng-datasets raster-workflow --dataset irrecoverable-carbon-2022 \
-  --source-url s3://public-carbon/v2/cogs/irrecoverable_c_total_2022.tif \
-  --bucket public-carbon --h3-resolution 8 --parent-resolutions "0" \
-  --value-column carbon --hex-memory 32Gi --max-parallelism 61 \
-  --output-dir catalog/carbon/k8s/v2/irrecoverable-carbon-2022
-
-kubectl apply -f catalog/carbon/k8s/v2/irrecoverable-carbon-2022/workflow-rbac.yaml
-kubectl apply -f catalog/carbon/k8s/v2/irrecoverable-carbon-2022/configmap.yaml \
-              -f catalog/carbon/k8s/v2/irrecoverable-carbon-2022/workflow.yaml
-```
-Hex job runs `cng-datasets raster` once per h0 cell (122 indexed pods), writing `hex/h0={cell}/data_0.parquet`. Empty cells skipped silently. No repartition step — output goes directly to its final partition.
-
+Worked end-to-end ingests to copy from — PAD-US multi-layer GDB (5 spatial layers), Census TIGER
+per-state zips with a preprocess job, and a single-COG carbon raster: **skill `dataset-recipes`**.
 ## Checking for User Dataset Requests
 
 Request form: **https://data-requests.nrp-nautilus.io/** (per-app routes, e.g. `/tpl`). Submissions stored as JSON in `s3://public-requests/dataset-requests/`.


### PR DESCRIPTION
Closes #569.

## The problem

`AGENTS.md` was **1,109 lines / ~24.6k tokens**, and `CLAUDE.md` includes it wholesale — so all of
it was in context for **every** session, including ones that never touch STAC, never hex a raster
and never see a failing job. One subsection (STAC description authoring) was **262 lines: 24% of
the file**, larger than every top-level section except its own parent, and relevant only at Step 5.

AGENTS.md already named `.claude/skills/` as a valid home for this material. The directory had
never been created, so everything accreted into the always-loaded file by default. #566 is the
current instance of that pressure: +77 lines of raster-resolution protocol, correct and
load-bearing, but only relevant when hexing a raster.

## Portability — checked, not assumed

[opencode reads `.claude/skills/<name>/SKILL.md` natively](https://opencode.ai/docs/skills/),
alongside `.opencode/skills/` and a vendor-neutral `.agents/skills/` — same `SKILL.md` format,
same required `name`/`description` frontmatter, same on-demand loading. One copy serves both
tools with no adapter and nothing to drift.

And skills are plain markdown committed to the repo, so a runner with no skill support at all can
still read them; AGENTS.md keeps a pointer index. Nothing became invisible — which matters
because AGENTS.md explicitly anticipates students and headless agents cloning this repo.

## Result

```
AGENTS.md   1,109 -> 507 lines   (~24.6k -> ~8.5k tokens, -66%)
```

| skill | lines | load it when |
|---|---:|---|
| `stac-authoring` | 323 | writing/editing any `stac-collection.json` or README (Steps 5–6) |
| `raster-hexing` | 116 | ingesting or re-hexing a GeoTIFF/COG |
| `job-troubleshooting` | 120 | a job fails or hangs, or a parquet will not read |
| `dataset-recipes` | 110 | starting an ingest resembling a worked example |
| `hex-tuning` | 97 | a hex OOMs, or choosing resolutions and chunk sizes |

**What stays in AGENTS.md is what must hold whether or not a skill loads:** all five hard
boundaries, git workflow, what you produce, the Step 1–7 skeleton, pod-count discipline, S3
layout, what-not-to-do, dataset requests. A skill that doesn't load can't stop you doing something
dangerous, so nothing safety-bearing was moved.

Where a moved rule has a short always-true core, that core stays inline and the full treatment
moves — `h8` is the universal join key; `--row-group-size 2000` for geometry-heavy writes; the two
raster choices (`--h3-resolution`, `--hex-resampling`) that silently corrupt data.

## Verification

- **No content lost.** Of **673** substantive lines (≥35 chars) in the original, **666** appear
  verbatim in the new AGENTS.md or a skill. The other 7 are the intro sentence — deliberately
  rewritten, since "this file tells you everything you need" is no longer true — and six headings
  whose `#` depth changed when re-levelled for their new documents.
- All 5 hard boundaries present (5 before, 5 after).
- Frontmatter valid on all five skills: `name` matches its directory, `description` 354–399 chars
  (well under the 1024 limit).

## One thing worth a look

`.gitignore` had `.claude/*` with allowlist exceptions for `settings.json` and `hooks/`, so the
skills were silently **not committed** on the first pass. Added `!.claude/skills/` — without it
the refactor would have made this content local-only and invisible to exactly the students and
headless runs it is meant to serve.

## Follow-up

#566 should be rebased on this so its resolution table lands in `raster-hexing` rather than
AGENTS.md, and its CHELSA build split out to its own PR against #564 (reviewed in
#566's thread).