### PR TITLE
AGENTS.md/README: cut the backup and mirror prose down to what is in scope

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,10 +26,12 @@ Do not run data processing commands (vector, raster, repartition) locally — th
 
 ## Available Skills
 
-Detailed reference guides are in `skills/`. **Do not read these proactively** — load a skill only when the task requires it:
+Detailed reference guides are in `.claude/skills/`. **Do not read these proactively** — load a skill only when the task requires it:
 
 | Skill file | When to load |
 |---|---|
-| `skills/nrp-k8s/SKILL.md` | Creating or debugging Kubernetes jobs on NRP Nautilus (priority classes, resource limits, GPU avoidance, namespace quotas) |
-| `skills/nrp-s3/SKILL.md` | S3 bucket operations: endpoints, rclone, bucket policies, CORS, DuckDB S3 access, syncing to source.coop |
-| `skills/gdal-remote/SKILL.md` | Reading remote geospatial files with GDAL/OGR virtual filesystems, DuckDB spatial, format conversions, Parquet driver availability |
+| `.claude/skills/stac-authoring/SKILL.md` | Writing or editing any `stac-collection.json` or dataset README |
+| `.claude/skills/raster-hexing/SKILL.md` | Ingesting or re-hexing a GeoTIFF/COG — resolution, reducer, mosaicking |
+| `.claude/skills/hex-tuning/SKILL.md` | A hex job OOMs, or choosing native/parent H3 resolutions and chunk sizes |
+| `.claude/skills/job-troubleshooting/SKILL.md` | A job fails, hangs, or a published parquet will not read |
+| `.claude/skills/dataset-recipes/SKILL.md` | Starting an ingest that resembles a worked example |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,42 +127,21 @@ kubectl -n geo-workflows get jobs | grep <name>
   **≤200 simultaneous pods** and **≤50Gi ephemeral per job** (`limits.ephemeral-storage`),
   especially on large-completion fan-out jobs. Oversubscribing is antisocial on shared nodes.
 
-**Credential rule — three data classes (the redistribution axis is NOT the credential axis):**
-- **Classes 1 & 2 — public-bucket data.** Includes the *non-redistributable* sets
-  (WDPA / WD-OECM, IUCN, ICCA, HydroBASINS): those are ordinary `public-*` buckets on
-  NRP + MinIO backup, merely **excluded from the source.coop mirror** (a mirror-scope
-  policy, not a credential boundary). Their build jobs **read/write NRP only.** Stage raw
-  under `s3://<bucket>/raw/` (Step 1b); **never** write intermediates to MinIO with a
-  personal key; reading public data needs **no** credential. No MinIO cred in `geo-workflows`.
-- **Class 3 — strictly private data** (`private-wyoming`, `private-tpl`): single-homed on
-  MinIO, **not on any NRP bucket**. Mount a **scoped, single-bucket, on-demand EXPIRING
-  MinIO mint** for that one bucket (`mc admin user svcacct add <parent> --policy <one-bucket>
-  --expiry …`; the `wyoming-publish` model) — **never** a standing broad MinIO key.
+**Credentials you have, and the only two you ever need:**
+- **Public buckets (almost everything).** Build jobs read and write **NRP only**, with the
+  `aws` + `rclone-config` secrets already in `geo-workflows`. Reading public data needs no
+  credential at all. Stage raw under `s3://<bucket>/raw/` (Step 1b).
+  A workflow-namespace `rclone-config` holding only `[nrp]` is **correct, not a
+  missing-remote bug** (internal endpoint `http://rook-ceph-rgw-nautiluss3.rook`,
+  `upload_concurrency=16`, `chunk_size=64Mi`).
+- **Private buckets** (`private-wyoming`, `private-tpl`) live only on MinIO. Mount a
+  **scoped, single-bucket, on-demand EXPIRING mint** for that one bucket
+  (`mc admin user svcacct add <parent> --policy <one-bucket> --expiry …`; the
+  `wyoming-publish` model) — never a standing broad key. This is the only MinIO access a
+  build job ever has.
 
-### Why the workflow `rclone-config` is nrp-only
-
-Build jobs run in `geo-workflows` with NRP-canonical credentials only. The MinIO and source.coop
-remotes live in a different secret, in a namespace this repo has no membership in, owned by
-geo-agent-ops. The separation is deliberate and two-sided: a confused or compromised build job
-cannot reach the backup credentials, so it cannot propagate a delete or a corruption into the
-backups. Recovery, not just prevention.
-
-What that means for a build, concretely:
-
-- **A workflow-namespace `rclone-config` holding only `[nrp]` is CORRECT** — not a
-  missing-remote bug. (Verified 2026-07-12 during #392 in both `geo-workflows` and
-  `biodiversity`: internal endpoint `http://rook-ceph-rgw-nautiluss3.rook`,
-  `upload_concurrency=16`, `chunk_size=64Mi`.)
-- **Never add a MinIO or source.coop remote — or the `rclone-backup` secret — to a workflow
-  namespace.** That re-opens the boundary the split exists to close.
-- **Treat NRP canonical as corruptible.** It is not the last copy, and restoring it is not your
-  job and not within your reach.
-
-**MinIO matters to a build for exactly one reason:** it is the canonical, **sole** home for
-class-3 private data (`private-wyoming`, `private-tpl`, …), which lives on no NRP bucket and no
-mirror — losing MinIO loses it. Reading such an input through a scoped, expiring, single-bucket
-mint (above) is normal, and is the only MinIO access a build job ever has. MinIO's other roles
-(backup vault; the fine-grained-IAM tier NRP lacks) belong to geo-agent-ops.
+⛔ **Never add any other remote or secret to a workflow namespace.** If a job appears to need
+one, it is out of scope — stop and ask.
 
 ## What You Produce
 
@@ -379,42 +358,21 @@ editing any `stac-collection.json` or README.
 **The STAC catalog is a TREE** — datasets belong in their domain/bucket sub-catalog, not the root.
 Only touch the root when adding a **new** top-level sub-catalog. Procedure: **skill
 `stac-authoring`**.
-### Step 7: License the collection — you register NOTHING for backup or mirror
+### Step 7: Get the licence right
 
-Backups and the source.coop mirror are **owned end to end by geo-agent-ops**, in a namespace
-this repo has no membership in. That tier derives its own scope, holds its own credentials, and
-vendors its own code. In its own words (geo-agent-ops `k8s/minio-sync-cron.yaml`):
+**This is a metadata step and nothing else.** Every collection carries an accurate SPDX
+`license` plus a `{"rel": "license"}` link in its STAC (Step 5). Getting it wrong is how data
+ends up over- or under-published.
 
-> data-workflows supplies NOTHING to the backup tier — no code, no scope, no manifest.
-> It produces datasets on NRP and nothing else.
-
-So there is **no registration step here** — not for a new bucket, not for an existing one, not
-for a new collection in an existing bucket. Nothing in this repo is read by the backup tier.
-
-**Your one obligation is metadata.** Every collection must carry an accurate SPDX `license` and
-a license link in its STAC (Step 5). That field is the *advisory input* the mirror-scope auditor
-reads, so it is how a licence fact actually reaches the backup tier — and a wrong one is how
-data gets over- or under-published.
-
-- Record the **licence fact**: what upstream granted, with evidence. That is a STAC field and it
-  belongs here.
-- Do **not** record a **redistribution verdict** ("may we mirror this?"). That decision, and its
-  holds and blocklist, live in geo-agent-ops `scripts/check-source-scope.py`. A verdict written
-  down in this repo reaches nothing.
-- If a licence is genuinely unconfirmed, say so — `license: "other"` **and** a description that
-  states it. Never assert an SPDX id upstream did not grant, and never list a provider as
-  `licensor` when no licence was granted; the auditor acts on a clean-looking `license` string.
-  This has gone wrong in both directions: `rivers/american-rivers/*` asserted `CC-BY-4.0` with
-  no `licensor` behind it, and `hazard/mid-century-habitat-climate-exposure` asserts
-  `CC-BY-4.0` while its own description says the terms "require confirmation".
-- Notice a scope problem — something mirrored that should not be, or held that should not be —
-  **file an issue on geo-agent-ops.** Do not try to fix it here; there is nothing here to fix.
-
-⛔ **Never execute any part of the backup or mirror tier from this repo or namespace.** No
-`kubectl` against `sync-*` / `source-sync-*` / `minio-sync` Jobs or CronJobs, no source.coop
-repo creation, no MinIO bucket policy, and never add a MinIO or source.coop remote (or the
-`rclone-backup` secret) to a workflow namespace. You hold none of those credentials, and that is
-the design, not an oversight.
+- Record what upstream actually granted, with evidence.
+- If the terms are genuinely unconfirmed or no licence was granted, say so: a non-committal
+  `license` **and** a description sentence stating it. Never assert an SPDX id upstream did not
+  grant, and never name a provider as `licensor` when no licence was granted. This has gone
+  wrong in both directions — `rivers/american-rivers/*` asserted `CC-BY-4.0` with no `licensor`
+  behind it, and `hazard/mid-century-habitat-climate-exposure` asserts `CC-BY-4.0` while its own
+  description says the terms "require confirmation".
+- Do not invent a terms URL to clear the gate. If no public terms page exists, the finding
+  stands; record the facts in the description and say so in the issue.
 
 ## Hex sizing and resolution
 

--- a/README.md
+++ b/README.md
@@ -86,30 +86,19 @@ Key commands:
 
 ## Backups & the public mirror — not in this repo
 
-NRP S3 is canonical. It is backed up to office MinIO and, where the licence allows, mirrored to
-Source Cooperative — but **both tiers are owned end to end by
-[geo-agent-ops](https://github.com/boettiger-lab/geo-agent-ops)**, running in a namespace this
-repo has no membership in, with credentials it does not hold. That tier derives its own scope
-and vendors its own code: nothing here is read by it, and nothing here can execute it.
+NRP S3 is canonical. It is backed up, and licence-permitting mirrored, by
+[geo-agent-ops](https://github.com/boettiger-lab/geo-agent-ops), which owns those tiers end to
+end. Nothing here is read by them and nothing here can execute them.
 
-| Destination | Purpose | Owner |
-|---|---|---|
-| **MinIO** (`minio.carlboettiger.info`) | private off-domain backup of every public bucket; the sole home for class-3 private data | geo-agent-ops |
-| **Source Cooperative** (`data.source.coop/cboettig/<repo>`) | public mirror, licence-gated | geo-agent-ops |
-
-**What this repo owes them is one field: an accurate STAC `license` on every collection**, which
-is the advisory input the mirror-scope auditor reads. See [AGENTS.md](AGENTS.md) Step 7.
-Redistribution verdicts — holds, blocklist, per-collection excludes — live in geo-agent-ops
-`scripts/check-source-scope.py`. If a mirror looks wrong, file an issue there; there is nothing
-in this repo to change.
+What this repo owes: **an accurate STAC `license` on every collection** (AGENTS.md Step 7). If a
+mirror looks wrong, file an issue on geo-agent-ops.
 
 ## Infrastructure
 
 - **Cluster:** NRP Nautilus, namespace `geo-workflows` (see AGENTS.md Hard Boundary 3)
 - **S3:** Ceph object storage (S3-compatible, not AWS)
 - **Public endpoint:** `https://s3-west.nrp-nautilus.io/<bucket>/<path>`
-- **MinIO backup:** `minio.carlboettiger.info` (private backup; owned + run by geo-agent-ops)
-- **Source Cooperative:** `data.source.coop/cboettig/<repo>` (public mirror, licence-gated; owned + run by geo-agent-ops)
-- **Secrets:** `aws` and `rclone-config` are pre-configured in the namespace. `rclone-config` holds the `nrp` remote **only** — the MinIO and source.coop remotes live in a separate secret in the backup namespace, by design.
+- **Secrets:** `aws` and `rclone-config` are pre-configured in the namespace. `rclone-config`
+  holds the `nrp` remote **only**, which is correct — no other remote belongs here.
 
 See [.github/copilot-instructions.md](.github/copilot-instructions.md) for detailed infrastructure context.


### PR DESCRIPTION
Finishes #550, which was closed after `8951888` with only its first half done.

That commit deleted `catalog/sync/**` but left a condensed version of the prose behind: **27 lines across AGENTS.md** still explained the backup tier, the source.coop mirror, MinIO's three roles, the `rclone-backup` secret, and what this repo does *not* register for any of them — plus another ~27 in README.md.

None of it is wrong. It just isn't ours, and keeping it has a cost: it keeps a tier this repo cannot touch as a live topic in every session, so scope questions about it get reopened instead of staying closed. Net −51 lines.

## Kept — only what changes what a build job does

- public buckets are NRP-only via the `aws` + `rclone-config` secrets already in the namespace, and an nrp-only `rclone-config` is **correct**, not a missing remote (this one genuinely misleads people)
- private buckets need a scoped, single-bucket, expiring MinIO mint — the only MinIO access a build job ever has
- never add any other remote or secret to a workflow namespace; if a job seems to need one, it's out of scope, stop and ask

## Step 7 becomes what it actually is

"Get the licence right" — record what upstream granted; if nothing was granted or terms are unconfirmed, say so without asserting an SPDX id or naming a licensor; don't invent a terms URL to clear the gate. The two worked examples are kept, since those are the mistakes that recur.

Everything about who owns the mirror, what reads what, and what to register is gone. The answer is *nothing*, which needs no section.

## Also

`.github/copilot-instructions.md` pointed at a `skills/` layout that does not exist — `nrp-k8s`, `nrp-s3`, `gdal-remote` — instead of the five real skills under `.claude/skills/`. Anyone following it got three dead paths. That stale `nrp-s3` row also carried the last source.coop reference in the repo.

Verified: zero `backup`/`mirror`/`source.coop`/`minio` mentions remain in AGENTS.md, README.md, or copilot-instructions.md, apart from the two MinIO lines describing how to read a private bucket.