### PR TITLE
feat(#584): USFS Inventoried Roadless Areas (2001 Roadless Rule) — national

### DIFF
--- a/catalog/usfs/k8s/roadless-areas-2001/BUILD.md
+++ b/catalog/usfs/k8s/roadless-areas-2001/BUILD.md
@@ -158,3 +158,65 @@ scripts/verify-stac.py --bucket public-usfs --dataset roadless-areas-2001
   features cannot be expected to align, and the National Forest Planning Record Documents
   (Appendix C) / RARE II documents remain the official version of the inventory. Relevant to
   any road-proximity buffering in #588.
+
+## Build results (2026-08-19)
+
+Whole pipeline completed in **3m20s** in `geo-workflows`. Every job `Complete`; the hex job
+reported `Complete=True` with `failedIndexes: []` and 12/12 succeeded.
+
+| Job | Duration |
+|---|---|
+| setup-bucket | 25s |
+| stage-raw | 18s |
+| convert | 16s |
+| hex (12 indexed pods) | 105s |
+| pmtiles | 64s |
+| repartition | 47s |
+
+Artifacts: `roadless-areas-2001.parquet` (48.5 MB), `roadless-areas-2001.pmtiles` (93.0 MB),
+9 populated `hex/h0=*` partitions, 16,309,549 hex rows.
+
+### Acceptance criteria — verified against the INGESTED parquet
+
+| Check | Result |
+|---|---|
+| `SUM(ACRES)` all features | 58,419,694 ✅ |
+| `SUM(ACRES) WHERE STATE NOT IN ('ID','CO')` | 44,701,002 ✅ |
+| West-10 ÷ rule-affected | 95.61% ✅ |
+| Montana | 6,395,401 ✅ |
+| Feature count | 11,391 ✅ |
+| `COUNT(DISTINCT _cng_fid)` on flat | 11,391 (= row count, so no upstream row duplication) ✅ |
+| `COUNT(DISTINCT _cng_fid)` on hex | 11,391 — no silent `--max-completions` cap ✅ |
+| Hex/flat agreement, deduped `SUM(ACRES)` | 58,419,694 — exact ✅ |
+| H3 resolution 10 footprint vs published acreage | 58,274,632 ac, −0.25% ✅ |
+| Invalid geometries | 0 ✅ |
+| Bounding box | `(-150.008, 18.246, -65.707, 61.519)` — matches source ✅ |
+| NULL finest-parent (`h10`) cells | 0, so no #311 note required ✅ |
+| h0 partition gate | PASS, 9 == 9 populated, no empty partitions ✅ |
+| `verify-stac.py` (dataset + bucket, full data checks) | PASS ✅ |
+| PMTiles-fields + categorical linters | PASS ✅ |
+
+**No seam inflation.** `h0=576707042908045311` is the cell `AGENTS.md` flags for dateline
+problems, and it is populated here — but legitimately: it holds 705 Alaska features spanning
+longitudes −150.01 to −138.94, entirely in the western hemisphere with no wrap to +180. The
+layer's Alaska coverage is the Southeast panhandle and Chugach, so the antimeridian is never
+crossed.
+
+### Per-feature duplication verdict (`scripts/audit-feature-dup.py`)
+
+Dedup key `_cng_fid`, 0 blank. All eight attribute columns classify **REPEATED** — 10,728 of
+11,391 features occupy more than one hex row, and `_cng_fid` repeats 1,431.79× on average. Raw
+`SUM(ACRES)` over hex rows inflates 32,891.77× (1.92 × 10¹² acres against a true 58,419,694).
+`COUNT(*)` returns 16,309,549 cells rather than 11,391 polygons. Both traps are documented in the
+hex asset description with correct-vs-wrong SQL.
+
+Axis 2 (upstream row duplication) does **not** apply: the flat parquet's
+`COUNT(DISTINCT _cng_fid)` equals its row count, so each input row is one logical polygon.
+
+### Published
+
+- `s3://public-usfs/roadless-areas-2001.parquet` · `.pmtiles` · `roadless-areas-2001/hex/h0=*/data_0.parquet`
+- `s3://public-usfs/roadless-areas-2001/stac-collection.json` (dataset collection)
+- `s3://public-usfs/stac-collection.json` (bucket collection, id `usfs-datasets`)
+- `s3://public-usfs/README.md`
+- `public-usfs` registered as a child of `public-data/stac/catalog.json` (61 → 62 children)

--- a/catalog/usfs/k8s/roadless-areas-2001/BUILD.md
+++ b/catalog/usfs/k8s/roadless-areas-2001/BUILD.md
@@ -1,0 +1,160 @@
+# `roadless-areas-2001` — build notes and measured evidence
+
+USFS Inventoried Roadless Areas designated by the 2001 Roadless Area Conservation Rule
+(36 CFR 294 Subpart B). Issue: boettiger-lab/data-workflows#584. First dataset in the new
+`public-usfs` bucket.
+
+## Source
+
+```
+https://data.fs.usda.gov/geodata/edw/edw_resources/shp/S_USA.RoadlessArea_2001.zip
+```
+
+Verified 2026-08-19: HTTP 200, `application/zip`, **41,740,635 bytes**,
+`Last-Modified: Sun, 11 May 2025 17:11:45 GMT`. Zip contents include the FGDC metadata
+sidecar `S_USA.RoadlessArea_2001.shp.xml` (40,825 bytes), staged separately under
+`raw/` so provenance can be cited without unpacking the archive.
+
+Landing page: <https://www.fs.usda.gov/managing-land/planning/roadless>.
+Credit (FGDC `idCredit`): US Forest Service, Geospatial Service and Technology Center
+(GSTC), National Inventoried Roadless Areas Program. FGDC `pubDate` 2023-10-03.
+
+## Measured schema (read from the source shapefile, 2026-08-19)
+
+11,391 **Polygon** features (not MultiPolygon), **EPSG:4269 (NAD83)** → reprojected to
+EPSG:4326 by `cng-convert-to-parquet`. Source extent
+`(-150.008, 18.246) … (-65.707, 61.519)` — Alaska coverage is the Southeast/Chugach
+panhandle, so **the layer does not cross the antimeridian** and the h0 dateline cell is
+not in play. The southern limit is Puerto Rico.
+
+| Column | Type | Measured domain / range |
+|---|---|---|
+| `REGION` | int32 | `1,2,3,4,5,6,8,9,10` — **no Region 7** (confirmed in FGDC `attrdef`) |
+| `FOREST` | string | 122 distinct forest names |
+| `STATE` | string | 39 distinct 2-letter codes (incl. `PR`) |
+| `NAME` | string | 2,618 distinct; **1,219 names occur on more than one polygon**; **4 NULLs** |
+| `CATEGORY` | string | `1B` (3,365), `1B-1` (178), `1C` (7,848) |
+| `ACRES` | double | min 0.010261, max 1,160,364.68 — per-feature total |
+| `SHAPE_AREA` | double | per-feature total |
+| `SHAPE_LEN` | double | per-feature total |
+
+Per-polygon acreage by state and category:
+`1B` 19,970,735 ac · `1B-1` 4,211,812 ac · `1C` 34,237,147 ac.
+
+`NAME` is **not** a feature key (1,219 duplicated names, 4 NULLs) — use the synthesized
+`_cng_fid` as the stable per-feature key.
+
+### Authoritative `CATEGORY` domain (from the FGDC `edom` entries, not inferred)
+
+- `1B` — Inventoried Roadless Areas where road construction and reconstruction is prohibited.
+- `1B-1` — Inventoried Roadless Areas that are recommended for wilderness designation in the
+  forest plan and where road construction and reconstruction is prohibited.
+- `1C` — Inventoried Roadless Areas where road construction and reconstruction is **not**
+  prohibited.
+
+⚠️ The FGDC metadata attaches the same caveat to all three: *"The category descriptions are
+based on forest plan direction prior to adoption of the Roadless Rule. This information is
+displayed for historical reference. However, the Roadless Rule prohibits road construction in
+all IRAs, regardless of the attribute descriptions."* So `CATEGORY = '1C'` does **not** mean
+road construction was permitted under the 2001 Rule; it records pre-rule forest-plan
+direction. This must not be read as a rule-status field.
+
+## Acceptance criteria — reproduced from the source before the build
+
+Computed by iterating the source shapefile (`scripts` in the session scratchpad, GDAL/OGR):
+
+| Quantity | Computed | Issue target | ✓ |
+|---|---|---|---|
+| `SUM(ACRES)` all features | 58,419,694 | 58,419,694 | ✓ |
+| `SUM(ACRES) WHERE STATE IN ('ID','CO')` | 13,718,692 (23.5%) | — | — |
+| `SUM(ACRES) WHERE STATE NOT IN ('ID','CO')` | **44,701,002** | 44,701,002 | ✓ |
+| West-10 ÷ rule-affected | **95.61%** | 95.6% | ✓ |
+| West-10 ÷ all-IRA | 73.16% | 73.2% | ✓ |
+| Montana | 6,395,401 | 6,395,401 | ✓ |
+| Feature count | 11,391 | 11,391 | ✓ |
+
+West-10 = `AK, AZ, CA, MT, NV, NM, OR, UT, WA, WY`.
+
+**The denominator is load-bearing.** The 2026-08-18 announcement's ">44 million acres" and
+">95% in 10 Western states" are both computed against the **44.7M rule-affected** base
+(`STATE NOT IN ('ID','CO')`), not the 58.4M all-IRA total — West-10 over the full 58.4M is
+73.16%, not 95.61%. Both totals go in the STAC collection description so a consumer cannot
+silently pick the wrong base.
+
+The proposed rescission does not apply to Idaho or Colorado, which adopted state-specific
+roadless rules (2008 and 2012). There is **no rule-type attribute** — the split is by
+`STATE`. The FGDC abstract states the position directly: *"Idaho and Colorado have adopted
+state-specific roadless rules. The Idaho and Colorado Roadless Areas boundaries, represented
+in separate datasets, supersede the 2001 Roadless Area Boundaries."* So the ID and CO
+polygons here are the **superseded** 2001 boundaries — they are retained (not clipped out)
+because they are the untouched-comparison stratum and part of the "95% in 10 states"
+denominator, but they are not the operative boundaries for those two states.
+
+Probed and confirmed **404** on the EDW shapefile endpoint, so there is no companion EDW
+layer to ingest here: `S_USA.RoadlessArea_Idaho2008`, `…_Colorado2012`, `…_Idaho`,
+`…_Colorado`, `S_USA.IdahoRoadlessArea`, `S_USA.ColoradoRoadlessArea`.
+
+## Pipeline
+
+| Setting | Value | Why |
+|---|---|---|
+| dataset | `roadless-areas-2001` | PMTiles `source-layer` = `roadless-areas-2001` |
+| bucket | `public-usfs` | new bucket; also hosts #585, #588, #591 |
+| H3 native | `10` | parents `9,8,0`; small-to-moderate polygons, res 10 keeps sub-acre slivers from vanishing, and `h8` is the catalog join key |
+| `--max-completions` | `12` | fixed chunk size is 1000 → `ceil(11391/1000) = 12`. The default 200 would schedule 188 no-op pods |
+| `--hex-memory` | `16Gi` | largest single feature is Juneau-Skagway Icefield, 1,160,365 ac ≈ 4,700 km² ≈ 313k res-10 cells — comfortable, with headroom |
+| `--row-group-size` | 100000 (default) | total geometry is ~55 MB, far below the ~2.8 GB httpfs `stoi` cliff |
+| namespace | `geo-workflows` | |
+
+Run order (the bucket is new, so `setup-bucket` must precede `stage-raw`):
+
+```bash
+kubectl apply -n geo-workflows -f workflow-rbac.yaml           # once per namespace
+kubectl apply -n geo-workflows -f roadless-areas-2001-setup-bucket.yaml
+kubectl apply -n geo-workflows -f roadless-areas-2001-stage-raw.yaml
+kubectl apply -n geo-workflows -f configmap.yaml -f workflow.yaml
+```
+
+`stage-raw` asserts the exact 41,740,635-byte length and the `PK` zip magic before upload,
+so an HTML error page served with HTTP 200 fails the job instead of poisoning the build.
+
+## Post-build verification
+
+```sql
+-- flat: the four acceptance numbers, from the ingested parquet
+SELECT COUNT(*)                                                   AS features,
+       SUM(ACRES)                                                 AS all_ira_acres,
+       SUM(ACRES) FILTER (WHERE STATE NOT IN ('ID','CO'))         AS rule_affected_acres,
+       SUM(ACRES) FILTER (WHERE STATE IN ('AK','AZ','CA','MT','NV','NM','OR','UT','WA','WY'))
+         / SUM(ACRES) FILTER (WHERE STATE NOT IN ('ID','CO')) * 100 AS west10_pct
+FROM read_parquet('s3://public-usfs/roadless-areas-2001.parquet');
+-- expect 11391 | 58419694 | 44701002 | 95.61
+
+-- hex coverage: every feature must survive hexing (the #494 silent-cap check)
+SELECT COUNT(DISTINCT _cng_fid) FROM
+  read_parquet('s3://public-usfs/roadless-areas-2001/hex/h0=*/data_0.parquet');
+-- expect 11391
+```
+
+Then the h0 partition gate and the STAC gate:
+
+```bash
+scripts/check-hex-coverage.sh nrp:public-usfs/roadless-areas-2001/hex/ --expect-count <N>
+scripts/verify-stac.py --bucket public-usfs --dataset roadless-areas-2001
+```
+
+## Notes
+
+- **No backup/mirror registration happens in this repo.** Issue #584 (and #585/#586/#588)
+  cite `AGENTS.md:661` for "root-catalog registration + MinIO backup" on a new bucket. That
+  instruction is stale: `AGENTS.md` Step 7 on `main` now states the backup and source.coop
+  tiers are owned end to end by geo-agent-ops and that data-workflows supplies them nothing.
+  The only obligation here is an accurate SPDX `license` plus a license link in the STAC.
+  `catalog/sync/` no longer exists on `main`.
+- License: US Forest Service work, no upstream restriction beyond a no-warranty disclaimer
+  and "Data may be viewed and used by any and all entities" (FGDC `useLimit`) → US federal
+  work, `public-domain`.
+- The FGDC access constraint is worth carrying into STAC: source scales vary, external
+  features cannot be expected to align, and the National Forest Planning Record Documents
+  (Appendix C) / RARE II documents remain the official version of the inventory. Relevant to
+  any road-proximity buffering in #588.

--- a/catalog/usfs/k8s/roadless-areas-2001/configmap.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/configmap.yaml
@@ -1,0 +1,427 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: roadless-areas-2001-setup-bucket.yaml, roadless-areas-2001-convert.yaml, roadless-areas-2001-pmtiles.yaml, roadless-areas-2001-hex.yaml, roadless-areas-2001-repartition.yaml
+# Generation command: cng-datasets workflow --dataset roadless-areas-2001 --source-url https://s3-west.nrp-nautilus.io/public-usfs/raw/S_USA.RoadlessArea_2001.zip --bucket public-usfs --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap roadless-areas-2001-yamls \
+#     --from-file=roadless-areas-2001-setup-bucket.yaml \
+#     --from-file=roadless-areas-2001-convert.yaml \
+#     --from-file=roadless-areas-2001-pmtiles.yaml \
+#     --from-file=roadless-areas-2001-hex.yaml \
+#     --from-file=roadless-areas-2001-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  roadless-areas-2001-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: roadless-areas-2001-convert
+      labels:
+        k8s-app: roadless-areas-2001-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: roadless-areas-2001-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-usfs
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                https://s3-west.nrp-nautilus.io/public-usfs/raw/S_USA.RoadlessArea_2001.zip \
+                s3://public-usfs/roadless-areas-2001.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  roadless-areas-2001-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: roadless-areas-2001-hex
+      labels:
+        k8s-app: roadless-areas-2001-hex
+    spec:
+      completions: 12
+      parallelism: 12
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: roadless-areas-2001-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usfs
+            - name: DATASET
+              value: roadless-areas-2001
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-usfs/roadless-areas-2001.parquet --output s3://public-usfs/roadless-areas-2001/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  roadless-areas-2001-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: roadless-areas-2001-pmtiles
+      labels:
+        k8s-app: roadless-areas-2001-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: roadless-areas-2001-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usfs
+            - name: DATASET
+              value: roadless-areas-2001
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usfs/roadless-areas-2001.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-usfs/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 16Gi
+              limits:
+                cpu: '4'
+                memory: 16Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  roadless-areas-2001-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: roadless-areas-2001-repartition
+      labels:
+        k8s-app: roadless-areas-2001-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: roadless-areas-2001-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-usfs
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-usfs/roadless-areas-2001/chunks --output-dir s3://public-usfs/roadless-areas-2001/hex --source-parquet s3://public-usfs/roadless-areas-2001.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  roadless-areas-2001-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: roadless-areas-2001-setup-bucket
+      labels:
+        k8s-app: roadless-areas-2001-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: roadless-areas-2001-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-usfs
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: roadless-areas-2001-yamls
+  namespace: geo-workflows

--- a/catalog/usfs/k8s/roadless-areas-2001/gen_stac.py
+++ b/catalog/usfs/k8s/roadless-areas-2001/gen_stac.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Emit the public-usfs bucket collection, the roadless-areas-2001 dataset collection,
+and the bucket README to /tmp for rclone upload (AGENTS.md Hard Boundary 1 — this repo
+never contains STAC JSON or README files).
+
+One source schema (COLUMNS) is written identically to the flat GeoParquet and the hex so
+the mcp-data-server#303 per-column fold never drops a variant. PMTiles gets the lean
+form (name + type + values, no prose).
+"""
+import copy
+import json
+
+BUCKET = "public-usfs"
+DATASET = "roadless-areas-2001"
+BASE = f"https://s3-west.nrp-nautilus.io/{BUCKET}"
+ROOT = "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
+BBOX = [-150.008, 18.246, -65.707, 61.519]
+
+CATEGORY_DEF = (
+    "Land-use category recorded in the forest plan that predates the 2001 Roadless Rule, kept "
+    "for historical reference. Values: 1B=Inventoried roadless area where road construction and "
+    "reconstruction is prohibited, 1B-1=Inventoried roadless area recommended for wilderness "
+    "designation in the forest plan, where road construction and reconstruction is prohibited, "
+    "1C=Inventoried roadless area where road construction and reconstruction is not prohibited. "
+    "These labels describe pre-rule forest plan direction, not the rule itself: the 2001 Roadless "
+    "Rule prohibits road construction across every inventoried roadless area regardless of "
+    "category, so category 1C does not identify areas where the rule permits road building."
+)
+
+REGION_DEF = (
+    "USDA Forest Service administrative region. Values: 1=Northern, 2=Rocky Mountain, "
+    "3=Southwestern, 4=Intermountain, 5=Pacific Southwest, 6=Pacific Northwest, 8=Southern, "
+    "9=Eastern, 10=Alaska. There is no Region 7."
+)
+
+STATE_NAMES = {
+    "AK": "Alaska", "AL": "Alabama", "AR": "Arkansas", "AZ": "Arizona", "CA": "California",
+    "CO": "Colorado", "FL": "Florida", "GA": "Georgia", "ID": "Idaho", "IL": "Illinois",
+    "IN": "Indiana", "KY": "Kentucky", "LA": "Louisiana", "ME": "Maine", "MI": "Michigan",
+    "MN": "Minnesota", "MO": "Missouri", "MS": "Mississippi", "MT": "Montana",
+    "NC": "North Carolina", "ND": "North Dakota", "NH": "New Hampshire", "NM": "New Mexico",
+    "NV": "Nevada", "OK": "Oklahoma", "OR": "Oregon", "PA": "Pennsylvania", "PR": "Puerto Rico",
+    "SC": "South Carolina", "SD": "South Dakota", "TN": "Tennessee", "TX": "Texas", "UT": "Utah",
+    "VA": "Virginia", "VT": "Vermont", "WA": "Washington", "WI": "Wisconsin",
+    "WV": "West Virginia", "WY": "Wyoming",
+}
+STATES = sorted(STATE_NAMES)
+STATE_LIST = ", ".join(f"{k}={v}" for k, v in sorted(STATE_NAMES.items()))
+
+# name, type, description, values
+COLUMNS = [
+    ("_cng_fid", "int64",
+     "Stable per-feature identifier assigned during conversion, unique for every one of the "
+     "11,391 source polygons. Use this as the feature key: the roadless area name is not unique "
+     "(1,219 names appear on more than one polygon) and is empty on 4 polygons.", None),
+    ("OGC_FID", "int64", "Sequential row identifier carried over from the source shapefile.", None),
+    ("REGION", "int32", REGION_DEF, [1, 2, 3, 4, 5, 6, 8, 9, 10]),
+    ("FOREST", "string",
+     "Name of the national forest or grassland administering the area. 122 distinct names.", None),
+    ("STATE", "string",
+     "Two-letter state or territory abbreviation, covering 38 states and Puerto Rico. This is the "
+     "field that separates the areas the 2026 proposed rescission would affect from the ones it "
+     "would not: the proposal excludes Idaho and Colorado, which adopted their own state-specific "
+     "roadless rules in 2008 and 2012. There is no separate rule-type attribute, so the split is "
+     "made on this column. Values: " + STATE_LIST, STATES),
+    ("NAME", "string",
+     "Name of the inventoried roadless area. 2,618 distinct names across 11,391 polygons: a "
+     "single named area is often split into several polygons, and 4 polygons carry no name. Group "
+     "by the feature identifier rather than by name to count areas.", None),
+    ("CATEGORY", "string", CATEGORY_DEF, ["1B", "1B-1", "1C"]),
+    ("ACRES", "float64",
+     "Area of the whole source polygon in acres, as published by the Forest Service. Summing this "
+     "column over all 11,391 polygons gives 58,419,694 acres; restricting to polygons outside "
+     "Idaho and Colorado gives 44,701,002 acres.", None),
+    ("SHAPE_AREA", "float64", "Area of the whole source polygon in the source projection's units.", None),
+    ("SHAPE_LEN", "float64", "Perimeter of the whole source polygon in the source projection's units.", None),
+]
+
+H3_COLUMNS = [
+    ("h10", "uint64", "H3 cell identifier at resolution 10.", None),
+    ("h9", "uint64", "H3 cell identifier at resolution 9.", None),
+    ("h8", "uint64", "H3 cell identifier at resolution 8.", None),
+    ("h0", "int64",
+     "H3 cell identifier at resolution 0, used as the partition key for hive-partitioned reads.", None),
+]
+
+GEOM = ("geom", "geometry", "Feature geometry (GeoParquet), in EPSG:4326.", None)
+
+
+def cols(entries, lean=False):
+    out = []
+    for name, typ, desc, values in entries:
+        c = {"name": name, "type": typ}
+        if not lean:
+            c["description"] = desc
+        if values is not None:
+            c["values"] = values
+        out.append(c)
+    return out
+
+
+TITLE = "Inventoried Roadless Areas (2001 Roadless Rule)"
+
+HEX_NOTE = (
+    "One row per (polygon, resolution 10 cell) pair — 16,309,549 rows for 11,391 polygons, since a "
+    "polygon that covers many cells appears on many rows. Every attribute column is therefore "
+    "repeated on every cell the polygon covers, so counts and totals must go through _cng_fid:\n\n"
+    "```sql\n"
+    "-- correct: 11,391 roadless area polygons, 58,419,694 acres\n"
+    "SELECT COUNT(DISTINCT _cng_fid) FROM read_parquet('…/hex/h0=*/data_0.parquet');\n"
+    "SELECT SUM(ACRES) FROM (SELECT DISTINCT _cng_fid, ACRES\n"
+    "                        FROM read_parquet('…/hex/h0=*/data_0.parquet'));\n"
+    "-- wrong: COUNT(*) returns 16,309,549 cells, not polygons\n"
+    "-- wrong: SUM(ACRES) over raw rows returns about 1.9 trillion acres\n"
+    "```\n\n"
+    "For the area of a selection, prefer the H3 footprint of its distinct cells over summing ACRES; "
+    "across the whole layer the two agree to within 0.25%."
+)
+
+DESCRIPTION = (
+    "The official Forest Service boundaries of the Inventoried Roadless Areas designated by the "
+    "2001 Roadless Area Conservation Rule (36 CFR 294, Subpart B) — 11,391 polygons covering "
+    "58,419,694 acres across 38 states and Puerto Rico.\n\n"
+    "**Two different national totals, and choosing the wrong one changes the answer.** All "
+    "inventoried roadless areas together come to 58,419,694 acres. The 2026 proposed rescission of "
+    "the rule excludes Idaho and Colorado, which adopted their own state-specific roadless rules in "
+    "2008 and 2012, and those two states hold 13,718,692 acres. The area the proposal would affect "
+    "is therefore 44,701,002 acres. Percentages quoted about the proposal are generally computed "
+    "against that smaller base, and the two bases give materially different answers — the ten "
+    "Western states of Alaska, Arizona, California, Montana, Nevada, New Mexico, Oregon, Utah, "
+    "Washington and Wyoming hold 95.61% of the 44,701,002-acre affected total but 73.16% of the "
+    "58,419,694-acre full total. State any figure alongside the base it uses.\n\n"
+    "There is no attribute recording which rule governs a given area, so the Idaho and Colorado "
+    "split is made on the STATE column:\n\n"
+    "```sql\n"
+    "-- acres the 2026 proposed rescission would affect\n"
+    "SELECT SUM(ACRES) FROM read_parquet('" + BASE + "/" + DATASET + ".parquet')\n"
+    "WHERE STATE NOT IN ('ID','CO');\n"
+    "```\n\n"
+    "Idaho and Colorado are included in this layer rather than removed, for two reasons: they are "
+    "part of the denominator for any national percentage, and they serve as a comparison group of "
+    "roadless areas the proposal leaves alone. Note that for those two states these are the "
+    "superseded 2001 boundaries — the Forest Service publishes the operative Idaho and Colorado "
+    "roadless boundaries as separate datasets, which are not included here.\n\n"
+    "The CATEGORY column is a frequent source of error. It records forest plan direction from "
+    "before the rule took effect, so category 1C reads as though road construction were allowed. "
+    "It was not: the 2001 rule prohibits road construction across every inventoried roadless area "
+    "regardless of category.\n\n"
+    "The Forest Service cautions that source scales vary across this layer and that boundaries "
+    "cannot be expected to align with features from other datasets; the National Forest Planning "
+    "Record documents remain the official version of the inventory. Treat boundary-adjacency and "
+    "buffer-distance results as approximate."
+)
+
+
+def dataset_collection():
+    flat_cols = cols(COLUMNS) + cols([GEOM])
+    hex_cols = cols(COLUMNS) + cols(H3_COLUMNS)
+    pm_cols = cols(COLUMNS, lean=True)
+    extent = f"({BBOX[0]}, {BBOX[1]}, {BBOX[2]}, {BBOX[3]})"
+    return {
+        "stac_version": "1.0.0",
+        "type": "Collection",
+        "id": DATASET,
+        "title": f"{TITLE} — national",
+        "description": DESCRIPTION,
+        "license": "public-domain",
+        "stac_extensions": ["https://stac-extensions.github.io/table/v1.2.0/schema.json"],
+        "extent": {
+            "spatial": {"bbox": [BBOX]},
+            "temporal": {"interval": [["2001-01-12T00:00:00Z", None]]},
+        },
+        "providers": [
+            {"name": "USDA Forest Service, Geospatial Service and Technology Center",
+             "roles": ["producer", "licensor"],
+             "url": "https://www.fs.usda.gov/managing-land/planning/roadless"},
+            {"name": "Boettiger Lab / cirrus", "roles": ["processor", "host"],
+             "url": f"{BASE}/"},
+        ],
+        "links": [
+            {"rel": "self", "href": f"{BASE}/{DATASET}/stac-collection.json",
+             "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": f"{BASE}/stac-collection.json",
+             "type": "application/json"},
+            {"rel": "license", "href": "https://www.usa.gov/government-works",
+             "type": "text/html", "title": "US Government work — public domain"},
+            {"rel": "via",
+             "href": "https://data.fs.usda.gov/geodata/edw/edw_resources/shp/S_USA.RoadlessArea_2001.zip",
+             "type": "application/zip", "title": "Source shapefile (Forest Service EDW)"},
+            {"rel": "describedby", "href": f"{BASE}/raw/S_USA.RoadlessArea_2001.shp.xml",
+             "type": "application/xml", "title": "FGDC metadata as published with the source"},
+        ],
+        "assets": {
+            f"{DATASET}-parquet": {
+                "href": f"{BASE}/{DATASET}.parquet",
+                "type": "application/x-parquet",
+                "title": f"{TITLE} {extent} — GeoParquet",
+                "description": "One row per source polygon (11,391 rows). Use this asset for "
+                               "boundary geometry and for true distance or buffer work.",
+                "roles": ["data"],
+                "table:columns": flat_cols,
+            },
+            f"{DATASET}-pmtiles": {
+                "href": f"{BASE}/{DATASET}.pmtiles",
+                "type": "application/vnd.pmtiles",
+                "title": f"{TITLE} {extent} — PMTiles",
+                "roles": ["data", "visual"],
+                "vector:layers": [DATASET],
+                "table:columns": pm_cols,
+            },
+            f"{DATASET}-hex": {
+                "href": f"{BASE}/{DATASET}/hex/h0=*/data_0.parquet",
+                "type": "application/x-parquet",
+                "title": f"{TITLE} {extent} — H3 Hex (resolution 10)",
+                "description": HEX_NOTE + " Use this asset to join roadless areas against other "
+                               "hex datasets in the catalog; resolution 8 is the shared join key.",
+                "roles": ["data"],
+                "h3:native_resolution": 10,
+                "h3:parent_resolutions": [9, 8, 0],
+                "table:columns": hex_cols,
+            },
+        },
+    }
+
+
+def bucket_collection():
+    return {
+        "stac_version": "1.0.0",
+        "type": "Collection",
+        "id": "usfs-datasets",
+        "title": "USDA Forest Service (USFS) Datasets",
+        "description":
+            "Geospatial datasets administered by the USDA Forest Service and published from the "
+            "Forest Service Enterprise Data Warehouse, starting with the Inventoried Roadless "
+            "Areas of the 2001 Roadless Area Conservation Rule. Forest Service activity records "
+            "(FACTS) are published separately in the public-facts bucket, and Forest Service "
+            "wildfire products in public-fire.",
+        "license": "public-domain",
+        "extent": {
+            "spatial": {"bbox": [BBOX]},
+            "temporal": {"interval": [["2001-01-12T00:00:00Z", None]]},
+        },
+        "providers": [
+            {"name": "USDA Forest Service", "roles": ["producer", "licensor"],
+             "url": "https://data.fs.usda.gov/geodata/edw/datasets.php"},
+            {"name": "Boettiger Lab / cirrus", "roles": ["processor", "host"],
+             "url": f"{BASE}/"},
+        ],
+        "links": [
+            {"rel": "self", "href": f"{BASE}/stac-collection.json", "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": ROOT, "type": "application/json"},
+            {"rel": "license", "href": "https://www.usa.gov/government-works",
+             "type": "text/html", "title": "US Government work — public domain"},
+            {"rel": "child", "href": f"{BASE}/{DATASET}/stac-collection.json",
+             "type": "application/json", "title": f"{TITLE} — national"},
+        ],
+    }
+
+
+README = f"""# `{BUCKET}` — USDA Forest Service datasets
+
+Cloud-native mirrors of USDA Forest Service geospatial data, published as GeoParquet, PMTiles
+and H3 hex parquet on NRP S3.
+
+STAC: <{BASE}/stac-collection.json>
+
+## Collections
+
+| Dataset | Description |
+|---|---|
+| [`{DATASET}`]({BASE}/{DATASET}/stac-collection.json) | Inventoried Roadless Areas designated by the 2001 Roadless Area Conservation Rule (36 CFR 294 Subpart B) — 11,391 polygons, 58,419,694 acres, national |
+
+## `{DATASET}`
+
+### The two national totals
+
+All inventoried roadless areas come to **58,419,694 acres**. The 2026 proposed rescission of the
+rule excludes Idaho and Colorado — which adopted their own state-specific roadless rules in 2008
+and 2012 — leaving **44,701,002 acres** affected. Percentages about the proposal are generally
+computed against the smaller base, and the choice matters: the ten Western states hold 95.61% of
+the affected total but 73.16% of the full total. Always state which base a figure uses.
+
+There is no rule-type attribute, so the split is made on `STATE`:
+
+```sql
+SELECT
+  SUM(ACRES)                                          AS all_ira_acres,          -- 58,419,694
+  SUM(ACRES) FILTER (WHERE STATE NOT IN ('ID','CO'))  AS rule_affected_acres     -- 44,701,002
+FROM read_parquet('{BASE}/{DATASET}.parquet');
+```
+
+### DuckDB
+
+```sql
+INSTALL spatial; LOAD spatial;
+INSTALL httpfs;  LOAD httpfs;
+
+-- roadless acres by state, largest first
+SELECT STATE, ROUND(SUM(ACRES)) AS acres, COUNT(*) AS polygons
+FROM read_parquet('{BASE}/{DATASET}.parquet')
+GROUP BY STATE ORDER BY acres DESC;
+```
+
+The hex asset carries one row per (polygon, resolution 10 cell) pair, so whole-polygon totals
+(`ACRES`, `SHAPE_AREA`, `SHAPE_LEN`) repeat across every cell a polygon covers. Deduplicate on
+`_cng_fid` before summing them:
+
+```sql
+SELECT SUM(ACRES) FROM (
+  SELECT DISTINCT _cng_fid, ACRES
+  FROM read_parquet('{BASE}/{DATASET}/hex/h0=*/data_0.parquet')
+);
+```
+
+Native resolution is 10, with parents 9, 8 and 0. Join to other catalog datasets on `h8`.
+
+### MapLibre GL JS
+
+The PMTiles `source-layer` is **`{DATASET}`**.
+
+```js
+import * as pmtiles from 'pmtiles';
+maplibregl.addProtocol('pmtiles', new pmtiles.Protocol().tile);
+
+map.addSource('roadless', {{
+  type: 'vector',
+  url: 'pmtiles://{BASE}/{DATASET}.pmtiles'
+}});
+
+// affected by the 2026 proposed rescission vs. governed by a state rule
+map.addLayer({{
+  id: 'roadless-fill',
+  type: 'fill',
+  source: 'roadless',
+  'source-layer': '{DATASET}',
+  paint: {{
+    'fill-color': [
+      'match', ['get', 'STATE'],
+      ['ID', 'CO'], '#9e9e9e',
+      '#2e7d32'
+    ],
+    'fill-opacity': 0.6
+  }}
+}});
+```
+
+## Caveats
+
+- `CATEGORY` records forest plan direction from *before* the rule took effect. Category `1C` reads
+  as though road construction were permitted; it was not. The 2001 rule prohibits road
+  construction across every inventoried roadless area regardless of category.
+- `NAME` is not unique — 2,618 distinct names across 11,391 polygons, and 4 polygons are unnamed.
+  Count areas with `_cng_fid`, not `NAME`.
+- For Idaho and Colorado these are the **superseded** 2001 boundaries. The operative boundaries for
+  those two states are published by the Forest Service as separate datasets and are not included.
+- The Forest Service notes that source scales vary and that these boundaries cannot be expected to
+  align with features from other datasets. Treat adjacency and buffer-distance results as
+  approximate.
+
+## License
+
+US Government work — public domain. Produced by the USDA Forest Service, Geospatial Service and
+Technology Center. Source: [Forest Service EDW](https://data.fs.usda.gov/geodata/edw/edw_resources/shp/S_USA.RoadlessArea_2001.zip),
+landing page <https://www.fs.usda.gov/managing-land/planning/roadless>. The FGDC metadata as
+published with the source is retained at `{BASE}/raw/S_USA.RoadlessArea_2001.shp.xml`.
+"""
+
+if __name__ == "__main__":
+    with open("/tmp/usfs-bucket-stac.json", "w") as f:
+        json.dump(bucket_collection(), f, indent=2)
+        f.write("\n")
+    with open("/tmp/roadless-areas-2001-stac.json", "w") as f:
+        json.dump(dataset_collection(), f, indent=2)
+        f.write("\n")
+    with open("/tmp/usfs-README.md", "w") as f:
+        f.write(README)
+    print("wrote /tmp/usfs-bucket-stac.json /tmp/roadless-areas-2001-stac.json /tmp/usfs-README.md")

--- a/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-convert.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-convert
+  labels:
+    k8s-app: roadless-areas-2001-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: roadless-areas-2001-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usfs
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            https://s3-west.nrp-nautilus.io/public-usfs/raw/S_USA.RoadlessArea_2001.zip \
+            s3://public-usfs/roadless-areas-2001.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-hex.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-hex
+  labels:
+    k8s-app: roadless-areas-2001-hex
+spec:
+  completions: 12
+  parallelism: 12
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: roadless-areas-2001-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usfs
+        - name: DATASET
+          value: roadless-areas-2001
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-usfs/roadless-areas-2001.parquet --output s3://public-usfs/roadless-areas-2001/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-pmtiles.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-pmtiles.yaml
@@ -1,0 +1,94 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-pmtiles
+  labels:
+    k8s-app: roadless-areas-2001-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: roadless-areas-2001-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usfs
+        - name: DATASET
+          value: roadless-areas-2001
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-usfs/roadless-areas-2001.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-usfs/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-repartition.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-repartition
+  labels:
+    k8s-app: roadless-areas-2001-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: roadless-areas-2001-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-usfs
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-usfs/roadless-areas-2001/chunks --output-dir s3://public-usfs/roadless-areas-2001/hex --source-parquet s3://public-usfs/roadless-areas-2001.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-setup-bucket.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-setup-bucket
+  labels:
+    k8s-app: roadless-areas-2001-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: roadless-areas-2001-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-usfs
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-stage-raw.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/roadless-areas-2001-stage-raw.yaml
@@ -1,0 +1,88 @@
+# Step 1b: stage the USFS Inventoried Roadless Areas (2001 Roadless Rule) shapefile
+# at s3://public-usfs/raw/ so the convert step restarts from S3 rather than re-hitting
+# data.fs.usda.gov.
+#
+# Source (verified 2026-08-19): S_USA.RoadlessArea_2001.zip, 41,740,635 bytes,
+# Last-Modified Sun, 11 May 2025 17:11:45 GMT, EPSG:4269, 11,391 Polygon features.
+# The zip carries the FGDC .shp.xml (40,825 bytes) — extracted alongside the zip so
+# STAC provenance can cite it without unpacking the archive.
+#
+# ⚠️ public-usfs is a BRAND-NEW bucket: run roadless-areas-2001-setup-bucket.yaml
+# BEFORE this job, or the upload fails with NoSuchBucket after the download
+# (AGENTS.md Step 1b).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-stage-raw
+  labels:
+    k8s-app: roadless-areas-2001-stage-raw
+spec:
+  backoffLimit: 2
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: roadless-areas-2001-stage-raw
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+      containers:
+      - name: stage-raw
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: '2'
+            memory: 4Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '2'
+            memory: 4Gi
+            ephemeral-storage: 10Gi
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cd /tmp
+          echo "Downloading S_USA.RoadlessArea_2001.zip ..."
+          curl -L --retry 5 --fail -o S_USA.RoadlessArea_2001.zip \
+            "https://data.fs.usda.gov/geodata/edw/edw_resources/shp/S_USA.RoadlessArea_2001.zip"
+
+          # Fail loudly on an HTML error page served with HTTP 200.
+          SIZE=$(stat -c %s S_USA.RoadlessArea_2001.zip)
+          echo "Downloaded ${SIZE} bytes"
+          if [ "$SIZE" -ne 41740635 ]; then
+            echo "ERROR: expected 41740635 bytes, got ${SIZE}" >&2
+            exit 1
+          fi
+          head -c 2 S_USA.RoadlessArea_2001.zip | grep -q 'PK' || { echo "ERROR: not a zip" >&2; exit 1; }
+
+          echo "Extracting FGDC metadata sidecar ..."
+          unzip -o -j S_USA.RoadlessArea_2001.zip 'S_USA.RoadlessArea_2001.shp.xml'
+
+          echo "Staging to s3://public-usfs/raw/ ..."
+          rclone mkdir nrp:public-usfs/raw
+          rclone copy S_USA.RoadlessArea_2001.zip nrp:public-usfs/raw/ -P
+          rclone copy S_USA.RoadlessArea_2001.shp.xml nrp:public-usfs/raw/ -P
+          rclone lsl nrp:public-usfs/raw/
+          echo "✓ Complete"
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config

--- a/catalog/usfs/k8s/roadless-areas-2001/workflow-rbac.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/usfs/k8s/roadless-areas-2001/workflow.yaml
+++ b/catalog/usfs/k8s/roadless-areas-2001/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: roadless-areas-2001-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting roadless-areas-2001 workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/roadless-areas-2001-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/roadless-areas-2001-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/roadless-areas-2001-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/roadless-areas-2001-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/roadless-areas-2001-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/roadless-areas-2001-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/roadless-areas-2001-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/roadless-areas-2001-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/roadless-areas-2001-repartition -n geo-workflows\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs roadless-areas-2001-setup-bucket roadless-areas-2001-convert\
+          \ roadless-areas-2001-pmtiles roadless-areas-2001-hex roadless-areas-2001-repartition\
+          \ roadless-areas-2001-workflow -n geo-workflows\"\necho \"  kubectl delete\
+          \ configmap roadless-areas-2001-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: roadless-areas-2001-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800


### PR DESCRIPTION
Closes #584. First dataset in the new `public-usfs` bucket, and the hard blocker for the rest of the `roadless` set (#585–#593) — every other dataset in that group intersects this one.

## What landed

| Asset | |
|---|---|
| `roadless-areas-2001.parquet` | 48.5 MB, 11,391 polygons |
| `roadless-areas-2001.pmtiles` | 93.0 MB, source-layer `roadless-areas-2001` |
| `roadless-areas-2001/hex/h0=*/data_0.parquet` | 16,309,549 rows, 9 populated partitions, native resolution 10, parents 9/8/0 |

Plus the dataset and bucket STAC collections, the bucket README, and `public-usfs` registered as a child of the root catalog. National extent including Alaska and Puerto Rico; Idaho and Colorado retained rather than clipped.

Pipeline ran in `geo-workflows` in **3m20s**. Hex reported `Complete=True` with `failedIndexes: []`, 12/12.

## Acceptance criteria — all verified against the ingested parquet, not the source

| Check | Result |
|---|---|
| `SUM(ACRES)` | 58,419,694 ✅ |
| `SUM(ACRES) WHERE STATE NOT IN ('ID','CO')` | 44,701,002 ✅ |
| West-10 ÷ rule-affected | 95.61% ✅ |
| Montana | 6,395,401 ✅ |
| Feature count | 11,391 ✅ |
| `COUNT(DISTINCT _cng_fid)` on hex | 11,391 — no silent `--max-completions` cap ✅ |
| Deduped `SUM(ACRES)` on hex vs flat | exact match ✅ |
| H3 resolution-10 footprint vs published acreage | −0.25% ✅ |
| Invalid geometries | 0 ✅ |
| h0 partition gate | PASS, 9 == 9 populated ✅ |
| `verify-stac.py` dataset + bucket, with data checks | PASS ✅ |
| PMTiles-fields + categorical linters | PASS ✅ |

`--max-completions 12` rather than the default 200: chunk size is fixed at 1000, so 200 would schedule 188 no-op pods.

No seam inflation. `h0=576707042908045311` — the cell `AGENTS.md` flags for dateline problems — is populated, but legitimately: 705 Alaska features spanning longitudes −150.01 to −138.94, no wrap to +180. This layer's Alaska coverage is the Southeast panhandle and Chugach.

## Things worth a reviewer's attention

**The denominator is load-bearing, so the collection carries both totals.** West-10 is 95.61% of the 44.7M rule-affected base but **73.16%** of the 58.4M full total. A consumer that silently picks the wrong base produces a wrong headline number, so the description states both and defines the exclusion as `STATE NOT IN ('ID','CO')` — there is no rule-type attribute to key on.

**`CATEGORY` is a trap and is documented as one.** The values read as rule status — `1C` is literally "road construction and reconstruction is not prohibited" — but they record *pre-rule forest-plan direction*. The FGDC metadata attaches the correction to all three values: the 2001 rule prohibits road construction in every inventoried roadless area regardless of category. Definitions are verbatim from the FGDC enumerated domain rather than written from memory (#294).

**For Idaho and Colorado these are superseded boundaries.** The FGDC abstract says so directly; the operative state-rule boundaries ship as separate datasets and are not included here. They are kept because they are part of any national denominator and serve as the comparison group the proposal leaves alone.

**`NAME` is not a feature key** — 2,618 distinct names across 11,391 polygons, 1,219 names on more than one polygon, 4 unnamed. `_cng_fid` is the key, and `audit-feature-dup.py` classifies all eight attribute columns REPEATED (raw `SUM(ACRES)` on hex inflates 32,892×; `COUNT(*)` returns cells, not polygons). Both traps are in the hex asset description as correct-vs-wrong SQL.

## Two stale premises in the issues, worth fixing before #585

1. **No bucket registration happens in this repo.** #584 — and #585, #586, #588 — cite `AGENTS.md:661` for "root-catalog registration + MinIO backup" on a new bucket. `AGENTS.md` Step 7 on `main` now states the backup and source.coop tiers are owned end to end by geo-agent-ops and that this repo supplies them nothing; `catalog/sync/` no longer exists on `main`. Nothing was registered for backup here, by design. The only obligation is the SPDX `license`, which is set to `public-domain` with a license link.
2. **`public-fire` already exists** on NRP. #586 describes it as a new bucket needing registration. Only `public-usfs` was genuinely new.

## Note on CI

The Verify STAC check derives collections from the `s3://` paths in changed `catalog/**` YAMLs. The data is already published, so it should come up green; if it was queued before the build finished, re-fire it.
