### PR TITLE
CHELSA v2.1 pilot: ensemble reduction + res-8 hex recipe (#564)

### DIFF
--- a/catalog/bioclimate/k8s/chelsa/configmap.yaml
+++ b/catalog/bioclimate/k8s/chelsa/configmap.yaml
@@ -1,0 +1,358 @@
+apiVersion: v1
+data:
+  chelsa_ensemble.py: |
+    """CHELSA v2.1 GCM-ensemble reduction -> physical-unit float32 COG (data-workflows #564).
+
+    Reads the N per-GCM rasters for one (variable, ssp, period) triple and writes one COG per
+    requested ensemble quantile, in physical units.
+
+    Design notes (all driven by the measured preflight on #564):
+      * scale/offset and nodata are read FROM EACH FILE (`GetScale`/`GetOffset`/`GetNoDataValue`),
+        never hardcoded -- CHELSA declares different sentinels per variable (bio1/bio4/bio12 use 0,
+        bio15 uses 65535), so a single batch-wide constant would corrupt the output.
+      * a pixel is nodata in the output if it is nodata in ANY member -- the ensemble is only
+        defined where every GCM has a value.
+      * bio12 saturates at the UInt16 ceiling (65535); those pixels are flagged, counted, and
+        reported so the clipping is visible rather than silently averaged.
+      * processed in row blocks so a 43200x20880 x N-member stack never has to fit in RAM.
+    """
+    import argparse
+    import os
+    import sys
+
+    import numpy as np
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+
+    UINT16_CEIL = 65535
+    OUT_NODATA = -9999.0
+
+
+    def main() -> int:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--input", action="append", required=True, help="per-GCM source raster (repeat)")
+        ap.add_argument("--out-prefix", required=True, help="output path prefix; quantile is appended")
+        ap.add_argument("--quantiles", default="10,50,90")
+        ap.add_argument("--block-rows", type=int, default=512)
+        args = ap.parse_args()
+
+        qs = [float(q) for q in args.quantiles.split(",")]
+        srcs = [gdal.Open(p) for p in args.input]
+        n = len(srcs)
+        if n < 2:
+            print("ERROR: need at least 2 members for an ensemble", file=sys.stderr)
+            return 1
+
+        b0 = srcs[0].GetRasterBand(1)
+        xsize, ysize = srcs[0].RasterXSize, srcs[0].RasterYSize
+        scale = b0.GetScale() if b0.GetScale() is not None else 1.0
+        offset = b0.GetOffset() if b0.GetOffset() is not None else 0.0
+        nodata = b0.GetNoDataValue()
+
+        # Every member must share grid, scale/offset and sentinel, or the ensemble is meaningless.
+        for p, ds in zip(args.input, srcs):
+            b = ds.GetRasterBand(1)
+            if (ds.RasterXSize, ds.RasterYSize) != (xsize, ysize):
+                print(f"ERROR: grid mismatch in {p}", file=sys.stderr)
+                return 1
+            s = b.GetScale() if b.GetScale() is not None else 1.0
+            o = b.GetOffset() if b.GetOffset() is not None else 0.0
+            if (s, o) != (scale, offset) or b.GetNoDataValue() != nodata:
+                print(f"ERROR: scale/offset/nodata mismatch in {p}: "
+                      f"{(s, o, b.GetNoDataValue())} != {(scale, offset, nodata)}", file=sys.stderr)
+                return 1
+
+        print(f"members={n} grid={xsize}x{ysize} scale={scale} offset={offset} nodata={nodata}")
+
+        drv = gdal.GetDriverByName("GTiff")
+        opts = ["COMPRESS=ZSTD", "PREDICTOR=3", "TILED=YES", "BIGTIFF=YES"]
+        tmp_paths, outs = [], []
+        for q in qs:
+            tp = f"{args.out_prefix}_p{int(q)}.tmp.tif"
+            ds = drv.Create(tp, xsize, ysize, 1, gdal.GDT_Float32, options=opts)
+            ds.SetGeoTransform(srcs[0].GetGeoTransform())
+            ds.SetProjection(srcs[0].GetProjection())
+            ds.GetRasterBand(1).SetNoDataValue(OUT_NODATA)
+            tmp_paths.append(tp)
+            outs.append(ds)
+
+        n_valid = n_nodata = n_saturated = 0
+        vmin, vmax = np.inf, -np.inf
+
+        for y in range(0, ysize, args.block_rows):
+            rows = min(args.block_rows, ysize - y)
+            stack = np.empty((n, rows, xsize), dtype=np.float64)
+            bad = np.zeros((rows, xsize), dtype=bool)
+            for i, ds in enumerate(srcs):
+                a = ds.GetRasterBand(1).ReadAsArray(0, y, xsize, rows)
+                if nodata is not None:
+                    bad |= (a == nodata)
+                n_saturated += int((a == UINT16_CEIL).sum())
+                stack[i] = a
+
+            vals = np.percentile(stack, qs, axis=0)          # (len(qs), rows, xsize)
+            vals = vals * scale + offset                      # -> physical units
+
+            n_valid += int((~bad).sum())
+            n_nodata += int(bad.sum())
+            if (~bad).any():
+                vmin = min(vmin, float(vals[:, ~bad].min()))
+                vmax = max(vmax, float(vals[:, ~bad].max()))
+
+            for k, ds in enumerate(outs):
+                band = vals[k]
+                band[bad] = OUT_NODATA
+                ds.GetRasterBand(1).WriteArray(band.astype(np.float32), 0, y)
+            print(f"  rows {y}-{y + rows} done", flush=True)
+
+        for ds in outs:
+            ds.FlushCache()
+        outs = None
+
+        # Rewrite as proper COGs.
+        for tp, q in zip(tmp_paths, qs):
+            final = f"{args.out_prefix}_p{int(q)}.tif"
+            print(f"COG -> {final}")
+            gdal.Translate(final, tp, format="COG",
+                           creationOptions=["COMPRESS=ZSTD", "PREDICTOR=3",
+                                            "OVERVIEWS=IGNORE_EXISTING", "BIGTIFF=YES"])
+            os.remove(tp)
+
+        total = n_valid + n_nodata
+        print(f"MEASURED valid={n_valid} nodata={n_nodata} "
+              f"({100.0 * n_valid / total:.4f}% valid)")
+        print(f"MEASURED physical range: min={vmin:.4f} max={vmax:.4f}")
+        print(f"MEASURED source pixels at UInt16 ceiling ({UINT16_CEIL}) across all members: {n_saturated}")
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+  chelsa_h0_for_index.py: |
+    """Resolve a cng-datasets h0 *index* (0-121) to its h0 *cell id* (data-workflows #564).
+
+    `cng-datasets raster --h0-index N` looks N up in the h0 grid parquet by its `i` column. Doing
+    the same lookup up front lets a job decide whether an h0 holds any land *before* paying to hex
+    it: only 108 of the 122 h0 cells intersect the WWF ecoregions land mask, so the remaining 14
+    would otherwise hex every ensemble member and then discard the result.
+    """
+    import argparse
+    import sys
+
+    import duckdb
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--grid", required=True, help="local path to the h0 grid parquet")
+    ap.add_argument("--index", type=int, required=True)
+    args = ap.parse_args()
+
+    row = duckdb.connect().execute(
+        "SELECT h0 FROM read_parquet(?) WHERE i = ?", [args.grid, args.index]
+    ).fetchone()
+
+    if row is None:
+        print(f"ERROR: no h0 cell for index {args.index}", file=sys.stderr)
+        sys.exit(1)
+
+    print(row[0])
+  chelsa_join_mask.py: |
+    """Join the per-GCM hex partitions for one h0, apply units + land mask (data-workflows #564).
+
+    Each ensemble member is hexed separately by `cng-datasets raster` into
+    `<hex-root>/<member>/h0=<cell>/data_0.parquet`. They share a grid, resolution and h0, so they
+    share an h8 key -- this joins them into one wide row per cell.
+
+    Three things happen here that cannot happen earlier:
+
+    1. **Units are ALREADY PHYSICAL -- do not transform them here.** `cng-datasets` hands the raster
+       *path* to `exactextract`, whose GDAL source applies the GeoTIFF scale/offset, so hex values
+       arrive in degrees C / mm, not raw integers. Measured on the Amazon h0: min 1.51, max 30.15,
+       mean 27.32 (degrees C). Applying the transform again yielded ~-273, which the plausibility
+       bound below caught.
+
+       Note the contrast with `chelsa_ensemble.py`, which reads via `gdal.Band.ReadAsArray` --
+       that path does NOT apply scale/offset, so the explicit transform there is correct. The two
+       files legitimately differ; do not "fix" one to match the other.
+
+    2. **Ensemble statistics.** All five member values are kept as columns; the upstream product
+       ships per-GCM files and no ensemble product, so the members are the faithful representation.
+       `median`/`min`/`max` are materialised alongside them because a five-member ensemble is
+       summarised by its median and full range (percentiles need a larger ensemble), and because
+       these are the expressions a consumer is most likely to get wrong across five columns.
+
+    3. **Land mask.** WWF Terrestrial Ecoregions h8 hex -- chosen over Overture countries, which is
+       a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica.
+
+    Exit 3 means "nothing survived the mask" -- the caller treats that as a skip, not a failure.
+    """
+    import argparse
+    import glob
+    import sys
+
+    import duckdb
+
+
+    def part(hex_root: str, member_col: str, h0: str) -> str:
+        hits = glob.glob(f"{hex_root}/{member_col}/h0={h0}/data_0.parquet")
+        if not hits:
+            raise SystemExit(f"ERROR: missing hex partition for member {member_col} h0={h0}")
+        return hits[0]
+
+
+    def main() -> int:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--h0", required=True)
+        ap.add_argument("--var", required=True, help="variable prefix, e.g. bio1")
+        ap.add_argument("--members", required=True,
+                        help="comma-separated member column suffixes, e.g. gfdl_esm4,ipsl_cm6a_lr,...")
+        ap.add_argument("--hex-root", required=True)
+        ap.add_argument("--mask", required=True)
+        ap.add_argument("--out", required=True)
+        ap.add_argument("--sane-min", type=float, default=None,
+                        help="fail if any physical value falls below this")
+        ap.add_argument("--sane-max", type=float, default=None,
+                        help="fail if any physical value rises above this")
+        args = ap.parse_args()
+
+        members = [m.strip() for m in args.members.split(",") if m.strip()]
+        if len(members) < 2:
+            print("ERROR: need at least 2 ensemble members", file=sys.stderr)
+            return 1
+
+        var = args.var
+        con = duckdb.connect()
+        paths = {m: part(args.hex_root, f"{var}_{m}", args.h0) for m in members}
+
+        counts = {m: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
+                  for m, p in paths.items()}
+        print(f"rows per member: {counts}")
+        if len(set(counts.values())) != 1:
+            print("WARNING: member partitions differ in row count; join keeps the intersection")
+
+        base = members[0]
+        # Values are already in physical units (see module docstring) -- pass them straight through.
+        phys = [f"{m}t.{var}_{m}" for m in members]
+        sel_members = ", ".join(f"{e} AS {var}_{m}" for e, m in zip(phys, members))
+        arr = "[" + ", ".join(phys) + "]"
+
+        joins = " ".join(
+            f"JOIN read_parquet('{paths[m]}') {m}t ON {m}t.h8 = {base}t.h8"
+            for m in members if m != base
+        )
+
+        con.execute(f"""
+            COPY (
+                SELECT {base}t.h8, {base}t.h5, {base}t.h4, {base}t.h0,
+                       {sel_members},
+                       list_sort({arr})[{(len(members) + 1) // 2}] AS {var}_median,
+                       list_min({arr})  AS {var}_min,
+                       list_max({arr})  AS {var}_max
+                FROM read_parquet('{paths[base]}') {base}t
+                {joins}
+                SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) msk
+                  ON {base}t.h8 = msk.h8
+            ) TO '{args.out}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+        """)
+
+        after = con.execute(f"SELECT COUNT(*) FROM read_parquet('{args.out}')").fetchone()[0]
+        before = counts[base]
+        print(f"MASK h0={args.h0} rows_before={before} rows_after={after} "
+              f"kept={100.0 * after / before if before else 0:.2f}%")
+        if after == 0:
+            print("EMPTY after land mask")
+            return 3
+
+        lo, hi, nulls = con.execute(f"""
+            SELECT MIN({var}_min), MAX({var}_max),
+                   COUNT(*) FILTER (WHERE {var}_median IS NULL)
+            FROM read_parquet('{args.out}')
+        """).fetchone()
+        print(f"MEASURED {var} physical range: min={lo} max={hi} median_nulls={nulls}")
+
+        # median must lie within [min, max] for every cell -- catches a broken ensemble reduce.
+        bad = con.execute(f"""
+            SELECT COUNT(*) FROM read_parquet('{args.out}')
+            WHERE {var}_median < {var}_min OR {var}_median > {var}_max
+        """).fetchone()[0]
+        print(f"CHECK median-outside-range violations: {bad}")
+        if bad:
+            print("ERROR: ensemble median falls outside the member range", file=sys.stderr)
+            return 4
+
+        # Plausibility bound -- catches a wrong scale/offset, which is otherwise invisible.
+        if args.sane_min is not None and lo is not None and lo < args.sane_min:
+            print(f"ERROR: min {lo} below sane bound {args.sane_min}", file=sys.stderr)
+            return 5
+        if args.sane_max is not None and hi is not None and hi > args.sane_max:
+            print(f"ERROR: max {hi} above sane bound {args.sane_max}", file=sys.stderr)
+            return 5
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+  chelsa_read_meta.py: |
+    """Print scale, offset and nodata for a CHELSA raster (data-workflows #564).
+
+    CHELSA declares these per file and they differ per variable -- bio1/bio4/bio12 use nodata 0
+    while bio15 uses 65535, and bio1 carries offset -273.15 where the others carry 0. The build
+    reads them from the file rather than carrying a table, so a new variable cannot silently
+    inherit the wrong sentinel.
+
+    Emits one shell-eval-able line: SCALE=<f> OFFSET=<f> NODATA=<v>
+    (NODATA is empty when the source declares none.)
+    """
+    import argparse
+    import sys
+
+    from osgeo import gdal
+
+    gdal.UseExceptions()
+
+
+    def fmt_nodata(v):
+        if v is None:
+            return ""
+        # GDAL returns a float; emit an integer when the sentinel is integral so the value
+        # round-trips into `cng-datasets --nodata` as e.g. "0", never "0.0".
+        return str(int(v)) if float(v).is_integer() else repr(v)
+
+
+    def main() -> int:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--input", required=True)
+        args = ap.parse_args()
+
+        # Hold the Dataset for the lifetime of the band: chaining
+        # `gdal.Open(p).GetRasterBand(1)` lets the Dataset be garbage-collected and leaves the
+        # band dangling, which surfaces as a TypeError inside the SWIG shim rather than as a
+        # clean failure.
+        ds = gdal.Open(args.input)
+        if ds is None:
+            print(f"ERROR: could not open {args.input}", file=sys.stderr)
+            return 1
+        band = ds.GetRasterBand(1)
+        if band is None:
+            print(f"ERROR: no band 1 in {args.input}", file=sys.stderr)
+            return 1
+
+        scale = band.GetScale()
+        offset = band.GetOffset()
+        nodata = band.GetNoDataValue()
+
+        print(f"SCALE={1.0 if scale is None else scale} "
+              f"OFFSET={0.0 if offset is None else offset} "
+              f"NODATA={fmt_nodata(nodata)}")
+        del band
+        del ds
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+kind: ConfigMap
+metadata:
+  name: chelsa-scripts
+  namespace: geo-workflows

--- a/catalog/bioclimate/k8s/chelsa/pilot-ensemble.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-ensemble.yaml
@@ -1,0 +1,77 @@
+# PILOT (data-workflows #564): bio1, ssp370, 2041-2070 -> p10/p50/p90 physical-unit COGs.
+# One pod: reads the 5 GCM members from s3://public-bioclimate/raw/, reduces, uploads 3 COGs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chelsa-pilot-ensemble
+  namespace: geo-workflows
+  labels: {k8s-app: chelsa-pilot-ensemble}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: chelsa-pilot-ensemble}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+              - {key: kubernetes.io/hostname, operator: NotIn, values: [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org]}
+      containers:
+      - name: ensemble
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,           value: /usr/share/gdal}
+        - {name: PYTHONPATH,          value: /usr/lib/python3/dist-packages}
+        - {name: GDAL_CACHEMAX,       value: '2048'}
+        - {name: VAR,                 value: '1'}
+        - {name: SSP,                 value: ssp370}
+        - {name: PERIOD,              value: 2041-2070}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: scripts, mountPath: /opt/scripts, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          GCMS="GFDL-ESM4 IPSL-CM6A-LR MPI-ESM1-2-HR MRI-ESM2-0 UKESM1-0-LL"
+          mkdir -p /tmp/in /tmp/out && cd /tmp/in
+          ARGS=""
+          for G in $GCMS; do
+            GL=$(echo "$G" | tr 'A-Z' 'a-z')
+            F="CHELSA_bio${VAR}_${PERIOD}_${GL}_${SSP}_V.2.1.tif"
+            echo "localizing $G/$F"
+            rclone copyto "nrp:public-bioclimate/raw/chelsa-2-1/${PERIOD}/${G}/${SSP}/${F}" "/tmp/in/${G}.tif" \
+              --retries 5 --low-level-retries 20 --retries-sleep 10s
+            ARGS="$ARGS --input /tmp/in/${G}.tif"
+          done
+          ls -la /tmp/in
+          python3 /opt/scripts/chelsa_ensemble.py $ARGS \
+            --out-prefix "/tmp/out/bio${VAR}_${SSP}_${PERIOD}" --quantiles 10,50,90
+          ls -la /tmp/out
+          for q in 10 50 90; do
+            SRC="/tmp/out/bio${VAR}_${SSP}_${PERIOD}_p${q}.tif"
+            DST="nrp:public-bioclimate/chelsa-2-1/${SSP}-${PERIOD}/bio${VAR}-median-cog.tif"
+            echo "uploading -> $DST"
+            rclone copyto "$SRC" "$DST" -P --retries 5 --low-level-retries 20 --retries-sleep 10s
+          done
+          echo "PILOT ENSEMBLE COMPLETE"
+        resources:
+          requests: {cpu: '4', memory: 32Gi, ephemeral-storage: 40Gi}
+          limits:   {cpu: '4', memory: 32Gi, ephemeral-storage: 40Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: scripts, configMap: {name: chelsa-scripts}}

--- a/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
+++ b/catalog/bioclimate/k8s/chelsa/pilot-hex.yaml
@@ -1,0 +1,159 @@
+# PILOT hex (data-workflows #564): bio1, ssp370, 2041-2070 -> one wide hex, res 8, parents 5,4,0.
+#
+# 122 completions = one pod per h0. Each pod hexes all FIVE GCM members straight from the staged
+# raw rasters and joins them locally on h8, producing the wide hex directly -- no per-member COG
+# and no cross-pod merge.
+#
+# Columns per cell: the five members (upstream-faithful; CHELSA ships per-GCM files and no
+# ensemble product) plus median/min/max. A five-member ensemble is summarised by its median and
+# full range; percentiles need a larger ensemble to mean anything.
+#
+# Units: values arrive ALREADY IN PHYSICAL UNITS and must NOT be transformed again. cng-datasets
+# hands the raster path to exactextract, whose GDAL source applies the GeoTIFF scale/offset, so
+# the hex holds degrees C / mm, not raw integers. Measured on the Amazon h0 at res 5:
+# min 1.51, max 30.15, mean 27.32 -- plainly degrees C. Re-applying the transform yielded
+# -273.5 .. -269.9. A double-scaled column passes every structural check (row counts, coverage,
+# NULL counts, median-within-range), so only the physical plausibility bound below catches it.
+# See skill `raster-hexing`. NOTE: gdal.Band.ReadAsArray does NOT apply scale/offset -- the
+# ensemble script uses that path and applies the transform explicitly. The two differ on purpose.
+#
+# Land mask: CHELSA is a full-globe surface (VALID_PERCENT 99.999, real values over ocean), so
+# the joined partition is semi-joined against the WWF Terrestrial Ecoregions h8 hex. An h0 with
+# no ecoregion partition is all-ocean and writes nothing (no empty partitions).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chelsa-pilot-hex
+  namespace: geo-workflows
+  labels: {k8s-app: chelsa-pilot-hex}
+spec:
+  completions: 122
+  parallelism: 24
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 15
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: chelsa-pilot-hex}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+              - {key: kubernetes.io/hostname, operator: NotIn, values: [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org]}
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: GDAL_DATA,           value: /usr/share/gdal}
+        - {name: PYTHONPATH,          value: /usr/lib/python3/dist-packages}
+        - {name: CNG_HEX_WORKERS,     value: '8'}
+        - {name: VAR,                 value: bio1}
+        - {name: SSP,                 value: ssp370}
+        - {name: PERIOD,              value: 2041-2070}
+        # Plausibility bounds for annual mean temperature in degrees C. A wrong scale/offset is
+        # otherwise invisible -- raw integers look like perfectly ordinary numbers.
+        - {name: SANE_MIN,            value: '-95'}
+        - {name: SANE_MAX,            value: '60'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: scripts, mountPath: /opt/scripts, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          GCMS=(GFDL-ESM4 IPSL-CM6A-LR MPI-ESM1-2-HR MRI-ESM2-0 UKESM1-0-LL)
+          COLS=(gfdl_esm4 ipsl_cm6a_lr mpi_esm1_2_hr mri_esm2_0 ukesm1_0_ll)
+          H0IDX=${JOB_COMPLETION_INDEX}
+          RAW="public-bioclimate/raw/chelsa-2-1/${PERIOD}"
+          rm -rf /tmp/hex /tmp/mask /tmp/cache && mkdir -p /tmp/hex /tmp/mask /tmp/cache
+          echo "=== h0-index ${H0IDX}, ${VAR} ${SSP} ${PERIOD} ==="
+
+          # scale/offset/nodata read FROM THE FILE -- they differ per variable upstream.
+          FIRST_GL=$(echo "${GCMS[0]}" | tr 'A-Z' 'a-z')
+          META_URL="/vsicurl/https://${AWS_PUBLIC_ENDPOINT}/${RAW}/${GCMS[0]}/${SSP}/CHELSA_${VAR}_${PERIOD}_${FIRST_GL}_${SSP}_V.2.1.tif"
+          META=$(python3 /opt/scripts/chelsa_read_meta.py --input "$META_URL")
+          echo "source metadata: $META"
+          eval "$META"
+          # SCALE/OFFSET are informational only: exactextract applies them when cng-datasets
+          # reads the raster, so hex values arrive already in physical units. NODATA is the
+          # value actually used below.
+          NODATA_ARG=""
+          if [ -n "${NODATA:-}" ]; then NODATA_ARG="--nodata ${NODATA}"; fi
+
+          # Skip an all-ocean h0 BEFORE hexing: resolve the index to its h0 cell and look for a
+          # land partition. Only 108 of 122 h0 cells intersect the land mask, so this avoids
+          # hexing five members for a result that would be discarded.
+          rclone copyto nrp:public-grids/hex/h0-valid.parquet /tmp/h0grid.parquet \
+            --retries 5 --low-level-retries 20 --retries-sleep 10s
+          H0=$(python3 /opt/scripts/chelsa_h0_for_index.py --grid /tmp/h0grid.parquet --index ${H0IDX})
+          echo "h0-index ${H0IDX} -> h0 cell ${H0}"
+          # NOTE: `rclone copyto` exits 0 when the source does not exist, so its exit code
+          # cannot be used to detect a missing partition — test for the file itself.
+          rclone copyto "nrp:public-ecoregion/ecoregion/hex/h0=${H0}/data_0.parquet" \
+            /tmp/mask/eco.parquet --retries 5 --low-level-retries 20 --retries-sleep 10s 2>/dev/null || true
+          if [ ! -s /tmp/mask/eco.parquet ]; then
+            echo "no ecoregion (land) partition for h0=${H0} — all-ocean, skipping before hexing"
+            exit 0
+          fi
+          echo "land mask for h0=${H0}: $(stat -c %s /tmp/mask/eco.parquet) bytes"
+
+          for i in 0 1 2 3 4; do
+            G=${GCMS[$i]}; C=${COLS[$i]}
+            GL=$(echo "$G" | tr 'A-Z' 'a-z')
+            echo "--- hexing member $G -> ${VAR}_${C}"
+            cng-datasets raster \
+              --input "s3://${RAW}/${G}/${SSP}/CHELSA_${VAR}_${PERIOD}_${GL}_${SSP}_V.2.1.tif" \
+              --output-parquet "/tmp/hex/${VAR}_${C}" \
+              --h0-index ${H0IDX} \
+              --resolution 8 --parent-resolutions 5,4,0 \
+              --value-column "${VAR}_${C}" \
+              --hex-resampling mean \
+              ${NODATA_ARG} \
+              --local-cache-dir /tmp/cache
+          done
+
+          PART=$(ls -d /tmp/hex/${VAR}_${COLS[0]}/h0=* 2>/dev/null | head -1 || true)
+          if [ -z "$PART" ]; then
+            echo "no hex output for h0-index ${H0IDX} — raster does not cover it, nothing to do"
+            exit 0
+          fi
+          H0_OUT=$(basename "$PART" | sed 's/^h0=//')
+          if [ "$H0_OUT" != "$H0" ]; then
+            echo "ERROR: hex wrote h0=${H0_OUT} but the grid says index ${H0IDX} is h0=${H0}" >&2
+            exit 1
+          fi
+
+          MEMBER_LIST=$(IFS=,; echo "${COLS[*]}")
+          set +e
+          python3 /opt/scripts/chelsa_join_mask.py \
+            --h0 "${H0}" --var "${VAR}" --members "${MEMBER_LIST}" \
+            --hex-root /tmp/hex --mask /tmp/mask/eco.parquet --out /tmp/final.parquet \
+            --sane-min "${SANE_MIN}" --sane-max "${SANE_MAX}"
+          rc=$?
+          set -e
+          if [ "$rc" -eq 3 ]; then echo "empty after land mask — skipping h0=${H0}"; exit 0; fi
+          if [ "$rc" -ne 0 ]; then echo "join/mask failed rc=${rc}"; exit "$rc"; fi
+
+          rclone copyto /tmp/final.parquet \
+            "nrp:public-bioclimate/chelsa-2-1/${SSP}-${PERIOD}/hex/h0=${H0}/data_0.parquet" \
+            --retries 5 --low-level-retries 20 --retries-sleep 10s
+          echo "h0=${H0} complete"
+        resources:
+          requests: {cpu: '8', memory: 64Gi, ephemeral-storage: 45Gi}
+          limits:   {cpu: '8', memory: 64Gi, ephemeral-storage: 45Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: scripts, configMap: {name: chelsa-scripts}}

--- a/catalog/bioclimate/k8s/chelsa/setup-bucket.yaml
+++ b/catalog/bioclimate/k8s/chelsa/setup-bucket.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bioclimate-setup-bucket
+  namespace: geo-workflows
+  labels: {k8s-app: bioclimate-setup-bucket}
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata: {labels: {k8s-app: bioclimate-setup-bucket}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - {matchExpressions: [{key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}]}
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_PUBLIC_ENDPOINT, value: s3-west.nrp-nautilus.io}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        - {name: BUCKET,              value: public-bioclimate}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets storage setup-bucket --bucket "${BUCKET}" --remote nrp --verify
+          echo "Bucket setup complete"
+        resources:
+          requests: {cpu: '1', memory: 2Gi}
+          limits:   {cpu: '1', memory: 2Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/bioclimate/k8s/chelsa/stage-raw.yaml
+++ b/catalog/bioclimate/k8s/chelsa/stage-raw.yaml
@@ -1,0 +1,80 @@
+# Stage all CHELSA v2.1 bioclim source rasters to s3://public-bioclimate/raw/ (data-workflows #564).
+# 322 files = 7 vars x (5 GCM x 3 ssp x 3 period) futures + 7 baseline, ~92.5 GB.
+# Index maps to one (period, GCM, ssp) triple = 7 files; index 45 is the 1981-2010 baseline.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chelsa-stage-raw
+  namespace: geo-workflows
+  labels: {k8s-app: chelsa-stage-raw}
+spec:
+  completions: 46           # 45 future triples (3 periods x 5 GCMs x 3 ssps) + 1 baseline
+  parallelism: 10
+  completionMode: Indexed
+  backoffLimitPerIndex: 3
+  maxFailedIndexes: 6
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata: {labels: {k8s-app: chelsa-stage-raw}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - {key: feature.node.kubernetes.io/pci-10de.present, operator: NotIn, values: ['true']}
+              - {key: kubernetes.io/hostname, operator: NotIn, values: [hpc-nrp-g1.nmsu.edu, service-02.nrp.mghpcc.org]}
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_ACCESS_KEY_ID,     valueFrom: {secretKeyRef: {name: aws, key: AWS_ACCESS_KEY_ID}}}
+        - {name: AWS_SECRET_ACCESS_KEY, valueFrom: {secretKeyRef: {name: aws, key: AWS_SECRET_ACCESS_KEY}}}
+        - {name: AWS_S3_ENDPOINT,     value: rook-ceph-rgw-nautiluss3.rook}
+        - {name: AWS_HTTPS,           value: 'false'}
+        - {name: AWS_VIRTUAL_HOSTING, value: 'FALSE'}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          U=https://os.zhdk.cloud.switch.ch/chelsav2/GLOBAL/climatologies
+          VARS="1 4 5 6 12 15 17"
+          PERIODS=(2011-2040 2041-2070 2071-2100)
+          GCMS=(GFDL-ESM4 IPSL-CM6A-LR MPI-ESM1-2-HR MRI-ESM2-0 UKESM1-0-LL)
+          SSPS=(ssp126 ssp370 ssp585)
+          IDX=${JOB_COMPLETION_INDEX}
+          mkdir -p /tmp/stage && cd /tmp/stage
+          if [ "$IDX" -eq 45 ]; then
+            echo "=== baseline 1981-2010 ==="
+            for v in $VARS; do
+              f="CHELSA_bio${v}_1981-2010_V.2.1.tif"
+              echo "-> $f"
+              curl -sS --fail --retry 5 --retry-delay 10 -o "$f" "$U/1981-2010/bio/$f"
+            done
+            rclone copy /tmp/stage nrp:public-bioclimate/raw/chelsa-2-1/1981-2010/ \
+              -P --retries 5 --low-level-retries 20 --retries-sleep 10s
+          else
+            PI=$(( IDX / 15 )); R=$(( IDX % 15 )); GI=$(( R / 3 )); SI=$(( R % 3 ))
+            P=${PERIODS[$PI]}; G=${GCMS[$GI]}; S=${SSPS[$SI]}
+            GL=$(echo "$G" | tr 'A-Z' 'a-z')
+            echo "=== idx $IDX -> period=$P gcm=$G ssp=$S ==="
+            for v in $VARS; do
+              f="CHELSA_bio${v}_${P}_${GL}_${S}_V.2.1.tif"
+              echo "-> $f"
+              curl -sS --fail --retry 5 --retry-delay 10 -o "$f" "$U/$P/$G/$S/bio/$f"
+            done
+            rclone copy /tmp/stage "nrp:public-bioclimate/raw/chelsa-2-1/${P}/${G}/${S}/" \
+              -P --retries 5 --low-level-retries 20 --retries-sleep 10s
+          fi
+          echo "index $IDX staged OK"
+        resources:
+          requests: {cpu: '2', memory: 4Gi, ephemeral-storage: 20Gi}
+          limits:   {cpu: '2', memory: 4Gi, ephemeral-storage: 20Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/bioclimate/scripts/chelsa_ensemble.py
+++ b/catalog/bioclimate/scripts/chelsa_ensemble.py
@@ -1,0 +1,128 @@
+"""CHELSA v2.1 GCM-ensemble reduction -> physical-unit float32 COG (data-workflows #564).
+
+Reads the N per-GCM rasters for one (variable, ssp, period) triple and writes one COG per
+requested ensemble quantile, in physical units.
+
+Design notes (all driven by the measured preflight on #564):
+  * scale/offset and nodata are read FROM EACH FILE (`GetScale`/`GetOffset`/`GetNoDataValue`),
+    never hardcoded -- CHELSA declares different sentinels per variable (bio1/bio4/bio12 use 0,
+    bio15 uses 65535), so a single batch-wide constant would corrupt the output.
+  * a pixel is nodata in the output if it is nodata in ANY member -- the ensemble is only
+    defined where every GCM has a value.
+  * bio12 saturates at the UInt16 ceiling (65535); those pixels are flagged, counted, and
+    reported so the clipping is visible rather than silently averaged.
+  * processed in row blocks so a 43200x20880 x N-member stack never has to fit in RAM.
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+from osgeo import gdal
+
+gdal.UseExceptions()
+
+UINT16_CEIL = 65535
+OUT_NODATA = -9999.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", action="append", required=True, help="per-GCM source raster (repeat)")
+    ap.add_argument("--out-prefix", required=True, help="output path prefix; quantile is appended")
+    ap.add_argument("--quantiles", default="10,50,90")
+    ap.add_argument("--block-rows", type=int, default=512)
+    args = ap.parse_args()
+
+    qs = [float(q) for q in args.quantiles.split(",")]
+    srcs = [gdal.Open(p) for p in args.input]
+    n = len(srcs)
+    if n < 2:
+        print("ERROR: need at least 2 members for an ensemble", file=sys.stderr)
+        return 1
+
+    b0 = srcs[0].GetRasterBand(1)
+    xsize, ysize = srcs[0].RasterXSize, srcs[0].RasterYSize
+    scale = b0.GetScale() if b0.GetScale() is not None else 1.0
+    offset = b0.GetOffset() if b0.GetOffset() is not None else 0.0
+    nodata = b0.GetNoDataValue()
+
+    # Every member must share grid, scale/offset and sentinel, or the ensemble is meaningless.
+    for p, ds in zip(args.input, srcs):
+        b = ds.GetRasterBand(1)
+        if (ds.RasterXSize, ds.RasterYSize) != (xsize, ysize):
+            print(f"ERROR: grid mismatch in {p}", file=sys.stderr)
+            return 1
+        s = b.GetScale() if b.GetScale() is not None else 1.0
+        o = b.GetOffset() if b.GetOffset() is not None else 0.0
+        if (s, o) != (scale, offset) or b.GetNoDataValue() != nodata:
+            print(f"ERROR: scale/offset/nodata mismatch in {p}: "
+                  f"{(s, o, b.GetNoDataValue())} != {(scale, offset, nodata)}", file=sys.stderr)
+            return 1
+
+    print(f"members={n} grid={xsize}x{ysize} scale={scale} offset={offset} nodata={nodata}")
+
+    drv = gdal.GetDriverByName("GTiff")
+    opts = ["COMPRESS=ZSTD", "PREDICTOR=3", "TILED=YES", "BIGTIFF=YES"]
+    tmp_paths, outs = [], []
+    for q in qs:
+        tp = f"{args.out_prefix}_p{int(q)}.tmp.tif"
+        ds = drv.Create(tp, xsize, ysize, 1, gdal.GDT_Float32, options=opts)
+        ds.SetGeoTransform(srcs[0].GetGeoTransform())
+        ds.SetProjection(srcs[0].GetProjection())
+        ds.GetRasterBand(1).SetNoDataValue(OUT_NODATA)
+        tmp_paths.append(tp)
+        outs.append(ds)
+
+    n_valid = n_nodata = n_saturated = 0
+    vmin, vmax = np.inf, -np.inf
+
+    for y in range(0, ysize, args.block_rows):
+        rows = min(args.block_rows, ysize - y)
+        stack = np.empty((n, rows, xsize), dtype=np.float64)
+        bad = np.zeros((rows, xsize), dtype=bool)
+        for i, ds in enumerate(srcs):
+            a = ds.GetRasterBand(1).ReadAsArray(0, y, xsize, rows)
+            if nodata is not None:
+                bad |= (a == nodata)
+            n_saturated += int((a == UINT16_CEIL).sum())
+            stack[i] = a
+
+        vals = np.percentile(stack, qs, axis=0)          # (len(qs), rows, xsize)
+        vals = vals * scale + offset                      # -> physical units
+
+        n_valid += int((~bad).sum())
+        n_nodata += int(bad.sum())
+        if (~bad).any():
+            vmin = min(vmin, float(vals[:, ~bad].min()))
+            vmax = max(vmax, float(vals[:, ~bad].max()))
+
+        for k, ds in enumerate(outs):
+            band = vals[k]
+            band[bad] = OUT_NODATA
+            ds.GetRasterBand(1).WriteArray(band.astype(np.float32), 0, y)
+        print(f"  rows {y}-{y + rows} done", flush=True)
+
+    for ds in outs:
+        ds.FlushCache()
+    outs = None
+
+    # Rewrite as proper COGs.
+    for tp, q in zip(tmp_paths, qs):
+        final = f"{args.out_prefix}_p{int(q)}.tif"
+        print(f"COG -> {final}")
+        gdal.Translate(final, tp, format="COG",
+                       creationOptions=["COMPRESS=ZSTD", "PREDICTOR=3",
+                                        "OVERVIEWS=IGNORE_EXISTING", "BIGTIFF=YES"])
+        os.remove(tp)
+
+    total = n_valid + n_nodata
+    print(f"MEASURED valid={n_valid} nodata={n_nodata} "
+          f"({100.0 * n_valid / total:.4f}% valid)")
+    print(f"MEASURED physical range: min={vmin:.4f} max={vmax:.4f}")
+    print(f"MEASURED source pixels at UInt16 ceiling ({UINT16_CEIL}) across all members: {n_saturated}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/catalog/bioclimate/scripts/chelsa_h0_for_index.py
+++ b/catalog/bioclimate/scripts/chelsa_h0_for_index.py
@@ -1,0 +1,26 @@
+"""Resolve a cng-datasets h0 *index* (0-121) to its h0 *cell id* (data-workflows #564).
+
+`cng-datasets raster --h0-index N` looks N up in the h0 grid parquet by its `i` column. Doing
+the same lookup up front lets a job decide whether an h0 holds any land *before* paying to hex
+it: only 108 of the 122 h0 cells intersect the WWF ecoregions land mask, so the remaining 14
+would otherwise hex every ensemble member and then discard the result.
+"""
+import argparse
+import sys
+
+import duckdb
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--grid", required=True, help="local path to the h0 grid parquet")
+ap.add_argument("--index", type=int, required=True)
+args = ap.parse_args()
+
+row = duckdb.connect().execute(
+    "SELECT h0 FROM read_parquet(?) WHERE i = ?", [args.grid, args.index]
+).fetchone()
+
+if row is None:
+    print(f"ERROR: no h0 cell for index {args.index}", file=sys.stderr)
+    sys.exit(1)
+
+print(row[0])

--- a/catalog/bioclimate/scripts/chelsa_join_mask.py
+++ b/catalog/bioclimate/scripts/chelsa_join_mask.py
@@ -1,0 +1,136 @@
+"""Join the per-GCM hex partitions for one h0, apply units + land mask (data-workflows #564).
+
+Each ensemble member is hexed separately by `cng-datasets raster` into
+`<hex-root>/<member>/h0=<cell>/data_0.parquet`. They share a grid, resolution and h0, so they
+share an h8 key -- this joins them into one wide row per cell.
+
+Three things happen here that cannot happen earlier:
+
+1. **Units are ALREADY PHYSICAL -- do not transform them here.** `cng-datasets` hands the raster
+   *path* to `exactextract`, whose GDAL source applies the GeoTIFF scale/offset, so hex values
+   arrive in degrees C / mm, not raw integers. Measured on the Amazon h0: min 1.51, max 30.15,
+   mean 27.32 (degrees C). Applying the transform again yielded ~-273, which the plausibility
+   bound below caught.
+
+   Note the contrast with `chelsa_ensemble.py`, which reads via `gdal.Band.ReadAsArray` --
+   that path does NOT apply scale/offset, so the explicit transform there is correct. The two
+   files legitimately differ; do not "fix" one to match the other.
+
+2. **Ensemble statistics.** All five member values are kept as columns; the upstream product
+   ships per-GCM files and no ensemble product, so the members are the faithful representation.
+   `median`/`min`/`max` are materialised alongside them because a five-member ensemble is
+   summarised by its median and full range (percentiles need a larger ensemble), and because
+   these are the expressions a consumer is most likely to get wrong across five columns.
+
+3. **Land mask.** WWF Terrestrial Ecoregions h8 hex -- chosen over Overture countries, which is
+   a sovereignty boundary that includes territorial and archipelagic waters and omits Antarctica.
+
+Exit 3 means "nothing survived the mask" -- the caller treats that as a skip, not a failure.
+"""
+import argparse
+import glob
+import sys
+
+import duckdb
+
+
+def part(hex_root: str, member_col: str, h0: str) -> str:
+    hits = glob.glob(f"{hex_root}/{member_col}/h0={h0}/data_0.parquet")
+    if not hits:
+        raise SystemExit(f"ERROR: missing hex partition for member {member_col} h0={h0}")
+    return hits[0]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--h0", required=True)
+    ap.add_argument("--var", required=True, help="variable prefix, e.g. bio1")
+    ap.add_argument("--members", required=True,
+                    help="comma-separated member column suffixes, e.g. gfdl_esm4,ipsl_cm6a_lr,...")
+    ap.add_argument("--hex-root", required=True)
+    ap.add_argument("--mask", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--sane-min", type=float, default=None,
+                    help="fail if any physical value falls below this")
+    ap.add_argument("--sane-max", type=float, default=None,
+                    help="fail if any physical value rises above this")
+    args = ap.parse_args()
+
+    members = [m.strip() for m in args.members.split(",") if m.strip()]
+    if len(members) < 2:
+        print("ERROR: need at least 2 ensemble members", file=sys.stderr)
+        return 1
+
+    var = args.var
+    con = duckdb.connect()
+    paths = {m: part(args.hex_root, f"{var}_{m}", args.h0) for m in members}
+
+    counts = {m: con.execute(f"SELECT COUNT(*) FROM read_parquet('{p}')").fetchone()[0]
+              for m, p in paths.items()}
+    print(f"rows per member: {counts}")
+    if len(set(counts.values())) != 1:
+        print("WARNING: member partitions differ in row count; join keeps the intersection")
+
+    base = members[0]
+    # Values are already in physical units (see module docstring) -- pass them straight through.
+    phys = [f"{m}t.{var}_{m}" for m in members]
+    sel_members = ", ".join(f"{e} AS {var}_{m}" for e, m in zip(phys, members))
+    arr = "[" + ", ".join(phys) + "]"
+
+    joins = " ".join(
+        f"JOIN read_parquet('{paths[m]}') {m}t ON {m}t.h8 = {base}t.h8"
+        for m in members if m != base
+    )
+
+    con.execute(f"""
+        COPY (
+            SELECT {base}t.h8, {base}t.h5, {base}t.h4, {base}t.h0,
+                   {sel_members},
+                   list_sort({arr})[{(len(members) + 1) // 2}] AS {var}_median,
+                   list_min({arr})  AS {var}_min,
+                   list_max({arr})  AS {var}_max
+            FROM read_parquet('{paths[base]}') {base}t
+            {joins}
+            SEMI JOIN (SELECT DISTINCT h8 FROM read_parquet('{args.mask}')) msk
+              ON {base}t.h8 = msk.h8
+        ) TO '{args.out}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000)
+    """)
+
+    after = con.execute(f"SELECT COUNT(*) FROM read_parquet('{args.out}')").fetchone()[0]
+    before = counts[base]
+    print(f"MASK h0={args.h0} rows_before={before} rows_after={after} "
+          f"kept={100.0 * after / before if before else 0:.2f}%")
+    if after == 0:
+        print("EMPTY after land mask")
+        return 3
+
+    lo, hi, nulls = con.execute(f"""
+        SELECT MIN({var}_min), MAX({var}_max),
+               COUNT(*) FILTER (WHERE {var}_median IS NULL)
+        FROM read_parquet('{args.out}')
+    """).fetchone()
+    print(f"MEASURED {var} physical range: min={lo} max={hi} median_nulls={nulls}")
+
+    # median must lie within [min, max] for every cell -- catches a broken ensemble reduce.
+    bad = con.execute(f"""
+        SELECT COUNT(*) FROM read_parquet('{args.out}')
+        WHERE {var}_median < {var}_min OR {var}_median > {var}_max
+    """).fetchone()[0]
+    print(f"CHECK median-outside-range violations: {bad}")
+    if bad:
+        print("ERROR: ensemble median falls outside the member range", file=sys.stderr)
+        return 4
+
+    # Plausibility bound -- catches a wrong scale/offset, which is otherwise invisible.
+    if args.sane_min is not None and lo is not None and lo < args.sane_min:
+        print(f"ERROR: min {lo} below sane bound {args.sane_min}", file=sys.stderr)
+        return 5
+    if args.sane_max is not None and hi is not None and hi > args.sane_max:
+        print(f"ERROR: max {hi} above sane bound {args.sane_max}", file=sys.stderr)
+        return 5
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/catalog/bioclimate/scripts/chelsa_read_meta.py
+++ b/catalog/bioclimate/scripts/chelsa_read_meta.py
@@ -1,0 +1,58 @@
+"""Print scale, offset and nodata for a CHELSA raster (data-workflows #564).
+
+CHELSA declares these per file and they differ per variable -- bio1/bio4/bio12 use nodata 0
+while bio15 uses 65535, and bio1 carries offset -273.15 where the others carry 0. The build
+reads them from the file rather than carrying a table, so a new variable cannot silently
+inherit the wrong sentinel.
+
+Emits one shell-eval-able line: SCALE=<f> OFFSET=<f> NODATA=<v>
+(NODATA is empty when the source declares none.)
+"""
+import argparse
+import sys
+
+from osgeo import gdal
+
+gdal.UseExceptions()
+
+
+def fmt_nodata(v):
+    if v is None:
+        return ""
+    # GDAL returns a float; emit an integer when the sentinel is integral so the value
+    # round-trips into `cng-datasets --nodata` as e.g. "0", never "0.0".
+    return str(int(v)) if float(v).is_integer() else repr(v)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    args = ap.parse_args()
+
+    # Hold the Dataset for the lifetime of the band: chaining
+    # `gdal.Open(p).GetRasterBand(1)` lets the Dataset be garbage-collected and leaves the
+    # band dangling, which surfaces as a TypeError inside the SWIG shim rather than as a
+    # clean failure.
+    ds = gdal.Open(args.input)
+    if ds is None:
+        print(f"ERROR: could not open {args.input}", file=sys.stderr)
+        return 1
+    band = ds.GetRasterBand(1)
+    if band is None:
+        print(f"ERROR: no band 1 in {args.input}", file=sys.stderr)
+        return 1
+
+    scale = band.GetScale()
+    offset = band.GetOffset()
+    nodata = band.GetNoDataValue()
+
+    print(f"SCALE={1.0 if scale is None else scale} "
+          f"OFFSET={0.0 if offset is None else offset} "
+          f"NODATA={fmt_nodata(nodata)}")
+    del band
+    del ds
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Split out of **#566**, which carried this alongside an unrelated docs change under a `docs:` title
and a body reading *"Docs only — no manifests, no STAC, no data."* It is **1,062 lines of build
recipe** and belongs here, against #564, where its acceptance criteria can actually be checked.

The documentation half of #566 is now #571.

## What this is

Pilot for #564: **bio1, ssp370, 2041–2070 → one wide hex at res 8, parents `5,4,0`** — matching
the #448 baseline so futures and baseline join cell-for-cell.

| file | what it does |
|---|---|
| `stage-raw.yaml` | 46 indexed pods stage 322 CHELSA rasters (~92.5 GB) to `s3://public-bioclimate/raw/` |
| `pilot-ensemble.yaml` | GCM-ensemble reduction → physical-unit float32 COG |
| `pilot-hex.yaml` | 122 pods (one per h0); hexes all 5 GCM members, joins locally on `h8`, applies the WWF ecoregions land mask |
| `scripts/*.py` | embedded **byte-identically** in `configmap.yaml` — verified by hash, no drift |

Design points worth keeping: scale/offset and nodata read **per file** rather than as batch
constants (CHELSA declares different sentinels per variable — bio1/bio4/bio12 use `0`, bio15 uses
`65535`); bio12's UInt16 saturation flagged and counted rather than silently averaged; row-block
processing so a 43200×20880 × N-member stack never has to fit in RAM; physical plausibility bounds
asserted before publish.

## Status: this is IN FLIGHT, not a proposal

At the time of writing, on the cluster:

```
chelsa-pilot-hex        Running    44/122   37m
chelsa-pilot-hex-smoke  Complete     1/1
chelsa-preflight{,2,3}  Complete     1/1
chelsa-scale-probe      Complete     1/1
chelsa-stage-raw        Failed     45/46
chelsa-stage-raw-retry5 Complete     1/1
```

**⚠️ `stage-raw` finished 45/46 and needed an out-of-band retry job for index 5.** That retry is
not part of the committed recipe, so as it stands the recipe does not reproduce the staged
inputs on its own. Worth fixing before this is treated as the durable recipe — this is the same
shape as the #494 / #535 class, where a build looked complete because the gap was patched by hand.

## One correction to the recipe as #566 had it

`pilot-hex.yaml`'s header comment said:

> cng-datasets does not apply the GeoTIFF scale/offset, so it is applied in the join

That contradicted **line 85 of the same file**, the script it invokes (`chelsa_join_mask.py`), and
the measured evidence. `exactextract`'s GDAL source **does** apply scale/offset, so hex values are
already physical; re-applying gives −273 °C.

The executable path was always correct — only the comment was wrong. But it sat at the top of the
file asserting the exact misconception the accompanying docs change exists to prevent, and
**a double-scaled column passes every structural check** (row counts, coverage, NULL counts,
median-within-range all stay consistent under a linear transform applied twice). Replaced with the
measured statement, including the note that `chelsa_ensemble.py` uses `gdal.Band.ReadAsArray`,
which genuinely *does* need the explicit transform — the two files differ on purpose.

## Not done here

#564's acceptance criteria are unmet and out of scope for this split: measured MIN/MAX + sentinel
per new column, `check-hex-coverage.sh`, `verify-stac.py`, and the Step 7 bucket registration —
which is now a no-op anyway after #568.