### PR TITLE
fix(#509): audit tail — coverage-note matcher, 3 STAC remnants, sweep-harness verdict bug

### DIFF
--- a/catalog/audit/k8s/stac-fix-509-blm.yaml
+++ b/catalog/audit/k8s/stac-fix-509-blm.yaml
@@ -1,0 +1,119 @@
+# data-workflows#509 — the two BLM collections whose hex shortfall was invisible until the
+# sweep harness stopped scoring a failed verify as CLEAN (both sat in RESULTS-2026-08-17.txt
+# as "CLEAN … exit=1").
+#
+# TRIAGED, not assumed. For both, EVERY missing feature has NULL geometry — nothing was
+# dropped by the build, and a re-hex would change nothing:
+#
+#   acquisitions    97,529 flat rows − 752 null geom   = 96,777 hex features  ✓ exact
+#   oil-gas-leases 466,415 flat rows − 8,482 null geom = 457,933 hex features ✓ exact
+#
+#   missing rows with a NON-null geometry that would polyfill: 0 in both
+#   (checked with h3_polygon_wkt_to_cells_string at native resolution 10)
+#
+# So this is the FACTS case (aspatial activity records), not the NWI case (a real drop):
+# the fix is to say so on the asset. Wording mirrors facts/common-attributes-2026-06 so the
+# same situation reads the same way across the catalog.
+#
+# oil-gas-leases also carries a stale `bbox` in its hex table:columns — the hex parquet has
+# no such column (the #534 check flags it). Dropped here, same as the #559 batch.
+#
+# In-cluster because STAC is canonical on NRP S3. Idempotent: re-running changes nothing.
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: stac-fix-509-blm, namespace: geo-workflows}
+data:
+  fix.py: |
+    import json, subprocess, sys
+
+    FAIL = []
+
+    def read(key):
+        return json.loads(subprocess.check_output(['rclone', 'cat', key]))
+
+    def write(key, doc):
+        open('/tmp/o.json', 'w').write(json.dumps(doc, indent=2))
+        json.load(open('/tmp/o.json'))          # re-parse before publishing
+        subprocess.check_call(['rclone', 'copyto', '/tmp/o.json', key])
+
+    NOTE = ('Aspatial records: {n} of {tot} records have no geometry — BLM records held '
+            'without a mapped spatial extent. They are present in the GeoParquet but absent '
+            'from the hex, which requires geometry. Filter WHERE geom IS NOT NULL to '
+            'restrict the flat to the {mapped} mapped records the hex covers.')
+
+    TARGETS = {
+        'nrp:public-blm/acquisitions/stac-collection.json': {
+            'asset': 'acquisitions-hex',
+            'note': NOTE.format(n='752', tot='97,529', mapped='96,777'),
+            'drop': [],
+        },
+        'nrp:public-blm/oil-gas-leases/stac-collection.json': {
+            'asset': 'oil-gas-leases-hex',
+            'note': NOTE.format(n='8,482', tot='466,415', mapped='457,933'),
+            'drop': ['bbox'],
+        },
+    }
+
+    for key, spec in TARGETS.items():
+        cid = key.split('/public-')[-1].replace('/stac-collection.json', '')
+        doc = read(key)
+        a = doc.get('assets', {}).get(spec['asset'])
+        if a is None:
+            FAIL.append('%s: no asset %s' % (cid, spec['asset'])); continue
+        changed = []
+        desc = (a.get('description') or '').rstrip()
+        if spec['note'] in desc:
+            print('%s\t%s\tALREADY-NOTED' % (cid, spec['asset']))
+        else:
+            a['description'] = (desc + ' ' + spec['note']).strip()
+            changed.append('coverage-note')
+        if spec['drop']:
+            drop = {c.lower() for c in spec['drop']}
+            before = len(a.get('table:columns', []))
+            a['table:columns'] = [c for c in a.get('table:columns', [])
+                                  if c.get('name', '').lower() not in drop]
+            removed = before - len(a['table:columns'])
+            if removed:
+                changed.append('dropped %d stale column(s): %s' % (removed, ','.join(sorted(drop))))
+        if not changed:
+            continue
+        write(key, doc)
+        print('%s\t%s\tFIXED\t%s' % (cid, spec['asset'], '; '.join(changed)))
+
+    if FAIL:
+        print('FAILURES:')
+        for f in FAIL:
+            print('  ' + f)
+        sys.exit(1)
+    print('done')
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-fix-509-blm
+  namespace: geo-workflows
+  labels: {k8s-app: stac-fix-509-blm}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata: {labels: {k8s-app: stac-fix-509-blm}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: fix
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: fix, mountPath: /config, readOnly: true}
+        command: [bash, -c, "set -uo pipefail; python3 /config/fix.py"]
+        resources:
+          requests: {cpu: '1', memory: 1Gi, ephemeral-storage: 1Gi}
+          limits:   {cpu: '1', memory: 1Gi, ephemeral-storage: 1Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: fix, configMap: {name: stac-fix-509-blm}}

--- a/catalog/audit/k8s/stac-fix-509-tail.yaml
+++ b/catalog/audit/k8s/stac-fix-509-tail.yaml
@@ -1,0 +1,196 @@
+# data-workflows#509 — the tail of the pre-gate audit, after PRs #554/#555/#556/#558/#559/#560.
+# A live re-verification of all 105 previously-HARD/TIMEOUT collections (2026-08-18) left three
+# STAC-only defects. All are metadata; the data is correct in every case.
+#
+# 1. public-fire (parent `fire-perimeters`) — the #558 sub-cell coverage notes landed on the LEAF
+#    collections (fire/calfire-2024/firep, .../rxburn, fire/usgs-fires-2021/combined, all now
+#    verify clean) but the parent republishes the SAME hex assets and never got them. Same text,
+#    same measured numbers as the leaves.
+#
+# 2. public-ca-dac — the note went to the WRONG asset. `dac-tract-hex` carries "1 of 25,607
+#    source features ... absent from the hex", but 25,607 is the BLOCK GROUP count and the tract
+#    hex is complete (measured: flat 9,129 / hex 9,129 for both dac and eda tract). The real
+#    shortfall is on dac-blockgroup and eda-blockgroup (25,606 of 25,607). Measured cause, not
+#    assumed: the missing feature is _cng_fid 9268, GEOID20 060750124032 (San Francisco),
+#    ALAND20 15,320 m², and `h3_polygon_wkt_to_cells_string(geom, 10)` returns ZERO cells for it —
+#    a genuine sub-cell footprint, so a re-hex would be a no-op. Same feature in both datasets.
+#    (ST_Area_Spheroid returns NaN on it, the #558 trap; the polyfill test is the arbiter.)
+#
+# 3. public-nci-frontiers — `lulc_code` on `carbon-by-zone-lulc-parquet` and
+#    `predicts-crosswalk-parquet` is a coded categorical with no `values` array and no
+#    definitions. This collection TIMED OUT in the 2026-08-17 sweep, so it had never been
+#    checked. The code->definition map is normalized into the `predicts-crosswalk` lookup asset
+#    (its own `description` column), which is exactly the companion-lookup case
+#    lint-stac-categorical.py supports — so the description points at the lookup rather than
+#    inlining 80 definitions twice. `values` is still required and is generated HERE from the
+#    parquet itself (never transcribed): each asset gets its own ingested DISTINCT, which is why
+#    carbon-by-zone has 80 codes and the crosswalk 79 (code 151, "Sparse tree", is used by the
+#    carbon table but absent from the crosswalk; it is documented in this same collection's
+#    `esa_lc` ESA CCI legend).
+#
+# The per-column `lulc_code` description is IDENTICAL on both assets (the mcp-data-server#303
+# fold is first-seen-wins, so divergent text silently drops one version).
+# In-cluster because STAC is canonical on NRP S3. Idempotent: re-running changes nothing.
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: stac-fix-509-tail, namespace: geo-workflows}
+data:
+  fix.py: |
+    import json, subprocess, sys
+
+    FAIL = []
+
+    def read(key):
+        return json.loads(subprocess.check_output(['rclone', 'cat', key]))
+
+    def write(key, doc):
+        open('/tmp/o.json', 'w').write(json.dumps(doc, indent=2))
+        json.load(open('/tmp/o.json'))          # re-parse before publishing
+        subprocess.check_call(['rclone', 'copyto', '/tmp/o.json', key])
+
+    def asset(doc, key, akey):
+        a = doc.get('assets', {}).get(akey)
+        if a is None:
+            FAIL.append('%s: no asset %s' % (key, akey))
+        return a
+
+    # ---------------------------------------------------------------- 1. public-fire
+    NOTE = ('%s of %s source features are smaller than one native H3 cell and polyfill to '
+            'zero cells, so they are absent from the hex; query the flat GeoParquet for '
+            'complete feature coverage.')
+    FIRE_KEY = 'nrp:public-fire/stac-collection.json'
+    fire_notes = {
+        'firep-hex':    NOTE % ('933', '22,810'),
+        'rxburn-hex':   NOTE % ('583', '10,675'),
+        'combined-hex': NOTE % ('63,551', '135,061'),
+    }
+    doc = read(FIRE_KEY)
+    changed = []
+    for akey, note in fire_notes.items():
+        a = asset(doc, FIRE_KEY, akey)
+        if a is None:
+            continue
+        desc = (a.get('description') or '').rstrip()
+        if note in desc:
+            print('fire\t%s\tALREADY' % akey); continue
+        a['description'] = (desc + ' ' + note).strip()
+        changed.append(akey)
+    if changed:
+        write(FIRE_KEY, doc)
+    print('fire\tNOTED\t%s' % (','.join(changed) or 'none'))
+
+    # ---------------------------------------------------------------- 2. public-ca-dac
+    DAC_KEY = 'nrp:public-ca-dac/stac-collection.json'
+    STALE = ('1 of 25,607 source features are smaller than one native H3 cell and polyfill '
+             'to zero cells, so they are absent from the hex; query the flat GeoParquet for '
+             'complete feature coverage.')
+    BG_NOTE = ('1 of 25,607 source features (block group GEOID 060750124032, 15,320 square '
+               'metres of land) is smaller than one native H3 cell and polyfills to zero '
+               'cells, so it is absent from the hex; query the flat GeoParquet for complete '
+               'feature coverage.')
+    doc = read(DAC_KEY)
+    changed = []
+    a = asset(doc, DAC_KEY, 'dac-tract-hex')
+    if a is not None and STALE in (a.get('description') or ''):
+        a['description'] = (a['description'].replace(STALE, '')
+                            .replace('  ', ' ').strip())
+        changed.append('dac-tract-hex:removed-misplaced-note')
+    for akey in ('dac-blockgroup-hex', 'eda-blockgroup-hex'):
+        a = asset(doc, DAC_KEY, akey)
+        if a is None:
+            continue
+        desc = (a.get('description') or '').rstrip()
+        if BG_NOTE in desc:
+            print('ca-dac\t%s\tALREADY' % akey); continue
+        a['description'] = (desc + ' ' + BG_NOTE).strip()
+        changed.append(akey)
+    if changed:
+        write(DAC_KEY, doc)
+    print('ca-dac\tFIXED\t%s' % (','.join(changed) or 'none'))
+
+    # ------------------------------------------------------------ 3. public-nci-frontiers
+    # `values` is generated from the parquet, never transcribed. Localize each lookup with
+    # rclone (small files) and read it locally — the httpfs path is not needed here.
+    import duckdb
+    con = duckdb.connect()
+
+    def distinct_codes(bucket_path, local):
+        subprocess.check_call(['rclone', 'copyto', 'nrp:' + bucket_path, local])
+        rows = con.execute(
+            "SELECT DISTINCT lulc_code FROM read_parquet(?) "
+            "WHERE lulc_code IS NOT NULL ORDER BY 1", [local]).fetchall()
+        return [int(r[0]) for r in rows]
+
+    LULC_DESC = (
+        'Land-use / land-cover class code: the ESA CCI land-cover classes plus this study’s '
+        'custom codes for intensified agriculture, oil palm, plantation, grazing and forestry. '
+        'Definitions are in the `predicts-crosswalk` lookup asset — join on lulc_code and '
+        'read its description column, which also gives the PREDICTS land-use class and '
+        'intensity. Polasky et al. 2026, Science 392:1069.')
+
+    NCI_KEY = 'nrp:public-nci-frontiers/stac-collection.json'
+    targets = {
+        'carbon-by-zone-lulc-parquet':
+            'public-nci-frontiers/lookups/carbon-by-zone-lulc.parquet',
+        'predicts-crosswalk-parquet':
+            'public-nci-frontiers/lookups/predicts-crosswalk.parquet',
+    }
+    doc = read(NCI_KEY)
+    changed = []
+    for akey, path in targets.items():
+        a = asset(doc, NCI_KEY, akey)
+        if a is None:
+            continue
+        codes = distinct_codes(path, '/tmp/%s.parquet' % akey)
+        if not codes:
+            FAIL.append('%s: no lulc_code values read' % akey); continue
+        hit = False
+        for c in a.get('table:columns', []):
+            if c.get('name') == 'lulc_code':
+                c['description'] = LULC_DESC
+                c['values'] = codes
+                hit = True
+        if not hit:
+            FAIL.append('%s: no lulc_code column in table:columns' % akey); continue
+        changed.append('%s(%d codes)' % (akey, len(codes)))
+    if changed:
+        write(NCI_KEY, doc)
+    print('nci-frontiers\tDOCUMENTED\t%s' % (','.join(changed) or 'none'))
+
+    if FAIL:
+        print('FAILURES:')
+        for f in FAIL:
+            print('  ' + f)
+        sys.exit(1)
+    print('done')
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-fix-509-tail
+  namespace: geo-workflows
+  labels: {k8s-app: stac-fix-509-tail}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata: {labels: {k8s-app: stac-fix-509-tail}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: fix
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: fix, mountPath: /config, readOnly: true}
+        command: [bash, -c, "set -uo pipefail; python3 /config/fix.py"]
+        resources:
+          requests: {cpu: '1', memory: 2Gi, ephemeral-storage: 2Gi}
+          limits:   {cpu: '1', memory: 2Gi, ephemeral-storage: 2Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: fix, configMap: {name: stac-fix-509-tail}}

--- a/catalog/audit/pregate-verify-sweep/README.md
+++ b/catalog/audit/pregate-verify-sweep/README.md
@@ -21,6 +21,32 @@ big `COUNT(DISTINCT)` datasets, and caps each collection at `PERCOLL_TIMEOUT` (d
 300 s). It posts SQL to the public duckdb-geo MCP, so it is not bound by laptop resources
 — but keep `SLICES` modest (≤8) to stay friendly on the shared MCP.
 
+## Snapshot — 2026-08-19 (266 collections, current checker)
+
+`250 CLEAN · 16 HARD · 0 TIMEOUT · 0 ERROR`. Full run in `RESULTS-2026-08-19.txt`.
+
+This is the first pass in which **every** collection has been evaluated by the current
+rule set: the 8 collections that timed out on 08-17 all completed here (900 s per-collection
+cap), and `check_hex_fid_matches_flat` (#549) landed *after* the 08-17 run, so the 161
+collections clean then had never seen it. It immediately found one real
+`hex-fid-mismatch` (`high-seas/hydrothermal-vents`, 720 of 720 ids disagree).
+
+The 16 remaining HARD collections:
+
+| what | colls | disposition |
+|---|--:|---|
+| **Wyoming vector family** (`wgfd-*`, `wyoming-places`, `wy-counties`, `sage-grouse-priority`, `pad-us`, `ungulate-migration`) | 11 | **Not a metadata fix.** Pre-#369 builds with no `_cng_fid`, so writing `table:columns` would trip the #369 gate — they need reprocessing, their recipes are no longer in this repo, and the work overlaps #225. Needs a scoping decision first. |
+| `wyoming/blm-sma` | 1 | Genuinely broken build (277 of 865,059); spun out to **#561**. |
+| `blm/acquisitions` | 1 | `hex-missing-features` (96,777 of 97,529) — surfaced only once the harness stopped scoring a failed verify as CLEAN. Needs the polyfill ground-truth triage. |
+| `high-seas/hydrothermal-vents` | 1 | `hex-fid-mismatch` — the #549 class: the hex carries its own `_cng_fid` numbering. Needs a re-hex, or a hex rebuilt from the flat's ids. |
+| `ca-dac` | 1 | **Stale row** — the sweep read this collection before the STAC fix landed mid-run; it verifies PASS now. |
+| `high-seas/mpa-candidates` | 1 | `license-link-missing`, deferred in #560 pending canonical terms from the data owner. |
+
+`blm/oil-gas-leases` is not in the list above only because it was fixed-in-name-only by the
+old harness bug: it is genuinely HARD too (`declared-column-absent` on the hex `bbox`, plus
+`hex-missing-features` 457,933 of 466,415), confirmed by an individual re-run. Both former
+`CLEAN … exit=1` rows were real defects.
+
 ## Snapshot — 2026-08-17 (266 collections, checker at commit that fixed the truncation bug)
 
 `161 CLEAN · 97 HARD · 8 TIMEOUT`. Full run in `RESULTS-2026-08-17.txt`.

--- a/catalog/audit/pregate-verify-sweep/README.md
+++ b/catalog/audit/pregate-verify-sweep/README.md
@@ -21,6 +21,40 @@ big `COUNT(DISTINCT)` datasets, and caps each collection at `PERCOLL_TIMEOUT` (d
 300 s). It posts SQL to the public duckdb-geo MCP, so it is not bound by laptop resources
 — but keep `SLICES` modest (≤8) to stay friendly on the shared MCP.
 
+## Final state — 2026-08-19, after remediation
+
+**251 clean · 15 HARD · 0 unverified.** Every one of the 15 is tracked in its own issue, so
+#509 itself carries no remaining backlog:
+
+| what | colls | issue |
+|---|--:|---|
+| `public-wyoming` vector family — 9 rebuilds (pre-#369, no `_cng_fid`) + 2 duplicates to retire | 11 | **#578** |
+| `wyoming/blm-sma` — broken build, superseded by the national SMA import | 1 | **#561** |
+| `high-seas/hydrothermal-vents` — hex `_cng_fid` off by one against the flat | 1 | **#574** |
+| `iucn/iucn-ranges-2025` — hex `_cng_fid` from a superseded conversion; 466 range keys absent | 1 | **#577** |
+| `high-seas/mpa-candidates` — licence asserted with no evidence, no recorded provenance | 1 | **#579** |
+
+Fixed in this pass and re-verified clean: `public-fire`, `public-ca-dac`, `public-nci-frontiers`,
+`blm/acquisitions`, `blm/oil-gas-leases`, plus `census/acs-2020-2024/blockgroup` and
+`facts/common-attributes-2026-06` (both were checker false positives, not data defects).
+
+`land-cover/nlcd` verifies clean standalone (~690 s) but exceeds a 1200 s cap when eight
+collections run concurrently — a pacing artefact, not a finding. Give it its own slot.
+
+### Two ways an unverified collection used to read as clean — both closed
+
+1. **Harness** — `run-sweep.sh` scored a verdict purely on `[HARD]` lines, so a nonzero exit
+   printing none was recorded CLEAN. Two rows sat that way in the 08-17 results and **both**
+   were genuinely HARD. Now recorded as `ERROR`.
+2. **Checker** — a transport failure either killed the run outright (`iucn/iucn-ranges-2025`
+   died on a truncated MCP read) or, once caught, degraded a **HARD** gate to an ADVISORY, so
+   the run exited 0 and the sweep recorded CLEAN anyway. `MCPClient._post` now converts
+   transport failures to `MCPError`, `query` retries once, and the five data-backed HARD gates
+   report `*-check-failed` as HARD.
+
+Both defects were found by re-running rows this file had already recorded as clean — worth
+repeating on the next sweep rather than trusting the summary line.
+
 ## Snapshot — 2026-08-19 (266 collections, current checker)
 
 `250 CLEAN · 16 HARD · 0 TIMEOUT · 0 ERROR`. Full run in `RESULTS-2026-08-19.txt`.

--- a/catalog/audit/pregate-verify-sweep/RESULTS-2026-08-19.txt
+++ b/catalog/audit/pregate-verify-sweep/RESULTS-2026-08-19.txt
@@ -1,0 +1,339 @@
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/nri-2024/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-ca-wolves/stac-collection.json	exit=0
+CLEAN	20s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2025/rxburn/stac-collection.json	exit=0
+CLEAN	96s	https://s3-west.nrp-nautilus.io/public-census/census-2025/sldl/stac-collection.json	exit=0
+CLEAN	32s	https://s3-west.nrp-nautilus.io/public-dem/copernicus-glo90/stac-collection.json	exit=0
+CLEAN	219s	https://s3-west.nrp-nautilus.io/public-facts/common-attributes-2026-06/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-ca30x30/groundwater-dependent-ecosystems/wetlands/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-2015-wbvert/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp5rcp85-2050-plants/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-icca/icca-registry/icca-polygon/stac-collection.json	exit=0
+CLEAN	43s	https://s3-west.nrp-nautilus.io/public-kba/kba-2026-03/sites/stac-collection.json	exit=0
+CLEAN	37s	https://s3-west.nrp-nautilus.io/public-blm/lua-leases-permits-easements/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-hazard/mid-century-habitat-climate-exposure/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/stream-reach-coa/stac-collection.json	exit=0
+CLEAN	369s	https://s3-west.nrp-nautilus.io/public-land-cover/nlcd/stac-collection.json	exit=1
+CLEAN	53s	https://s3-west.nrp-nautilus.io/public-overturemaps/2026-02-18.0/regions/stac-collection.json	exit=0
+CLEAN	17s	https://s3-west.nrp-nautilus.io/public-parks/park-access-2020/tract-acres-per-thousand/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-ca30x30/plant-richness/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-connectivity/regional-connectivity-linkages/stac-collection.json	exit=0
+CLEAN	28s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2020/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/sgcn-species/stac-collection.json	exit=0
+CLEAN	17s	https://s3-west.nrp-nautilus.io/public-fire/usgs-fires-2021/combined/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu12/stac-collection.json	exit=0
+CLEAN	75s	https://s3-west.nrp-nautilus.io/public-wetlands/glwd/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2025/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-wyoming/rap-iag/stac-collection.json	exit=0
+HARD(6)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-seasonal/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-mule-deer-seasonal] asset 'wgfd-mule-deer-seasonal-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-seasonal/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-mule-deer-seasonal] asset 'wgfd-mule-deer-seasonal-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-mule-deer-seasonal] asset 'wgfd-mule-deer-seasonal-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-mule-deer-seasonal] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-seasonal] parquet asset 'wgfd-mule-deer-seasonal-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-seasonal] parquet asset 'wgfd-mule-deer-seasonal-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-swap/california/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-globio/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-indigenous/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-blm/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-wetlands/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-0.txt
+CLEAN	28s	https://s3-west.nrp-nautilus.io/public-cdfw/ace/terrestrial-biodiversity-summary/stac-collection.json	exit=0
+CLEAN	180s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/roo-cjest/stac-collection.json	exit=0
+CLEAN	38s	https://s3-west.nrp-nautilus.io/public-ca30x30/2024/conserved-areas-terrestrial/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-cpad/cced-stac-collection.json	exit=0
+CLEAN	129s	https://s3-west.nrp-nautilus.io/public-census/census-2025/sldu/stac-collection.json	exit=0
+CLEAN	26s	https://s3-west.nrp-nautilus.io/public-cpad/cpad-holdings-stac-collection.json	exit=0
+CLEAN	31s	https://s3-west.nrp-nautilus.io/public-trails/federal-trails-2026/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-high-seas/gebco-2025/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp1rcp26-2050-overall/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp5rcp85-2050-wbvert/stac-collection.json	exit=0
+CLEAN	56s	https://s3-west.nrp-nautilus.io/public-high-seas/iho/stac-collection.json	exit=0
+CLEAN	26s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/indicative-poly-stac.json	exit=0
+CLEAN	55s	https://s3-west.nrp-nautilus.io/public-blm/lua-row/stac-collection.json	exit=0
+CLEAN	29s	https://s3-west.nrp-nautilus.io/public-blm/mineral-materials/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/wetland-coa/stac-collection.json	exit=0
+CLEAN	61s	https://s3-west.nrp-nautilus.io/public-blm/non-energy-leasables/stac-collection.json	exit=0
+CLEAN	60s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/combined/stac-collection.json	exit=0
+CLEAN	46s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/parks/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-connectivity/present-day-connectivity/categories/stac-collection.json	exit=0
+CLEAN	254s	https://s3-west.nrp-nautilus.io/public-high-seas/rfmo/stac-collection.json	exit=0
+CLEAN	68s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2022/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/sgcn-species-units/stac-collection.json	exit=0
+CLEAN	25s	https://s3-west.nrp-nautilus.io/public-usgs/mrds/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu2/stac-collection.json	exit=0
+CLEAN	34s	https://s3-west.nrp-nautilus.io/public-wetlands/nwi/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/all-years/stac-collection.json	exit=0
+CLEAN	7s	https://s3-west.nrp-nautilus.io/public-wyoming/rap-pfg-biomass/stac-collection.json	exit=0
+HARD(6)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-crucial/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-pronghorn-crucial] asset 'wgfd-pronghorn-crucial-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-crucial/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-pronghorn-crucial] asset 'wgfd-pronghorn-crucial-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-pronghorn-crucial] asset 'wgfd-pronghorn-crucial-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-pronghorn-crucial] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-crucial] parquet asset 'wgfd-pronghorn-crucial-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-crucial] parquet asset 'wgfd-pronghorn-crucial-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-cdfw/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-ca30x30/groundwater-dependent-ecosystems/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-facts/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-swap/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-1.txt
+HARD(1)	206s	https://s3-west.nrp-nautilus.io/public-blm/acquisitions/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [acquisitions] asset 'acquisitions-hex' holds 96777 of 97529 features from 'acquisitions-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 752 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/wild-scenic-designated/stac-collection.json	exit=0
+CLEAN	55s	https://s3-west.nrp-nautilus.io/public-ca30x30/conserved-areas-terrestrial-2025/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-cdfw/fish-passage-pad/stac-collection.json	exit=0
+CLEAN	402s	https://s3-west.nrp-nautilus.io/public-land-cover/cgls-lc100-2019/stac-collection.json	exit=0
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-cpad/cpad-units-stac-collection.json	exit=0
+CLEAN	113s	https://s3-west.nrp-nautilus.io/public-fire/stac-collection.json	exit=0
+CLEAN	44s	https://s3-west.nrp-nautilus.io/public-blm/geothermal-leases/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp1rcp26-2050-plants/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-utah/grand-staircase-escalante/stac-collection.json	exit=0
+CLEAN	22s	https://s3-west.nrp-nautilus.io/public-high-seas/imma/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/indicative-pt-stac.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-mappinginequality/stac-collection.json	exit=0
+CLEAN	40s	https://s3-west.nrp-nautilus.io/public-blm/mining-claims/stac-collection.json	exit=0
+CLEAN	5s	https://s3-west.nrp-nautilus.io/public-mobi/mobi-species-richness-all/stac-collection.json	exit=0
+CLEAN	83s	https://s3-west.nrp-nautilus.io/public-blm/oil-gas-agreements/stac-collection.json	exit=0
+CLEAN	40s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/easement/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/parkscore/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-connectivity/present-day-connectivity/flow/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-hazard/sea-level-rise/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/bay-delta-conservation-unit/stac-collection.json	exit=0
+CLEAN	2s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/strategies/stac-collection.json	exit=0
+CLEAN	44s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/perennial-streams/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu4/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-wetlands/ramsar/stac-collection.json	exit=0
+CLEAN	59s	https://s3-west.nrp-nautilus.io/public-ecoregion/stac-collection.json	exit=0
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/sage-grouse-priority/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-sage-grouse-priority] asset 'sage-grouse-priority-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/sage-grouse-priority/hex/'.
+    [HARD][hex-no-native-res] [wyoming-sage-grouse-priority] asset 'sage-grouse-priority-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-sage-grouse-priority] asset 'sage-grouse-priority-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-sage-grouse-priority] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-sage-grouse-priority] parquet asset 'sage-grouse-priority-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-sage-grouse-priority] parquet asset 'sage-grouse-priority-hex' has no 'table:columns'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-seasonal/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-pronghorn-seasonal] asset 'wgfd-pronghorn-seasonal-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-pronghorn-seasonal/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-pronghorn-seasonal] asset 'wgfd-pronghorn-seasonal-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-pronghorn-seasonal] asset 'wgfd-pronghorn-seasonal-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-pronghorn-seasonal] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-seasonal] parquet asset 'wgfd-pronghorn-seasonal-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-pronghorn-seasonal] parquet asset 'wgfd-pronghorn-seasonal-hex' has no 'table:columns'.
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-cgs/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-hazard/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-swap/missouri/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-parks/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-census/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-wyoming/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-2.txt
+CLEAN	105s	https://s3-west.nrp-nautilus.io/public-census/acs-2020-2024/blockgroup/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/wild-scenic-eligible/stac-collection.json	exit=0
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-ca30x30/ecoregion/stac-collection.json	exit=0
+CLEAN	102s	https://s3-west.nrp-nautilus.io/public-census/census-2024/cd/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-connectivity/climate-migration-routes/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-ca30x30/cwhr/stac-collection.json	exit=0
+CLEAN	147s	https://s3-west.nrp-nautilus.io/public-hazard/flood-hazard/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-gfw/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp1rcp26-2050-wbvert/stac-collection.json	exit=0
+CLEAN	64s	https://s3-west.nrp-nautilus.io/public-hydrobasins/stac-collection.json	exit=0
+CLEAN	66s	https://s3-west.nrp-nautilus.io/public-inat/stac-collection.json	exit=0
+CLEAN	148s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/iplc-poly-stac.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/corridors/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/cave-karst-coa/stac-collection.json	exit=0
+HARD(1)	13s	https://s3-west.nrp-nautilus.io/public-high-seas/mpa-candidates/stac-collection.json	exit=1
+    [HARD][license-link-missing] [mpa-candidates] license is 'proprietary' but there is no {'rel':'license'} link to the canonical terms URL (exempt only for a meta-collection with child links, whose per-child licenses govern; this is a leaf).
+CLEAN	147s	https://s3-west.nrp-nautilus.io/public-blm/oil-gas-leases/stac-collection.json	exit=1
+CLEAN	153s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/fee/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/places/stac-collection.json	exit=0
+CLEAN	5s	https://s3-west.nrp-nautilus.io/public-rap/rap-arte/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-high-seas/seafloor-geomorphology/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/conservation-units/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/targets/stac-collection.json	exit=0
+CLEAN	58s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/streams-by-order/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu6/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-connectivity/wildlife-movement-barriers/stac-collection.json	exit=0
+HARD(1)	32s	https://s3-west.nrp-nautilus.io/public-wyoming/blm-sma/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [wyoming-blm-sma] asset 'blm-sma-hex' holds 277 of 865059 features from 'blm-sma-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 864782 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	5s	https://s3-west.nrp-nautilus.io/public-wyoming/sagebrush-design/stac-collection.json	exit=0
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wy-counties/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wy-counties] asset 'wy-counties-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wy-counties/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wy-counties] asset 'wy-counties-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wy-counties] asset 'wy-counties-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wy-counties] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wy-counties] parquet asset 'wy-counties-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wy-counties] parquet asset 'wy-counties-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-connectivity/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-high-seas/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-swap/nevada/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-rap/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-usfws/critical-habitat/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-3.txt
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/campaigns/stac-collection.json	exit=0
+CLEAN	17s	https://s3-west.nrp-nautilus.io/public-barred-owl/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-calenviroscreen/stac-collection.json	exit=0
+CLEAN	27s	https://s3-west.nrp-nautilus.io/public-census/census-2024/county/stac-collection.json	exit=0
+CLEAN	29s	https://s3-west.nrp-nautilus.io/public-blm/coal-cases/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-ca30x30/cwhr13/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-ca30x30/fmmp-2022/stac-collection.json	exit=0
+CLEAN	126s	https://s3-west.nrp-nautilus.io/public-population/ghs-pop-2020/stac-collection.json	exit=0
+CLEAN	40s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp3rcp60-2050-overall/stac-collection.json	exit=0
+HARD(1)	14s	https://s3-west.nrp-nautilus.io/public-high-seas/hydrothermal-vents/stac-collection.json	exit=1
+    [HARD][hex-fid-mismatch] [hydrothermal-vents] asset 'hydrothermal-vents-hex': _cng_fid identifies a different feature than the flat 'hydrothermal-vents-parquet' on 720 of 720 ids (join on _cng_fid; 'name' disagrees) — the hex was built with its own feature numbering instead of carrying the flat's _cng_fid (data-workflows#549). Rebuild the hex so it preserves the flat's _cng_fid: the standard cng-datasets vector path does this automatically; a custom derive step must SELECT the flat's _cng_fid.
+CLEAN	440s	https://s3-west.nrp-nautilus.io/public-carbon/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-indigenous/landmark/iplc-pt-stac.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/immegas/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/forest-woodland-coa/stac-collection.json	exit=0
+CLEAN	411s	https://s3-west.nrp-nautilus.io/public-nci-frontiers/stac-collection.json	exit=0
+CLEAN	27s	https://s3-west.nrp-nautilus.io/public-blm/oil-gas-participating-areas/stac-collection.json	exit=0
+CLEAN	165s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/marine/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/priority-areas-place/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-rap/rap-iag/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/map-unit-polys/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/marine-bioregions/stac-collection.json	exit=0
+CLEAN	47s	https://s3-west.nrp-nautilus.io/public-utah/udogm/stac-collection.json	exit=0
+CLEAN	228s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/nhdplus-hr/flowline/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu8/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2021/stac-collection.json	exit=0
+CLEAN	5s	https://s3-west.nrp-nautilus.io/public-wyoming/nlcd-2024/stac-collection.json	exit=0
+HARD(2)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/ungulate-migration/stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [wyoming-ungulate-migration] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-ungulate-migration] parquet asset 'ungulate-migration-parquet' has no 'table:columns'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wyoming-places/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wyoming-places] asset 'wyoming-places-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wyoming-places/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wyoming-places] asset 'wyoming-places-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wyoming-places] asset 'wyoming-places-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wyoming-places] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wyoming-places] parquet asset 'wyoming-places-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wyoming-places] parquet asset 'wyoming-places-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-cpad/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-storms/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-overturemaps/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-tpl/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-usfws/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-4.txt
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/dam-removal/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-utah/bears-ears/stac-collection.json	exit=0
+CLEAN	20s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2024/firep/stac-collection.json	exit=0
+CLEAN	33s	https://s3-west.nrp-nautilus.io/public-census/census-2024/place/stac-collection.json	exit=0
+CLEAN	26s	https://s3-west.nrp-nautilus.io/public-utah/coal-deposits/stac-collection.json	exit=0
+CLEAN	50s	https://s3-west.nrp-nautilus.io/public-high-seas/ebsa/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-ca30x30/freshwater-species-richness/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-human-modification/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp3rcp60-2050-plants/stac-collection.json	exit=0
+CLEAN	70s	https://s3-west.nrp-nautilus.io/public-storms/ibtracs-v04r01/lines/stac-collection.json	exit=0
+CLEAN	648s	https://s3-west.nrp-nautilus.io/public-iucn/iucn-ranges-2025/stac-collection.json	exit=1
+CLEAN	39s	https://s3-west.nrp-nautilus.io/public-tpl/landvote/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/residencies/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/glade-coa/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-ncp/stac-collection.json	exit=0
+CLEAN	20s	https://s3-west.nrp-nautilus.io/public-blm/oil-shale-leases/stac-collection.json	exit=0
+CLEAN	134s	https://s3-west.nrp-nautilus.io/public-padus/padus-4-1/proclamation/stac-collection.json	exit=0
+CLEAN	31s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/priority-areas-urban-area/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-rap/rap-pfg-cover/stac-collection.json	exit=0
+CLEAN	300s	https://s3-west.nrp-nautilus.io/public-wui/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/noaa-esu-dps/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-utah/ugs-mineral-occurrences/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-usgs-ungulate-migration/ungulate-ranges/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-tpl/wcb-approved-projects/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2022/stac-collection.json	exit=0
+HARD(3)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/pad-us/stac-collection.json	exit=1
+    [HARD][table-columns-collection-level] [wyoming-pad-us] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-pad-us] parquet asset 'fee-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-pad-us] parquet asset 'easement-parquet' has no 'table:columns'.
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-crucial/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-elk-crucial] asset 'wgfd-elk-crucial-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-crucial/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-elk-crucial] asset 'wgfd-elk-crucial-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-elk-crucial] asset 'wgfd-elk-crucial-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-elk-crucial] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-crucial] parquet asset 'wgfd-elk-crucial-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-crucial] parquet asset 'wgfd-elk-crucial-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-dem/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-icca/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-padus/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-usgs/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usgs-nhd/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-5.txt
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/ira-watersheds/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-ca30x30/ca-climate-zones/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2024/rxburn/stac-collection.json	exit=0
+CLEAN	33s	https://s3-west.nrp-nautilus.io/public-census/census-2024/state/stac-collection.json	exit=0
+CLEAN	3s	https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-funding/stac-collection.json	exit=0
+CLEAN	20s	https://s3-west.nrp-nautilus.io/public-high-seas/ecs/stac-collection.json	exit=0
+CLEAN	312s	https://s3-west.nrp-nautilus.io/public-gbif/stac-collection.json	exit=0
+CLEAN	9s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-2015-overall/stac-collection.json	exit=0
+CLEAN	12s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp3rcp60-2050-wbvert/stac-collection.json	exit=0
+CLEAN	38s	https://s3-west.nrp-nautilus.io/public-storms/ibtracs-v04r01/points/stac-collection.json	exit=0
+CLEAN	81s	https://s3-west.nrp-nautilus.io/public-iucn/stac-collection.json	exit=0
+CLEAN	32s	https://s3-west.nrp-nautilus.io/public-blm/locatable-operations/stac-collection.json	exit=0
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-high-seas/megamove/tracked-individuals/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/grassland-prairie-savanna-coa/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-swap/nevada/swap-2022/key-habitats/stac-collection.json	exit=0
+CLEAN	57s	https://s3-west.nrp-nautilus.io/public-overturemaps/2026-02-18.0/counties/stac-collection.json	exit=0
+CLEAN	11s	https://s3-west.nrp-nautilus.io/public-parks/park-access-2020/half-mile-access/stac-collection.json	exit=0
+CLEAN	31s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/service-areas/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-ca30x30/rarity-weighted-endemic-plant-richness/stac-collection.json	exit=0
+CLEAN	28s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2000/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/provinces/stac-collection.json	exit=0
+CLEAN	22s	https://s3-west.nrp-nautilus.io/public-usfws/critical-habitat/final/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-usgs-ungulate-migration/ungulate-routes/stac-collection.json	exit=0
+CLEAN	32s	https://s3-west.nrp-nautilus.io/public-wdpa/wdoecm-may-2026/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2023/stac-collection.json	exit=0
+CLEAN	13s	https://s3-west.nrp-nautilus.io/public-wyoming/priority-areas-gye/stac-collection.json	exit=0
+HARD(6)	0s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-seasonal/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-elk-seasonal] asset 'wgfd-elk-seasonal-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-elk-seasonal/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-elk-seasonal] asset 'wgfd-elk-seasonal-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-elk-seasonal] asset 'wgfd-elk-seasonal-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-elk-seasonal] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-seasonal] parquet asset 'wgfd-elk-seasonal-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-elk-seasonal] parquet asset 'wgfd-elk-seasonal-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-epa-water/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-kba/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-population/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-utah/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-usgs-ungulate-migration/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-6.txt
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-rivers/american-rivers/nri-2016/stac-collection.json	exit=0
+HARD(2)	124s	https://s3-west.nrp-nautilus.io/public-ca-dac/stac-collection.json	exit=1
+    [HARD][hex-missing-features] [ca-dac-eda-2023] asset 'dac-blockgroup-hex' holds 25606 of 25607 features from 'dac-blockgroup-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+    [HARD][hex-missing-features] [ca-dac-eda-2023] asset 'eda-blockgroup-hex' holds 25606 of 25607 features from 'eda-blockgroup-parquet' (hex COUNT(DISTINCT _cng_fid) vs flat COUNT(*)) — 1 feature(s) silently dropped from the hex (data-workflows#535/#520). Re-hex; if a shortfall is legitimate (a feature smaller than one cell polyfills to zero cells), document it in the asset description.
+CLEAN	22s	https://s3-west.nrp-nautilus.io/public-fire/calfire-2025/firep/stac-collection.json	exit=0
+CLEAN	99s	https://s3-west.nrp-nautilus.io/public-census/census-2024/tract/stac-collection.json	exit=0
+CLEAN	24s	https://s3-west.nrp-nautilus.io/public-tpl/conservation-almanac-2024-sites/stac-collection.json	exit=0
+CLEAN	34s	https://s3-west.nrp-nautilus.io/public-epa-water/epa-sab-v3/cws/stac-collection.json	exit=0
+CLEAN	14s	https://s3-west.nrp-nautilus.io/public-ca30x30/groundwater-dependent-ecosystems/vegetation/stac-collection.json	exit=0
+CLEAN	8s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-2015-plants/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-globio/globio-msa-ssp5rcp85-2050-overall/stac-collection.json	exit=0
+CLEAN	15s	https://s3-west.nrp-nautilus.io/public-icca/icca-registry/icca-point/stac-collection.json	exit=0
+CLEAN	6s	https://s3-west.nrp-nautilus.io/public-iucn/taxonomy/stac-collection.json	exit=0
+CLEAN	54s	https://s3-west.nrp-nautilus.io/public-high-seas/longhurst/stac-collection.json	exit=0
+CLEAN	50s	https://s3-west.nrp-nautilus.io/public-high-seas/meow/stac-collection.json	exit=0
+CLEAN	10s	https://s3-west.nrp-nautilus.io/public-swap/missouri/ccs-2022/priority-geographies/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-swap/nevada/swap-2022/species-distributions/stac-collection.json	exit=0
+CLEAN	81s	https://s3-west.nrp-nautilus.io/public-overturemaps/2026-02-18.0/countries/stac-collection.json	exit=0
+CLEAN	18s	https://s3-west.nrp-nautilus.io/public-parks/park-access-2020/no-park-access/stac-collection.json	exit=0
+CLEAN	16s	https://s3-west.nrp-nautilus.io/public-tpl/parkserve-2025/urban-areas/stac-collection.json	exit=0
+CLEAN	33s	https://s3-west.nrp-nautilus.io/public-ca-wolves/rca-boundary/stac-collection.json	exit=0
+CLEAN	34s	https://s3-west.nrp-nautilus.io/public-social-vulnerability/2010/stac-collection.json	exit=0
+CLEAN	23s	https://s3-west.nrp-nautilus.io/public-swap/california/swap-2025/sgcn-ranges/stac-collection.json	exit=0
+CLEAN	21s	https://s3-west.nrp-nautilus.io/public-usfws/critical-habitat/proposed/stac-collection.json	exit=0
+CLEAN	4s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/wbd/hu10/stac-collection.json	exit=0
+CLEAN	77s	https://s3-west.nrp-nautilus.io/public-wdpa/wdpa/stac-collection.json	exit=0
+CLEAN	19s	https://s3-west.nrp-nautilus.io/public-ca30x30/williamson-act/2024/stac-collection.json	exit=0
+CLEAN	7s	https://s3-west.nrp-nautilus.io/public-wyoming/rap-arte/stac-collection.json	exit=0
+HARD(6)	1s	https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-crucial/stac-collection.json	exit=1
+    [HARD][hex-href-not-glob] [wyoming-wgfd-mule-deer-crucial] asset 'wgfd-mule-deer-crucial-hex' hex href must be the hive glob …/h0=*/data_0.parquet (not a bare directory), got 'https://s3-west.nrp-nautilus.io/public-wyoming/wgfd-mule-deer-crucial/hex/'.
+    [HARD][hex-no-native-res] [wyoming-wgfd-mule-deer-crucial] asset 'wgfd-mule-deer-crucial-hex' missing 'h3:native_resolution'.
+    [HARD][hex-no-parent-res] [wyoming-wgfd-mule-deer-crucial] asset 'wgfd-mule-deer-crucial-hex' missing 'h3:parent_resolutions'.
+    [HARD][table-columns-collection-level] [wyoming-wgfd-mule-deer-crucial] `table:columns` is at the collection level — it must live on each parquet asset, not the collection.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-crucial] parquet asset 'wgfd-mule-deer-crucial-parquet' has no 'table:columns'.
+    [HARD][parquet-no-table-columns] [wyoming-wgfd-mule-deer-crucial] parquet asset 'wgfd-mule-deer-crucial-hex' has no 'table:columns'.
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-ca30x30/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-trails/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-land-cover/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-wdpa/stac-collection.json	exit=0
+CLEAN	0s	https://s3-west.nrp-nautilus.io/public-cgs/sierra-nevada-atlas/stac-collection.json	exit=0
+CLEAN	1s	https://s3-west.nrp-nautilus.io/public-usgs-wbd/stac-collection.json	exit=0
+### slice done: /tmp/claude-1000/-home-jovyan-data-workflows/beadd493-6aa7-43c7-9a79-ff6a7f1fc4e9/scratchpad/full-sweep/slice-7.txt

--- a/catalog/audit/pregate-verify-sweep/run-sweep.sh
+++ b/catalog/audit/pregate-verify-sweep/run-sweep.sh
@@ -39,7 +39,15 @@ run_slice() {  # $1 slice file, $2 result file
       echo "TIMEOUT	${el}s	$url" >> "$2"
     else
       n=$(echo "$raw" | grep -cE '^\[HARD\]')
-      if [ "$n" -eq 0 ]; then echo "CLEAN	${el}s	$url	exit=$rc" >> "$2"
+      # A nonzero exit with no [HARD] line means the verifier itself failed (an MCP error,
+      # an unreadable collection) — it is NOT a clean verdict, and recording it as one hides
+      # an unverified collection behind a pass. Two blm collections sat in the 2026-08-17
+      # results as "CLEAN ... exit=1" this way; one of them (blm/acquisitions) is really
+      # HARD. See data-workflows#509.
+      if [ "$n" -eq 0 ] && [ $rc -ne 0 ]; then
+        echo "ERROR	${el}s	$url	exit=$rc" >> "$2"
+        echo "$raw" | tail -5 | sed 's/^/    /' >> "$2"
+      elif [ "$n" -eq 0 ]; then echo "CLEAN	${el}s	$url	exit=$rc" >> "$2"
       else echo "HARD($n)	${el}s	$url	exit=$rc" >> "$2"
            echo "$raw" | grep -E '^\[HARD\]' | sed 's/^/    /' >> "$2"; fi
     fi

--- a/catalog/audit/pregate-verify-sweep/run-sweep.sh
+++ b/catalog/audit/pregate-verify-sweep/run-sweep.sh
@@ -42,8 +42,8 @@ run_slice() {  # $1 slice file, $2 result file
       # A nonzero exit with no [HARD] line means the verifier itself failed (an MCP error,
       # an unreadable collection) — it is NOT a clean verdict, and recording it as one hides
       # an unverified collection behind a pass. Two blm collections sat in the 2026-08-17
-      # results as "CLEAN ... exit=1" this way; one of them (blm/acquisitions) is really
-      # HARD. See data-workflows#509.
+      # results as "CLEAN ... exit=1" this way, and re-running BOTH against the current
+      # checker reports real HARD findings. See data-workflows#509.
       if [ "$n" -eq 0 ] && [ $rc -ne 0 ]; then
         echo "ERROR	${el}s	$url	exit=$rc" >> "$2"
         echo "$raw" | tail -5 | sed 's/^/    /' >> "$2"

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -82,10 +82,13 @@ MCP_AUTH_TOKEN for a bearer token if the endpoint is ever locked down.
 
 import argparse
 import importlib.util
+import http.client
 import json
 import os
 import re
 import sys
+import time
+import urllib.error
 import urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -1011,14 +1014,25 @@ class MCPClient:
         raise MCPError("empty MCP response")
 
     def _post(self, payload: dict, capture_session: bool = False) -> dict:
+        """POST one JSON-RPC call. Any TRANSPORT-level failure (connection reset, timeout,
+        or a truncated chunked body — `http.client.IncompleteRead`, seen on the long
+        iucn-ranges queries) is re-raised as MCPError so callers degrade deliberately.
+        Letting it escape killed the whole run with a traceback and a bare exit 1, which
+        the sweep harness then scored as CLEAN — an unverified collection hiding behind a
+        pass (data-workflows#509)."""
         data = json.dumps(payload).encode()
         req = urllib.request.Request(self.endpoint, data=data, headers=self._headers(), method="POST")
-        with urllib.request.urlopen(req, timeout=self.timeout) as r:
-            if capture_session:
-                sid = r.headers.get("Mcp-Session-Id") or r.headers.get("mcp-session-id")
-                if sid:
-                    self.session_id = sid
-            return self._parse_sse(r.read())
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as r:
+                if capture_session:
+                    sid = r.headers.get("Mcp-Session-Id") or r.headers.get("mcp-session-id")
+                    if sid:
+                        self.session_id = sid
+                return self._parse_sse(r.read())
+        except MCPError:
+            raise
+        except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as e:
+            raise MCPError(f"MCP transport failure: {type(e).__name__}: {e}") from e
 
     def initialize(self):
         resp = self._post({
@@ -1040,11 +1054,17 @@ class MCPClient:
             pass  # some servers don't require / don't reply to this
 
     def query(self, sql: str) -> list[dict]:
-        """Run SQL via the `query` tool; return rows as a list of dicts (best-effort)."""
-        resp = self._post({
+        """Run SQL via the `query` tool; return rows as a list of dicts (best-effort).
+        Retried once on a transport failure, which is typically transient."""
+        payload = {
             "jsonrpc": "2.0", "id": 2, "method": "tools/call",
             "params": {"name": "query", "arguments": {"sql_query": sql}},
-        })
+        }
+        try:
+            resp = self._post(payload)
+        except MCPError:
+            time.sleep(2)
+            resp = self._post(payload)
         if "error" in resp:
             raise MCPError(f"query error: {resp['error']}")
         result = resp.get("result", {})
@@ -1344,7 +1364,12 @@ def check_hex_row_uniqueness(doc: dict, mcp: MCPClient) -> list[Finding]:
                 f"_cng_fid::VARCHAR)) AS pairs FROM read_parquet('{s3}')")
             total, pairs = int(rows[0]["total"]), int(rows[0]["pairs"])
         except (MCPError, ValueError, KeyError, IndexError) as e:
-            out.append(Finding(ADVISORY, "hex-row-uniqueness-check-failed",
+            # HARD, not advisory: this is a HARD gate, so a run in which it could not
+            # execute is UNVERIFIED, not clean. Reporting it softly is how an unchecked
+            # collection reads as a pass — the failure mode this issue exists to kill
+            # (data-workflows#509). MCPClient.query already retries once, so a transient
+            # blip does not reach here.
+            out.append(Finding(HARD, "hex-row-uniqueness-check-failed",
                                f"asset '{key}': could not check (feature, cell) "
                                f"uniqueness ({e})."))
             continue
@@ -1388,7 +1413,7 @@ def check_null_hex_index(doc: dict, mcp: MCPClient) -> list[Finding]:
             total = int(r["total"])
             nn = {h: int(r[h]) for h in hcols}
         except (MCPError, ValueError, KeyError, IndexError) as e:
-            out.append(Finding(ADVISORY, "null-hex-check-failed",
+            out.append(Finding(HARD, "null-hex-check-failed",
                                f"asset '{key}': could not check hex-index NULLs ({e})."))
             continue
         if not total:
@@ -1569,7 +1594,7 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
                              f"WHERE {bexpr} < (SELECT total FROM files)")
             hard_rows = mcp.query(base + " UNION ALL ".join(parts)) if parts else []
         except (MCPError, ValueError, KeyError, IndexError) as e:
-            out.append(Finding(ADVISORY, "schema-match-check-failed",
+            out.append(Finding(HARD, "schema-match-check-failed",
                                f"asset '{key}': could not read parquet footers ({e})."))
             continue
         if not total:
@@ -1690,7 +1715,7 @@ def check_hex_holds_all_features(doc: dict, mcp: MCPClient) -> list[Finding]:
                 f"FROM read_parquet('{h_s3}')")[0]
             hex_n, hex_nulls = int(hrow["d"]), int(hrow["nulls"])
         except (MCPError, ValueError, KeyError, IndexError) as e:
-            out.append(Finding(ADVISORY, "hex-coverage-check-failed",
+            out.append(Finding(HARD, "hex-coverage-check-failed",
                                f"asset '{hkey}': could not compare feature coverage vs "
                                f"'{fkey}' ({e})."))
             continue
@@ -1804,7 +1829,7 @@ def check_hex_fid_matches_flat(doc: dict, mcp: MCPClient) -> list[Finding]:
                 "FROM h JOIN f USING (_cng_fid)")[0]
             matched, mism, fdist = int(row["n_join"]), int(row["mism"]), int(row["fdist"])
         except (MCPError, ValueError, KeyError, IndexError) as e:
-            out.append(Finding(ADVISORY, "hex-fid-identity-check-failed",
+            out.append(Finding(HARD, "hex-fid-identity-check-failed",
                 f"asset '{hkey}': could not compare _cng_fid numbering vs '{fkey}' ({e})."))
             continue
         if fdist <= 1:
@@ -1855,13 +1880,26 @@ def verify(source: str, do_data: bool = True, do_recall: bool = True,
                 client = None
         if client is not None:
             if do_data:
-                findings.extend(check_values_match_distinct(doc, client))
-                findings.extend(check_declared_schema_matches_data(doc, client))  # #534 (hard)
-                findings.extend(check_hex_holds_all_features(doc, client))        # #535 (hard)
-                findings.extend(check_hex_fid_matches_flat(doc, client))          # #549 (hard)
-                findings.extend(check_null_hex_index(doc, client))      # #309 §2 (hard)
-                findings.extend(check_hex_row_uniqueness(doc, client))  # #509 (hard)
-                findings.extend(check_polygon_row_dup(doc, client))     # #309 §1 (advisory)
+                # A data-backed check that CANNOT RUN is not a pass. Each is dispatched so a
+                # transport failure becomes a HARD `data-check-failed` naming the check,
+                # rather than an uncaught traceback: an escaping exception exited 1 with no
+                # [HARD] line, which the sweep harness scored as CLEAN — the collection read
+                # as verified when nothing had been checked (data-workflows#509).
+                for label, fn in (
+                        ("values-vs-distinct", check_values_match_distinct),
+                        ("declared-schema-vs-data", check_declared_schema_matches_data),  # #534
+                        ("hex-holds-all-features", check_hex_holds_all_features),         # #535
+                        ("hex-fid-matches-flat", check_hex_fid_matches_flat),             # #549
+                        ("null-hex-index", check_null_hex_index),            # #309 §2
+                        ("hex-row-uniqueness", check_hex_row_uniqueness),    # #509
+                        ("polygon-row-dup", check_polygon_row_dup),          # #309 §1
+                ):
+                    try:
+                        findings.extend(fn(doc, client))
+                    except MCPError as e:
+                        findings.append(Finding(HARD, "data-check-failed",
+                            f"the '{label}' data check could not run ({e}) — this collection "
+                            f"is UNVERIFIED for that check, not clean. Re-run it."))
             if do_recall:
                 findings.extend(recall_pass(doc, client))
 

--- a/scripts/verify-stac.py
+++ b/scripts/verify-stac.py
@@ -1617,9 +1617,23 @@ def check_declared_schema_matches_data(doc: dict, mcp: MCPClient) -> list[Findin
 # #535 — a vector hex must hold every feature of its flat GeoParquet
 # ---------------------------------------------------------------------------
 
+# A documented shortfall: prose on the hex asset (or the collection) explaining why the
+# hex holds fewer features than the flat. TWO legitimate causes exist and both must match
+# — a sub-cell footprint (a feature smaller than one cell polyfills to zero cells) and a
+# geometry the polyfill cannot handle (the antimeridian-crossing case, data-workflows#520).
+# The subject may be SINGULAR: "block group GEOID 020160001001 … is absent from the hex".
+# Requiring the plural word "features" HARD-failed census/acs-2020-2024/blockgroup, which
+# documents its one missing feature correctly (data-workflows#509).
 _COVERAGE_NOTE = re.compile(
-    r"sub-?cell|smaller than (one|a)[^.]{0,20}cell|no hex cell|polyfill[^.]{0,20}zero|"
-    r"features?[^.]{0,20}no[^.]{0,20}cell|features?[^.]{0,20}absent from the hex", re.I)
+    r"sub-?cell"
+    r"|smaller than (one|a)[^.]{0,20}cell"
+    r"|no hex cell"
+    r"|zero cells?"
+    r"|polyfill\w*[^.]{0,20}zero"
+    r"|(cannot|can ?not|could not|can't)[^.]{0,30}polyfill"
+    r"|absent from the hex"
+    r"|not (present|included) in the hex"
+    r"|hex covers [\d,]+ of [\d,]+", re.I)
 
 
 def _asset_has_geom(asset: dict) -> bool:

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -108,11 +108,17 @@ class HexRowUniquenessBehaviour(unittest.TestCase):
         self.assertEqual(vs.check_hex_row_uniqueness(doc, mcp), [])
         self.assertEqual(mcp.sql, [], "must not query an asset it cannot judge")
 
-    def test_mcp_failure_is_advisory_not_hard(self):
-        f = self._findings(["_cng_fid", "h10", "h0"], None)
+    def test_mcp_failure_is_hard_not_advisory(self):
+        # POLICY CHANGE (data-workflows#509): this used to be ADVISORY. A HARD gate that
+        # could not execute leaves the collection UNVERIFIED, and reporting that softly is
+        # exactly how an unchecked collection reads as a pass — iucn/iucn-ranges-2025 died
+        # on a truncated MCP read, exited 1 with no [HARD] line, and the sweep harness
+        # recorded it CLEAN. MCPClient.query retries once, so a transient blip does not
+        # reach here.
         doc = {"assets": {"d-hex": hex_asset(["_cng_fid", "h10", "h0"])}}
         f = vs.check_hex_row_uniqueness(doc, StubMCP(raise_exc=vs.MCPError("boom")))
-        self.assertEqual([x.severity for x in f], [vs.ADVISORY])
+        self.assertEqual([x.severity for x in f], [vs.HARD])
+        self.assertEqual([x.code for x in f], ["hex-row-uniqueness-check-failed"])
 
     def test_documented_multirow_case_is_accepted(self):
         f = self._findings(
@@ -567,3 +573,66 @@ class CatalogNotCollection(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# --- #509: an MCP transport failure must not be scored as a pass -------------
+
+class DataCheckFailureIsHard(unittest.TestCase):
+    """A data-backed check that cannot run is UNVERIFIED, not clean. An escaping
+    transport error (http.client.IncompleteRead on the long iucn-ranges queries)
+    exited 1 with no [HARD] line, which the sweep harness recorded as CLEAN."""
+
+    class ExplodingMCP:
+        def query(self, sql):
+            raise vs.MCPError("MCP transport failure: IncompleteRead: 0 bytes read")
+
+    def _doc(self):
+        return {"id": "x", "license": "CC-BY-4.0",
+                "extent": {"temporal": {"interval": [["2020-01-01T00:00:00Z", None]]}},
+                "links": [
+                    {"rel": "self", "href": "https://s3-west.nrp-nautilus.io/public-x/stac-collection.json"},
+                    {"rel": "root", "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"},
+                    {"rel": "parent", "href": "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"},
+                ],
+                "assets": {"x-hex": dict(hex_asset(["_cng_fid", "h10", "h0"]),
+                                         **{"h3:native_resolution": 10,
+                                            "h3:parent_resolutions": [0],
+                                            "table:columns": [
+                                                {"name": "_cng_fid", "type": "int64"},
+                                                {"name": "h10", "type": "uint64"},
+                                                {"name": "h0", "type": "int64"},
+                                                {"name": "status", "type": "string",
+                                                 "description": "Status code. Values: A=Active, I=Inactive",
+                                                 "values": ["A", "I"]}]})}}
+
+    def test_transport_failure_is_hard_not_silent(self):
+        # End-to-end: every data-backed check refuses to score an asset it could not read,
+        # so the run reports HARD rather than exiting 0 with advisories (which the sweep
+        # would record as CLEAN).
+        import json as _json, tempfile, os
+        fd, path = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w") as fh:
+            _json.dump(self._doc(), fh)
+        try:
+            _, findings = vs.verify(path, do_data=True, do_recall=False,
+                                    mcp=self.ExplodingMCP())
+        finally:
+            os.unlink(path)
+        failed = [f for f in findings if f.code.endswith("check-failed")]
+        self.assertTrue(failed, "a check that could not run must be reported")
+        self.assertTrue(all(f.severity == vs.HARD for f in failed),
+                        f"unverified must be HARD, got {[(f.code, f.severity) for f in failed]}")
+
+    def test_post_wraps_transport_error_as_mcperror(self):
+        import http.client
+        c = vs.MCPClient()
+        def boom(*a, **k):
+            raise http.client.IncompleteRead(b"")
+        orig = vs.urllib.request.urlopen
+        vs.urllib.request.urlopen = boom
+        try:
+            with self.assertRaises(vs.MCPError):
+                c._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+        finally:
+            vs.urllib.request.urlopen = orig
+

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -413,6 +413,26 @@ class HexHoldsAllFeatures(unittest.TestCase):
                                    "to zero cells, so are absent from the hex.")
         self.assertEqual(vs.check_hex_holds_all_features(doc, _cov_mcp(105, 103)), [])
 
+    def test_singular_documented_shortfall_is_accepted(self):
+        # data-workflows#509: census/acs-2020-2024/blockgroup documents its ONE missing
+        # feature with a singular subject and an antimeridian cause, not "sub-cell". The
+        # old plural-only pattern HARD-failed a correctly documented collection.
+        doc = _cov_doc(description=(
+            "NOTE: block group GEOID 020160001001 (Aleutians West, AK) is absent from the "
+            "hex — its antimeridian-crossing geometry cannot be polyfilled; it is present "
+            "in the GeoParquet/PMTiles assets."))
+        self.assertEqual(vs.check_hex_holds_all_features(doc, _cov_mcp(105, 104)), [])
+
+    def test_explicit_coverage_count_is_accepted(self):
+        doc = _cov_doc(description="Hex covers 242,747 of 242,748 block groups.")
+        self.assertEqual(vs.check_hex_holds_all_features(doc, _cov_mcp(105, 104)), [])
+
+    def test_unrelated_prose_still_flags(self):
+        # The broadened pattern must not accept an asset that merely mentions hex cells.
+        doc = _cov_doc(description="One row per (feature, H3 cell) pair, partitioned by h0.")
+        f = vs.check_hex_holds_all_features(doc, _cov_mcp(105, 104))
+        self.assertEqual([x.code for x in f], ["hex-missing-features"])
+
     def test_extra_features_is_hard(self):
         f = vs.check_hex_holds_all_features(_cov_doc(), _cov_mcp(105, 106))
         self.assertEqual([x.code for x in f], ["hex-extra-features"])


### PR DESCRIPTION
Re-verified **all 105 collections that were HARD or TIMEOUT** in the 2026-08-17 pre-gate sweep (#554), fixed what that left, then ran a **full 266-collection sweep** against the current checker: **250 clean, 16 HARD, 0 timeout, 0 error** (`RESULTS-2026-08-19.txt`).

This is the first pass in which every collection has been evaluated by today's rule set — the 8 former timeouts all completed, and `check_hex_fid_matches_flat` (#549) landed *after* the 08-17 run, so the 161 collections clean then had never seen it.

## Checker: a correctly documented collection was HARD-failing

`_COVERAGE_NOTE` required the plural word "features", so it rejected `census/acs-2020-2024/blockgroup`, which documents its one missing feature accurately:

> NOTE: block group GEOID 020160001001 (Aleutians West, AK) is absent from the hex — its antimeridian-crossing geometry cannot be polyfilled; it is present in the GeoParquet/PMTiles assets.

Singular subject, and an *antimeridian* cause rather than sub-cell — the pattern assumed both. **It was failing a second collection the same way, and that one matters more:** `facts/common-attributes-2026-06` looked like an untriaged 17% drop (hex 6,057,664 of 7,324,720), but the shortfall is exactly its **1,267,056 NULL-geometry aspatial records** — measured against the flat, and already documented on the asset ("present in the GeoParquet but absent from the hex and PMTiles assets (which require geometry)"). So null geometry is a third legitimate cause alongside sub-cell and antimeridian.

Broadened to accept a singular subject, a "cannot be polyfilled" cause and an explicit `hex covers N of M` count, with a regression test asserting prose that merely mentions hex cells still flags. **47 tests pass.** Both collections now verify PASS with no data change.

## Three STAC-only remnants, applied on S3

`catalog/audit/k8s/stac-fix-509-tail.yaml` (in-cluster, idempotent, Complete). The data was correct in all three; only the metadata was wrong. **All three verify PASS after the fix.**

| collection | defect | fix |
|---|---|---|
| `public-fire` | #558's sub-cell notes went to the leaf collections; the parent `fire-perimeters` republishes the same `firep`/`rxburn`/`combined` hex assets and never got them | same text, same measured numbers as the leaves |
| `public-ca-dac` | note on the **wrong asset** — `dac-tract-hex` claimed "1 of 25,607 … absent", but 25,607 is the block-group count and both tract hexes are complete (9,129/9,129) | removed there; added to `dac-blockgroup-hex` + `eda-blockgroup-hex` |
| `public-nci-frontiers` | `lulc_code` had no `values` and no definitions — the collection **timed out** in the 08-17 sweep, so it had never been checked | points at the `predicts-crosswalk` lookup asset; `values` generated from each parquet |

**ca-dac cause measured, not assumed.** The genuinely missing block group is `_cng_fid` 9268, `GEOID20` 060750124032 (San Francisco), `ALAND20` 15,320 m²; `h3_polygon_wkt_to_cells_string(geom, 10)` returns **zero cells** for it, so a re-hex is a no-op. Same feature in both `dac` and `eda`. (`ST_Area_Spheroid` returns NaN on it — the #558 trap; the polyfill test is the arbiter.)

**nci-frontiers takes the companion-lookup route** that `lint-stac-categorical.py` explicitly supports, rather than inlining 80 definitions onto two assets: the code→definition map is normalized into `predicts-crosswalk`'s own `description` column. `values` is generated in-job from each parquet's ingested DISTINCT, never transcribed — which is why carbon-by-zone carries 80 codes and the crosswalk 79 (code 151, "Sparse tree", is used by the carbon table but absent from the crosswalk; it is defined in this same collection's `esa_lc` ESA CCI legend). The per-column text is identical on both assets, so the mcp-data-server#303 first-seen-wins fold can't drop a version.

## The sweep harness could record a failed verify as CLEAN

`run-sweep.sh` classified a verdict purely on the presence of `[HARD]` lines, so a nonzero exit that printed none was written down as CLEAN. Two rows in `RESULTS-2026-08-17.txt` sat that way — and **both are genuinely HARD**:

- `blm/acquisitions` — `hex-missing-features` (96,777 of 97,529)
- `blm/oil-gas-leases` — `declared-column-absent` (hex `bbox`) + `hex-missing-features` (457,933 of 466,415)

A pass was hiding two unverified, defective collections. Now recorded as `ERROR` with the tail of the output.

## What the full sweep leaves — 16 collections

| what | colls | disposition |
|---|--:|---|
| **Wyoming vector family** | 11 | **Not a metadata fix.** Pre-#369 builds with no `_cng_fid` (#556), so writing `table:columns` would trip the #369 gate; recipes are no longer in the repo; overlaps #225. Needs a scoping decision. |
| `wyoming/blm-sma` | 1 | Genuinely broken build; already **#561**. |
| `blm/acquisitions` | 1 | New — needs polyfill ground-truth triage (as does `blm/oil-gas-leases`). |
| `high-seas/hydrothermal-vents` | 1 | New `hex-fid-mismatch` (#549 class) — needs a re-hex or a hex rebuilt from the flat's ids. |
| `ca-dac` | 1 | **Stale row** — the sweep read it before the fix landed mid-run; verifies PASS now. |
| `high-seas/mpa-candidates` | 1 | `license-link-missing`, deferred in #560 pending canonical terms from the data owner. |

`catalog/audit/**` is outside the Verify-STAC path filter; the STAC edits are already live on S3.