### PR TITLE
docs: a reorder before a re-convert is what removes the cheap fix (#574, #577)

### DIFF
--- a/catalog/audit/pregate-verify-sweep/README.md
+++ b/catalog/audit/pregate-verify-sweep/README.md
@@ -63,6 +63,36 @@ job lives. `check_hex_fid_matches_flat` (#549) covered all 266 collections in th
 found only these two, so the other eight datasets on that list are clean — but the class is
 worth re-checking after any future backfill, not just after a per-dataset rebuild.
 
+#### A REORDER before a re-convert is what removes the cheap fix
+
+The two collections cost wildly different amounts to repair, and the difference is instructive.
+
+`hydrothermal-vents` was a uniform **+1 shift** (hex 0…720 against flat 1…721): the tool's id
+base changed from 0 to 1, the row order did not, so a re-key would have been provably lossless
+and the actual fix was minutes of cluster time.
+
+`iucn-ranges-2025` was an **unrelated permutation** — 0 of 134,969 ids unchanged. Not because
+its build was worse: its June hex carried the then-current flat's ids faithfully (old ids ran
+0…135,985 with exactly 1,017 gaps, matching the flat's row count and its missing-feature
+count; a build that had invented its own `ROW_NUMBER` would be gapless 0…134,968). What
+differed is that **`catalog/iucn/k8s/sort-ranges-polygons.yaml` (#255) reordered the flat by
+`sci_name` in between**. That job is harmless on its own — a plain `SELECT *`, so ids travel
+with their rows — but the later re-convert then assigned ids in the *new* order. Confirmed by
+inspection: new ids 1,2,3 are `Aa calceata` / `Aa mandonii` / `Aa matthewsii` (alphabetical),
+while old ids 0,1,2 are three parts of `Rhamnus intermedia`.
+
+So the rule to carry:
+
+> **Re-convert alone is recoverable in place. Reorder-then-re-convert is not.**
+> A sort/cluster job (`sort-ranges-polygons.yaml`, and any future one) is safe by itself and
+> unsafe in combination — it silently converts a later renumbering from a uniform offset into
+> a scramble, and once a hex carries no geometry there is nothing left to match parts back by.
+
+Practical consequence: **if you reorder a published flat, treat every hex built from it as
+stale from that moment**, even though nothing is wrong yet — the damage lands on whoever
+re-converts next. Rebuild or re-key the hex in the same change as the sort, or record in the
+dataset's `BUILD.md` that its hex predates the reorder.
+
 `land-cover/nlcd` verifies clean standalone (~690 s) but exceeds a 1200 s cap when eight
 collections run concurrently — a pacing artefact, not a finding. Give it its own slot.
 

--- a/catalog/backfill/k8s/cngfid-372/catA-cngfid-convert.yaml
+++ b/catalog/backfill/k8s/cngfid-372/catA-cngfid-convert.yaml
@@ -1,3 +1,28 @@
+# ⛔ THIS JOB ORPHANS EVERY HEX BUILT FROM THE FLATS IT TOUCHES. Read before re-running it,
+# or before copying it as a template for another backfill.
+#
+# `cng-convert-to-parquet` synthesizes `_cng_fid` at CONVERSION time, so re-converting a
+# published flat renumbers every feature while the hex keeps the old numbering. This job's
+# 2026-07-09 run did exactly that to ten flats, and two of them had hexes:
+#
+#   * high-seas/hydrothermal-vents (13:07) -> data-workflows#574
+#   * iucn/iucn-ranges-2025        (13:10) -> data-workflows#577
+#
+# Neither had any row-count, schema, or coverage symptom. A consumer joining hex->flat on
+# `_cng_fid` — the documented universal key — simply got the wrong feature, for 78 days on
+# one collection and across a 4-billion-row asset on the other. Only
+# `check_hex_fid_matches_flat` (#549) found them, and it did not exist yet at the time.
+#
+# The repair cost differs enormously depending on whether the flat had been REORDERED first:
+#   * not reordered -> a uniform +1 shift, losslessly re-keyable (hydrothermal-vents: minutes)
+#   * reordered     -> an unrelated permutation, and since a hex carries no geometry its parts
+#                      cannot be matched back to flat rows (iucn: a 22 GiB rewrite plus a
+#                      permanent part-level ambiguity — see catalog/iucn/k8s/rekey-577/BUILD.md)
+#
+# SO, IF YOU RE-RUN OR COPY THIS: for every flat in the PAIRS list, rebuild or re-key its hex
+# (and anything else keyed to `_cng_fid`) in the SAME change, and re-run
+# `scripts/verify-stac.py` on those collections afterwards. Do not treat a successful convert
+# as a finished backfill.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/catalog/high-seas/k8s/hydrothermal-vents/BUILD.md
+++ b/catalog/high-seas/k8s/hydrothermal-vents/BUILD.md
@@ -52,6 +52,18 @@ over a published flat renumbers `_cng_fid` and orphans every hex built from it, 
 job lives in this directory or in a catalog-wide backfill. A flat that is re-converted needs
 its hex (and anything else keyed to it) rebuilt in the same pass.
 
+**Why this one was cheap to fix.** The damage here was a uniform **+1 shift** — the tool's id
+base moved from 0 to 1 and the row order did not change — so the hex could have been re-keyed
+losslessly, and a full re-hex of 721 points was minutes anyway. Compare `iucn/iucn-ranges-2025`
+(#577), hit by the *same* backfill on the same afternoon but costing a 4-billion-row rewrite:
+its flat had been **reordered** by a `sci_name` sort in between, so the re-convert assigned ids
+in a new order and produced an unrelated permutation rather than an offset.
+
+The transferable rule: **re-convert alone is recoverable in place; reorder-then-re-convert is
+not.** A sort/cluster job is harmless by itself (it preserves ids) and unsafe in combination —
+it removes the cheap escape from a renumbering that has not happened yet. If a published flat
+is ever reordered, treat every hex built from it as stale from that moment.
+
 **So:**
 
 - **Do not run `workflow.yaml` (the orchestrator) on this dataset.** Its DAG starts with

--- a/catalog/iucn/k8s/rekey-577/BUILD.md
+++ b/catalog/iucn/k8s/rekey-577/BUILD.md
@@ -22,6 +22,29 @@ That is the same mechanism and the same afternoon as #574.
 **Only the id was wrong.** The hex's own attributes were never corrupt: its `sci_name` already
 agreed with the flat's on all 113,621 shared range records.
 
+### The hex build was NOT at fault — and a reorder is why this cost 4 billion rows
+
+Worth stating plainly, because "the hex carries its own numbering" (the checker's generic
+message) invites the wrong conclusion. The June build carried the then-current flat's ids
+faithfully: the pre-swap ids run **0…135,985 with exactly 1,017 gaps**, which matches the
+flat's row count and its missing-feature count. A build that had synthesized its own
+`ROW_NUMBER` over what it kept would be gapless 0…134,968.
+
+So why a permutation rather than the tidy +1 shift that `hydrothermal-vents` got from the same
+job? Because **`catalog/iucn/k8s/sort-ranges-polygons.yaml` (#255) reordered this flat by
+`sci_name` in between**. That job is harmless alone — a plain `SELECT *`, so ids travel with
+their rows — but the later re-convert then numbered rows in the *new* order. Visible directly
+in the surviving map: new ids 1,2,3 are `Aa calceata` / `Aa mandonii` / `Aa matthewsii`
+(alphabetical, i.e. assigned after the sort), while old ids 0,1,2 are three parts of
+`Rhamnus intermedia`.
+
+> **Re-convert alone is recoverable in place. Reorder-then-re-convert is not.**
+
+That ordering is the whole reason this needed a natural-key bridge and a 22 GiB rewrite instead
+of the `SELECT * REPLACE (_cng_fid + 1)` that fixed #574 — and the reason the part-level
+residual below is unavoidable. If this flat is ever reordered again, rebuild or re-key the hex
+in the same change.
+
 ## Why a re-key rather than a rebuild
 
 A rebuild is the correct fix and remains the eventual one, but it is blocked and expensive:

--- a/catalog/iucn/k8s/sort-ranges-polygons.yaml
+++ b/catalog/iucn/k8s/sort-ranges-polygons.yaml
@@ -9,6 +9,23 @@
 # enables tight per-row-group min/max pruning. Writes to a staging sibling first
 # (validated before the canonical file is swapped). DuckDB-native GeoParquet
 # (the source is already WKB/native, NOT geopandas — verified), so ST_ ops stay safe.
+#
+# ⛔ BEFORE RE-RUNNING THIS: it changes the flat's ROW ORDER, and that is what made
+# data-workflows#577 a 4-billion-row repair instead of a one-line one.
+#
+# This job itself is safe — `SELECT * ORDER BY` carries `_cng_fid` along with its row, so
+# nothing is renumbered here and no hex is invalidated by running it. The damage is
+# deferred: `cng_datasets` assigns `_cng_fid` at CONVERSION time, so the next job that
+# re-converts this flat (the #372 backfill did, on 2026-07-09) numbers rows in whatever
+# order it now finds them. After a reorder that is an unrelated permutation instead of a
+# uniform offset — and because a hex carries no geometry, parts can no longer be matched
+# back to flat rows, so the hex cannot be re-keyed losslessly. `high-seas/hydrothermal-vents`
+# was hit by the SAME backfill the same afternoon, had not been reordered, came out as a
+# tidy +1 shift, and was fixed in minutes (#574).
+#
+# So if you re-run this: rebuild or re-key every hex built from this flat in the SAME
+# change, or record in catalog/iucn/k8s/rekey-577/BUILD.md that the hex predates the
+# reorder. Do not leave a reordered flat sitting under a hex built before it.
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Docs only — no data, recipe, or gate behaviour changes. Follow-up to #583 (#574) and #595 (#577).

## The gap this fills

Both hex-key defects came from one job — the #372 `_cng_fid` backfill, which re-converted ten published flats on 2026-07-09 — but they cost wildly different repairs, and nothing recorded why:

| | `hydrothermal-vents` (#574) | `iucn-ranges-2025` (#577) |
|---|---|---|
| damage | uniform **+1 shift** (0…720 vs 1…721) | **unrelated permutation**, 0 of 134,969 ids unchanged |
| fix | losslessly re-keyable; re-hexed in minutes | natural-key bridge, 22 GiB rewrite, permanent part-level ambiguity |

The existing notes said "any job that re-converts a published flat orphans every hex built from it". True, but it doesn't distinguish those two outcomes — so a reader would reasonably conclude iucn's build was worse, or that mixed-resolution hexing is implicated. Neither is the case.

## What actually differs

**iucn's June hex was correct.** It carried the then-current flat's ids faithfully: the pre-swap ids run **0…135,985 with exactly 1,017 gaps**, matching the flat's row count and its missing-feature count. A build that had synthesized its own `ROW_NUMBER` over what it kept would be gapless 0…134,968.

**`sort-ranges-polygons.yaml` (#255) reordered that flat by `sci_name` in between.** That job is harmless alone — a plain `SELECT *`, so ids travel with their rows — but the later re-convert then numbered rows in the *new* order. Visible in the surviving id map: new ids 1,2,3 are `Aa calceata` / `Aa mandonii` / `Aa matthewsii` (alphabetical, so assigned after the sort), while old ids 0,1,2 are three parts of `Rhamnus intermedia`.

Resolution scheme is irrelevant: `hydrothermal-vents` is single-resolution via the standard `cng-datasets vector` path and was hit identically.

## The rule recorded

> **Re-convert alone is recoverable in place. Reorder-then-re-convert is not.**

A sort/cluster job is safe by itself and unsafe *in combination* — it removes the cheap escape from a renumbering that hasn't happened yet, and once a hex carries no geometry there is nothing left to match parts back by. Practical consequence: if you reorder a published flat, treat every hex built from it as stale from that moment, even though nothing is wrong yet — the damage lands on whoever re-converts next.

## Where it went

Placed where each audience will actually meet it, rather than only in the audit trail:

- `catalog/audit/pregate-verify-sweep/README.md` — the class, alongside the existing one-job finding
- `catalog/high-seas/k8s/hydrothermal-vents/BUILD.md` — why this one was cheap
- `catalog/iucn/k8s/rekey-577/BUILD.md` — why this one wasn't, and that the build was not at fault
- `catalog/iucn/k8s/sort-ranges-polygons.yaml` — **the file you read before re-running the reorder**; it now says the job is safe alone and what it obliges you to do
- `catalog/backfill/k8s/cngfid-372/catA-cngfid-convert.yaml` — the template for any future re-convert sweep, which carried **no warning at all** despite being the proximate cause of both issues

Both touched YAMLs still parse; 61 tests pass. The CI `verify` job derives collections from changed `catalog/**` YAMLs, so it will re-verify `iucn-ranges-2025` and `public-high-seas` — both verified clean on merge of #595 and #583 and unchanged here.
