### PR TITLE
docs(#509): stac-authoring — a `*-check-failed` finding means unverified, not broken data

### DIFF
--- a/.claude/skills/stac-authoring/SKILL.md
+++ b/.claude/skills/stac-authoring/SKILL.md
@@ -30,6 +30,14 @@ scripts/verify-stac.py --bucket <bucket> --dataset <dataset>
 #    Must exit 0 (no HARD findings). ADVISORY lines are informational.
 ```
 
+**A `*-check-failed` finding is HARD, and it means UNVERIFIED — not broken data.** If a
+data-backed check cannot reach the MCP (a transport failure, a query that will not
+complete), the run reports HARD rather than passing quietly: a gate that did not execute
+is not a green light. `MCPClient.query` already retries once, so re-running usually clears
+a transient blip. Read it as "check again", not as a defect in the collection — and never
+"fix" it by making the check advisory, which is exactly how an unverified collection came
+to read as clean (#509).
+
 CI runs the same verifier on the PR (`.github/workflows/verify-stac.yml`), deriving the
 collection(s) from the `s3://` paths in the changed `catalog/**` YAMLs. **The gate
 evaluates the produced artifact, not the proposal:** the cluster run lands after the PR


### PR DESCRIPTION
One-paragraph follow-up to #573, which made the five data-backed HARD gates report `*-check-failed` as **HARD** instead of ADVISORY.

The skill documents every other verify-stac verdict but not this one, so a red gate caused by an MCP transport blip reads as a data defect. Worse, the obvious "fix" — softening the check back to advisory — is precisely the regression #573 closed: it is how `iucn/iucn-ranges-2025` and `blm/oil-gas-leases` sat in a passing summary line while unverified.

Adds a short note in the gate section saying what the finding means, that `MCPClient.query` already retries once so re-running usually clears it, and not to make it advisory.