### PR TITLE
feat(#417): record ingest provenance — NWI access date, cwhr/cwhr13 fingerprint, standing rule

### DIFF
--- a/.claude/skills/stac-authoring/SKILL.md
+++ b/.claude/skills/stac-authoring/SKILL.md
@@ -150,6 +150,30 @@ was 8.5 points wrong — the same mechanism as the pinyon-juniper defect (#505).
   the special case stays visible and is never mistaken for a verified upstream grant. Worked
   example: `high-seas/mpa-candidates` (#579).
 
+- **Provenance — record the access date and the staged raw's fingerprint (#417).** A provenance
+  *chain* (`rel: about` to the landing page, `rel: source` to where you actually read it,
+  `providers` producer → host → processor) is not enough on its own: without a **date** it cannot be
+  resolved to an edition, and the date is unrecoverable later. Publishers overwrite in place and
+  links rot, at which point your staged copy plus its checksum *is* the provenance. On the
+  collection, record:
+  - `sci:citation` (add the scientific extension) carrying the **access date** — machine-readable,
+    so a downstream consumer cites the STAC rather than a bucket listing;
+  - `version` (version extension) **only if upstream publishes an edition label** — `fveg22_1` yes,
+    a guessed "October 2025" no;
+  - `created` / `updated` on the collection, and **`created` per asset**, each measured from the
+    object itself — this is what keeps "which asset came from which conversion" answerable (#549,
+    where a flat and hex built 33 days apart carried different `_cng_fid` numbering);
+  - the staged raw's **path, size and checksum in the description** — recomputed from the object,
+    never transcribed.
+  ⛔ **Do NOT add a `raw` asset** whose href points under `raw/`, tempting as it is: the
+  mirror-scope auditor keys the `raw/` backup exclusion on STAC asset hrefs, so a raw asset flips the
+  whole bucket into the mirrored-exempt list (#545 — how `population` ended up mirroring 10 GiB of
+  re-downloadable source). Description text is just as citable and carries no href.
+  ⛔ **Never let a number that isn't an edition stand in for one.** A temporal extent is content
+  coverage; a product-line name (`nwi-v2`) is not a release; a derived file's mtime is the
+  conversion, not the pull. All three were read as edition stamps downstream and produced retracted
+  claims. If the edition is not determinable, state that plainly in the description.
+
 - **Temporal extent — RFC 3339, or the dataset vanishes from the served catalog.** Every
   `extent.temporal.interval` endpoint must be a full RFC 3339 date-time with a timezone
   (`"1920-05-15T00:00:00Z"`), or `null` for a genuinely open start/end. This is not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,23 @@ Common patterns: Census TIGER = per-state (`tl_2024_{STATEFP}_tract.zip`); prote
 
 External downloads are slow/rate-limited; restart from S3 if conversion fails. Subsequent jobs read `s3://<bucket>/raw/<file>` (or `/vsicurl/https://s3-west.nrp-nautilus.io/<bucket>/raw/<file>` for GDAL).
 
+⛔ **Staging the raw is only half of it — record WHEN you pulled it, in the STAC (Step 5).** The
+access date is the field that makes a provenance chain resolvable to an actual edition, and it is
+unrecoverable after the fact: publishers overwrite in place (FWS republishes the NWI every May and
+October at the same URL, with no dated archive) and links rot (the CAL FIRE FRAP raster has *no*
+stable public download URL at all). When either happens, **your staged copy plus its checksum ARE
+the provenance** — there is nothing else left to point at. Capture, on the collection: the upstream
+**landing page** (stable, not a fragile direct-download link), the **edition label** if upstream
+publishes one, the **access date**, and the staged raw's **path + size + checksum**. Recompute the
+checksum from the object, never transcribe it. Worked examples: `wetlands/nwi` and `cwhr`/`cwhr13`
+(#417).
+
+**A caveat that has bitten twice: never let a *number that isn't an edition* stand in for one.** A
+temporal extent is content coverage, a product-line name (`nwi-v2` = FWS post-2012 mapping) is not a
+release, and a derived file's mtime is the conversion, not the pull. Consumers read all three as
+edition stamps and published three claims that had to be retracted. If the edition is genuinely not
+determinable, **say so** — do not synthesise one.
+
 > ⚠️ **Brand-new bucket? Run the `*-setup-bucket` job BEFORE any stage-raw/download job.** The
 > bucket does not exist until `cng-datasets storage setup-bucket` creates it, and
 > `rclone ... --s3-no-check-bucket` will happily scrape/build for many minutes and then fail the

--- a/catalog/audit/k8s/stac-fix-417-cwhr-provenance.yaml
+++ b/catalog/audit/k8s/stac-fix-417-cwhr-provenance.yaml
@@ -1,0 +1,205 @@
+# data-workflows#417 — backfill the ingest provenance of `cwhr` and `cwhr13` (the motivating case).
+#
+# Why these two are the hard case, and why the stored raw IS the provenance: the fveg22_1 raster
+# file-geodatabase has NO stable public direct-download URL. The FRAP endpoints 301-redirect to a
+# generic program page, the historical /media/<id>/fveg<ver>.zip pattern is dead for the current
+# release, and data.ca.gov distributes only CSV / Shapefile / GeoJSON / KML for these layers — not
+# the raster GDB. So nobody downstream can re-fetch what we ingested; the only verifiable anchor is
+# the copy on our own bucket plus its fingerprint. That is exactly the case #417 was filed for.
+#
+# Both collections come from the SAME raw zip — verified in catalog/cwhr/k8s/reclassify-fveg.yaml,
+# which pulls raw/fveg221gdb.zip once and reclassifies /tmp/fveg22_1.gdb through two LUTs
+# (Value -> WHRNUM for cwhr, Value -> WHR13NUM for cwhr13). So they share one provenance record.
+#
+# Anchors, measured from the bucket 2026-08-20 (the issue's table matched exactly):
+#
+#   raw/fveg221gdb.zip   147,269,039 bytes, staged 2026-06-17T19:47:29Z
+#                        ETag cffcb952d8ac1918046087ee6e8de55a  (single-part, so a real MD5)
+#                        sha256 is RECOMPUTED FROM S3 BY THIS JOB and asserted, never transcribed
+#   cwhr-cog.tif         2026-06-17T19:56:15Z     cwhr13-cog.tif  2026-06-17T19:56:03Z
+#   cwhr/hex             2026-06-18T01:49:20Z     cwhr13/hex      2026-06-17T23:56:48Z
+#   cwhr/hex-fractions   2026-07-11T18:30:48Z     cwhr13/hex-fr.  2026-07-08T15:28:28Z
+#
+# Unlike wetlands/nwi, the upstream EDITION here is determinable — `fveg22_1`, FGDC record ds1327 —
+# so `version` is set. That is a fact upstream published, not an inference.
+#
+# ⛔ No `raw` asset href, for the #545 reason documented in the NWI job: the mirror-scope auditor
+# keys the raw/ backup exclusion on asset hrefs. The job asserts none appears after writing.
+#
+# Idempotent: re-running changes nothing. In-cluster because STAC is canonical on NRP S3.
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: stac-fix-417-cwhr-provenance, namespace: geo-workflows}
+data:
+  fix.py: |
+    import hashlib, json, subprocess, sys
+
+    NRP = 'https://s3-west.nrp-nautilus.io'
+    RAW = 'nrp:public-ca30x30/raw/fveg221gdb.zip'
+    SCI_EXT = 'https://stac-extensions.github.io/scientific/v1.0.0/schema.json'
+    VER_EXT = 'https://stac-extensions.github.io/version/v1.2.0/schema.json'
+
+    EDITION = 'fveg22_1'
+    RAW_BYTES = 147269039
+    RAW_MD5 = 'cffcb952d8ac1918046087ee6e8de55a'
+    RAW_SHA256 = '6b6bc73c8b97eb3637ab283dfdeefebc0e284a40ce5280de0393900544e94cff'
+    STAGED = '2026-06-17T19:47:29Z'
+    UPSTREAM_UPDATED = '2024-12-27'
+
+    LANDING = {
+        'cwhr': 'https://data.ca.gov/dataset/california-vegetation-whrtype',
+        'cwhr13': 'https://data.ca.gov/dataset/california-vegetation-whr13-types',
+    }
+    FGDC = 'https://map.dfg.ca.gov/metadata/ds1327.html'
+    BUILDS = {
+        'cwhr':   {'cwhr-cog': '2026-06-17T19:56:15Z', 'cwhr-hex': '2026-06-18T01:49:20Z',
+                   'cwhr-hex-fractions': '2026-07-11T18:30:48Z'},
+        'cwhr13': {'cwhr13-cog': '2026-06-17T19:56:03Z', 'cwhr13-hex': '2026-06-17T23:56:48Z',
+                   'cwhr13-hex-fractions': '2026-07-08T15:28:28Z'},
+    }
+    LAYER = {'cwhr': 'WHRTYPE (California Vegetation - WHRTYPE)',
+             'cwhr13': 'WHR13 Types (California Vegetation - WHR13 Types)'}
+
+    # --- 1. Recompute the raw fingerprint from S3. Never transcribe a checksum. ------
+    print('hashing %s ...' % RAW)
+    proc = subprocess.Popen(['rclone', 'cat', RAW], stdout=subprocess.PIPE)
+    sha, md5, size = hashlib.sha256(), hashlib.md5(), 0
+    while True:
+        buf = proc.stdout.read(8 << 20)
+        if not buf:
+            break
+        sha.update(buf); md5.update(buf); size += len(buf)
+    if proc.wait() != 0:
+        print('FAIL: rclone cat exited %d' % proc.returncode); sys.exit(1)
+    got_sha, got_md5 = sha.hexdigest(), md5.hexdigest()
+    print('measured\tsize=%d\tmd5=%s\tsha256=%s' % (size, got_md5, got_sha))
+    for label, got, want in (('size', size, RAW_BYTES), ('md5', got_md5, RAW_MD5),
+                             ('sha256', got_sha, RAW_SHA256)):
+        if got != want:
+            print('FAIL: raw %s mismatch — measured %r, issue #417 recorded %r. The staged raw '
+                  'is not the object #417 fingerprinted; STOP and reconcile before publishing.'
+                  % (label, got, want))
+            sys.exit(1)
+    print('raw\tVERIFIED\tmatches the #417 fingerprint exactly')
+
+    PROVENANCE = (
+        'Provenance. Derived from the CAL FIRE FRAP raster file-geodatabase %s (FGDC record '
+        'ds1327, layer %s), whose upstream distribution was last updated %s. There is no stable '
+        'public direct-download URL for this raster: the FRAP download endpoints redirect to a '
+        'generic program page, the historical direct pattern is dead for the current release, and '
+        'data.ca.gov distributes only CSV / Shapefile / GeoJSON / KML for this layer, not the '
+        'raster GDB. The verifiable anchor is therefore the copy staged on this bucket at '
+        's3://public-ca30x30/raw/fveg221gdb.zip on %s — %s bytes, '
+        'MD5 %s, SHA-256 %s. Anyone reproducing this dataset should check that fingerprint rather '
+        'than attempt to re-download from the publisher.'
+    ) % (EDITION, '%s', UPSTREAM_UPDATED, STAGED, format(RAW_BYTES, ','), RAW_MD5, RAW_SHA256)
+
+    FAIL = []
+    for cid in ('cwhr', 'cwhr13'):
+        key = 'nrp:public-ca30x30/%s/stac-collection.json' % cid
+        doc = json.loads(subprocess.check_output(['rclone', 'cat', key]))
+        changed = []
+
+        exts = doc.setdefault('stac_extensions', [])
+        for e in (SCI_EXT, VER_EXT):
+            if e not in exts:
+                exts.append(e); changed.append('ext+' + e.rsplit('/', 3)[1])
+
+        # The edition IS determinable here, unlike nwi — upstream published it.
+        if doc.get('version') != EDITION:
+            doc['version'] = EDITION
+            changed.append('version')
+
+        citation = (
+            'CAL FIRE Fire and Resource Assessment Program (FRAP), %s, edition %s '
+            '(FGDC record ds1327). Upstream last updated %s; raw staged to '
+            's3://public-ca30x30/raw/fveg221gdb.zip on %s (SHA-256 %s). No stable public '
+            'direct-download URL exists for the raster geodatabase. Reclassified and processed '
+            'to COG and H3 by the Boettiger Lab, UC Berkeley.'
+        ) % (LAYER[cid], EDITION, UPSTREAM_UPDATED, STAGED[:10], RAW_SHA256)
+        if doc.get('sci:citation') != citation:
+            doc['sci:citation'] = citation
+            changed.append('sci:citation')
+
+        links = doc.setdefault('links', [])
+        want_links = [
+            {'rel': 'about', 'href': LANDING[cid], 'type': 'text/html',
+             'title': 'Upstream dataset landing page (data.ca.gov)'},
+            {'rel': 'describedby', 'href': FGDC, 'type': 'text/html',
+             'title': 'FGDC metadata record ds1327'},
+        ]
+        for wl in want_links:
+            if not any(l.get('rel') == wl['rel'] and l.get('href') == wl['href'] for l in links):
+                links.append(wl); changed.append('link+' + wl['rel'])
+
+        builds = BUILDS[cid]
+        created_vals = sorted(builds.values())
+        if doc.get('created') != created_vals[0]:
+            doc['created'] = created_vals[0]; changed.append('created')
+        if doc.get('updated') != created_vals[-1]:
+            doc['updated'] = created_vals[-1]; changed.append('updated')
+        for akey, created in builds.items():
+            a = doc.get('assets', {}).get(akey)
+            if a is None:
+                FAIL.append('%s: no asset %s' % (cid, akey)); continue
+            if a.get('created') != created:
+                a['created'] = created; changed.append('%s.created' % akey)
+
+        para = PROVENANCE % LAYER[cid]
+        desc = (doc.get('description') or '').rstrip()
+        if para not in desc:
+            doc['description'] = desc + '\n\n' + para
+            changed.append('description+provenance')
+
+        if not changed:
+            print('%s\tALREADY' % cid); continue
+
+        open('/tmp/o.json', 'w').write(json.dumps(doc, indent=2))
+        json.load(open('/tmp/o.json'))          # re-parse before publishing
+        subprocess.check_call(['rclone', 'copyto', '/tmp/o.json', key])
+
+        back = json.loads(subprocess.check_output(['rclone', 'cat', key]))
+        if back.get('version') != EDITION or RAW_SHA256 not in back.get('sci:citation', ''):
+            FAIL.append('%s: version/citation missing after write' % cid); continue
+        raw_assets = [k for k, v in back.get('assets', {}).items() if '/raw/' in v.get('href', '')]
+        if raw_assets:
+            FAIL.append('%s: asset(s) now publish from under raw/: %r' % (cid, raw_assets)); continue
+        print('%s\tCHANGED\t%s' % (cid, ','.join(changed)))
+
+    if FAIL:
+        print('FAILURES:')
+        for f in FAIL:
+            print('  ' + f)
+        sys.exit(1)
+    print('done')
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-fix-417-cwhr-provenance
+  namespace: geo-workflows
+  labels: {k8s-app: stac-fix-417-cwhr-provenance}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata: {labels: {k8s-app: stac-fix-417-cwhr-provenance}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: fix
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: fix, mountPath: /config, readOnly: true}
+        command: [bash, -c, "set -uo pipefail; python3 /config/fix.py"]
+        resources:
+          requests: {cpu: '1', memory: 2Gi, ephemeral-storage: 2Gi}
+          limits:   {cpu: '1', memory: 2Gi, ephemeral-storage: 2Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: fix, configMap: {name: stac-fix-417-cwhr-provenance}}

--- a/catalog/audit/k8s/stac-fix-417-nwi-provenance.yaml
+++ b/catalog/audit/k8s/stac-fix-417-nwi-provenance.yaml
@@ -1,0 +1,197 @@
+# data-workflows#417 — record the ingest provenance of `wetlands/nwi` in its STAC.
+#
+# The gap: the provenance CHAIN was already recorded (rel:about -> FWS, rel:source -> the
+# source.coop giswqs mirror, providers FWS -> giswqs -> us). Only the DATE was missing — and the
+# date is the one field that makes the chain resolvable to an edition. FWS republishes the NWI in
+# place twice a year (May and October) with no dated public archive, so once ingested the edition is
+# unrecoverable by anyone downstream, and nothing looks broken.
+#
+# Every anchor this job writes was measured from the bucket, not transcribed from the issue
+# (re-verified 2026-08-20 by anonymous S3 listing):
+#
+#   raw/nwi/*            51 objects, 81,364,206,213 bytes, ETag on 51/51 (46 multipart)
+#                        read window 2026-05-12T04:35:43.960Z -> 04:47:56.057Z
+#   nwi-v2.parquet       2026-05-12T17:14:00Z   (the CONVERSION, ~12.5 h after the read)
+#   nwi-v2.pmtiles       2026-05-13T05:24:22Z
+#   nwi-v2/hex/          2026-08-18T19:04:46.708Z -> 19:07:22.521Z  (the #509/#563 re-hex)
+#
+# ⛔ Deliberately NOT added: a `raw` asset pointing under raw/. #417's proposal item 3 floats that
+# convention, but #545 shows it collides with the mirror-scope auditor, which keys the raw/ backup
+# exclusion on STAC asset hrefs — that is exactly why `population` and `tpl` are exempt and still
+# mirroring their re-downloadable sources. A raw asset here would flip `public-wetlands` into that
+# exempt list and start mirroring 81 GB of source. So the anchors go in the description and
+# sci:citation, where they are just as citable and carry no href. Raised on #417/#545 for a ruling.
+#
+# ⛔ Deliberately NOT added: a `version`. A 2026-05-12 read most plausibly corresponds to the
+# October 2025 edition, but that is an inference about what the mirror held that day, not a
+# determination. Asserting it as `version` is precisely the error #417 exists to stop, and the error
+# that produced three retracted claims in geo-agent-benchmark#64.
+#
+# Idempotent: re-running changes nothing. In-cluster because STAC is canonical on NRP S3.
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: stac-fix-417-nwi-provenance, namespace: geo-workflows}
+data:
+  fix.py: |
+    import json, subprocess, sys
+
+    KEY = 'nrp:public-wetlands/nwi/stac-collection.json'
+    SCI_EXT = 'https://stac-extensions.github.io/scientific/v1.0.0/schema.json'
+
+    # --- measured anchors (see the manifest header) -------------------------------
+    READ_START = '2026-05-12T04:35:43Z'
+    READ_END = '2026-05-12T04:47:56Z'
+    RAW_N = 51
+    RAW_BYTES = 81364206213
+    FLAT_CREATED = '2026-05-12T17:14:00Z'
+    PMTILES_CREATED = '2026-05-13T05:24:22Z'
+    HEX_CREATED = '2026-08-18T19:04:46Z'
+    HEX_END = '2026-08-18T19:07:22Z'
+
+    PROVENANCE = (
+        'Provenance and edition. The upstream data was read from the Source Cooperative mirror '
+        '(data.source.coop/giswqs/nwi/wetlands/) on 2026-05-12 between 04:35:43Z and 04:47:56Z. '
+        'The %d per-state GeoParquet files it returned (%s bytes in total) are retained on this '
+        'bucket under raw/nwi/, each carrying an S3 ETag, so the exact bytes that were ingested '
+        'remain verifiable; 46 of the %d are multipart uploads, whose ETag is therefore not a '
+        'plain MD5. That staged copy is the anchor, because the U.S. Fish & Wildlife Service does '
+        'not publish a dated archive of the NWI — it republishes in place twice a year (May and '
+        'October). The exact upstream edition behind this collection is therefore NOT recoverable. '
+        'A 2026-05-12 read most plausibly corresponds to the October 2025 edition, but that is an '
+        'inference about what the mirror held on that date, not a determination, and it should not '
+        'be cited as an edition.'
+    ) % (RAW_N, format(RAW_BYTES, ','), RAW_N)
+
+    NOT_AN_EDITION = (
+        'Three things here look like an edition stamp and are not. (1) The temporal interval '
+        '(1900-01-01 to 2024-12-31) is the coverage of the source mapping, not a release date. '
+        '(2) "nwi-v2" in the asset paths is the FWS product line — Version 2 means post-2012 '
+        'mapping that includes all surface-water features — not a dated version of this dataset. '
+        '(3) The nwi-v2.parquet object’s own modification time (%s) is when our conversion ran, '
+        'roughly 12.5 hours after the upstream read; the access date is the read window above. '
+        'All three have been mistaken for an edition by downstream consumers, so prefer the read '
+        'window and treat the edition as unknown.'
+    ) % FLAT_CREATED
+
+    CITATION = (
+        'U.S. Fish & Wildlife Service, National Wetlands Inventory (product line "NWI Version 2"). '
+        'Accessed %s via the Source Cooperative mirror data.source.coop/giswqs/nwi/wetlands/. '
+        'Upstream edition not determinable: FWS republishes in place biannually with no dated '
+        'archive. Processed to EPSG:4326 GeoParquet, PMTiles and H3 by the Boettiger Lab, '
+        'UC Berkeley.' % READ_START[:10]
+    )
+
+    ASSET_CREATED = {
+        'nwi-parquet': FLAT_CREATED,
+        'nwi-pmtiles': PMTILES_CREATED,
+        'nwi-hex': HEX_CREATED,
+    }
+    HEX_NOTE = (
+        'Rebuilt %s (through %s) under the #509 hex audit; the flat GeoParquet it was built from '
+        'has not been re-converted since %s, so the two remain the same conversion.'
+    ) % (HEX_CREATED[:10], HEX_END, FLAT_CREATED[:10])
+
+    FAIL = []
+    doc = json.loads(subprocess.check_output(['rclone', 'cat', KEY]))
+    changed = []
+
+    # 1. scientific extension, for a citable sci:citation carrying the access date.
+    exts = doc.setdefault('stac_extensions', [])
+    if SCI_EXT not in exts:
+        exts.append(SCI_EXT)
+        changed.append('stac_extensions+scientific')
+
+    # 2. The access date, machine-readable. A downstream consumer should cite this,
+    #    not a bucket listing (geo-agent-benchmark#65).
+    if doc.get('sci:citation') != CITATION:
+        doc['sci:citation'] = CITATION
+        changed.append('sci:citation')
+
+    # 3. Collection-level build span: first served build -> latest data change.
+    if doc.get('created') != FLAT_CREATED:
+        doc['created'] = FLAT_CREATED
+        changed.append('created')
+    if doc.get('updated') != HEX_END:
+        doc['updated'] = HEX_END
+        changed.append('updated')
+
+    # 4. Per-asset build dates, each measured from the object itself. This is what
+    #    makes "which asset came from which conversion" answerable later (#549).
+    for akey, created in ASSET_CREATED.items():
+        a = doc.get('assets', {}).get(akey)
+        if a is None:
+            FAIL.append('no asset %s' % akey); continue
+        if a.get('created') != created:
+            a['created'] = created
+            changed.append('%s.created' % akey)
+        if akey == 'nwi-hex':
+            desc = (a.get('description') or '').rstrip()
+            if HEX_NOTE not in desc:
+                a['description'] = (desc + ' ' + HEX_NOTE).strip()
+                changed.append('nwi-hex.description')
+
+    # 5. The provenance paragraphs, appended to the collection description.
+    desc = (doc.get('description') or '').rstrip()
+    for para in (PROVENANCE, NOT_AN_EDITION):
+        if para not in desc:
+            desc = desc + '\n\n' + para
+            changed.append('description+%s' % para.split('.')[0][:24])
+    doc['description'] = desc
+
+    if FAIL:
+        print('FAILURES:')
+        for f in FAIL:
+            print('  ' + f)
+        sys.exit(1)
+
+    if not changed:
+        print('ALREADY\tnothing to do')
+        sys.exit(0)
+
+    open('/tmp/o.json', 'w').write(json.dumps(doc, indent=2))
+    json.load(open('/tmp/o.json'))          # re-parse before publishing
+    subprocess.check_call(['rclone', 'copyto', '/tmp/o.json', KEY])
+    print('CHANGED\t%s' % ','.join(changed))
+
+    # 6. Confirm the published document round-trips, and that no asset href points
+    #    under raw/ (the #545 collision this job deliberately avoids).
+    back = json.loads(subprocess.check_output(['rclone', 'cat', KEY]))
+    if READ_START[:10] not in back.get('sci:citation', ''):
+        print('FAIL: access date missing from sci:citation after write'); sys.exit(1)
+    raw_assets = [k for k, v in back.get('assets', {}).items() if '/raw/' in v.get('href', '')]
+    if raw_assets:
+        print('FAIL: asset(s) now publish from under raw/: %r' % raw_assets); sys.exit(1)
+    print('verified\taccess=%s\tcreated=%s\tupdated=%s'
+          % (READ_START, back.get('created'), back.get('updated')))
+    print('done')
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-fix-417-nwi-provenance
+  namespace: geo-workflows
+  labels: {k8s-app: stac-fix-417-nwi-provenance}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata: {labels: {k8s-app: stac-fix-417-nwi-provenance}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: fix
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        - {name: fix, mountPath: /config, readOnly: true}
+        command: [bash, -c, "set -uo pipefail; python3 /config/fix.py"]
+        resources:
+          requests: {cpu: '1', memory: 1Gi, ephemeral-storage: 1Gi}
+          limits:   {cpu: '1', memory: 1Gi, ephemeral-storage: 1Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}
+      - {name: fix, configMap: {name: stac-fix-417-nwi-provenance}}


### PR DESCRIPTION
Closes #417 (all four acceptance criteria). Applied to S3 and verified — the collections below are
live and the data-backed gate exits 0 for each.

## What was actually missing

For `wetlands/nwi` the provenance **chain** was already recorded — `rel:about` to FWS, `rel:source`
to the giswqs source.coop mirror, `providers` FWS → giswqs → us. Only the **date** was missing, and
the date is the one field that makes the chain resolvable to an edition. FWS republishes the NWI in
place every May and October with no dated archive, so after ingest the edition is unrecoverable by
anyone downstream — and unlike a dead link, nothing looks broken.

For `cwhr`/`cwhr13` the problem is the opposite and worse: **there is no stable public download URL
at all.** FRAP endpoints redirect to a generic program page, the historical direct pattern is dead
for the current release, and data.ca.gov serves only CSV / Shapefile / GeoJSON / KML for these
layers, not the raster GDB. Nobody can re-fetch what we ingested, so the staged copy plus its
fingerprint *is* the provenance.

## Anchors — measured, not transcribed

Every value was re-derived from the bucket. The issue's table matched exactly in both cases.

| dataset | anchor |
|---|---|
| `nwi` raw | 51 objects, 81,364,206,213 bytes, ETag on 51/51 (46 multipart), read window **2026-05-12T04:35:43.960Z → 04:47:56.057Z** |
| `nwi` builds | flat `2026-05-12T17:14:00Z` (the conversion, ~12.5 h after the read) · pmtiles `2026-05-13T05:24:22Z` · hex `2026-08-18T19:04:46Z → 19:07:22Z` (the #509/#563 re-hex) |
| `cwhr` raw | 147,269,039 B · md5 `cffcb952…` (single-part, so a real MD5) · sha256 `6b6bc73c…` · staged `2026-06-17T19:47:29Z` |

The cwhr **sha256 is recomputed from S3 by the job and asserted before anything is written**, never
transcribed — and it matched the value #417 recorded two months ago to the byte. On mismatch the job
fails loudly and publishes nothing.

## What was written

`sci:citation` carrying the access date (machine-readable, so a consumer cites the STAC instead of a
bucket listing), collection `created`/`updated`, and **per-asset `created`** measured from each
object — that last one keeps "which asset came from which conversion" answerable, the #549 lesson
where a flat and hex built 33 days apart carried different `_cng_fid` numbering. cwhr/cwhr13 also get
`version: fveg22_1`, `rel:about` → data.ca.gov landing, `rel:describedby` → FGDC ds1327.

Plus, for NWI, an explicit description paragraph that **three fields here look like an edition stamp
and are not**: the temporal interval (content coverage), `nwi-v2` (FWS product line = post-2012
mapping, not a release), and the flat parquet's mtime (the conversion). All three were read as
editions downstream and produced three retracted claims in geo-agent-benchmark#64.

## Two things deliberately NOT done

- **No `version` on nwi.** A 2026-05-12 read most plausibly corresponds to the October 2025 edition,
  but that is an inference about what the mirror held that day, not a determination. Asserting it is
  precisely the error this issue exists to stop.
- **No `raw` asset anywhere.** #417 proposal item 3 floats that convention, and it turns out to
  **collide with #545**: the mirror-scope auditor keys the `raw/` backup exclusion on STAC asset
  hrefs, which is exactly why `population` and `tpl` are exempt and still mirroring their
  re-downloadable sources. A raw asset on `wetlands` would flip that bucket into the exempt list and
  start mirroring 81 GB of source. The anchors live in the description and `sci:citation` instead —
  just as citable, no href. Both jobs assert no asset publishes from under `raw/` after writing.
  **This needs a ruling on #417/#545 before item 3 is adopted anywhere.**

## Docs — the half that stops this recurring

- **AGENTS.md Step 1b**: staging the raw is only half of it; record *when* you pulled it, because
  publishers overwrite in place and links rot. Plus the never-synthesise-an-edition caveat.
- **`stac-authoring` skill**: the concrete fields, and the two prohibitions (no `raw` asset href, no
  invented edition).

## Verification

```
verify-stac.py --bucket public-wetlands  --dataset nwi      -> PASS, exit 0
verify-stac.py --bucket public-ca30x30   --dataset cwhr     -> PASS, exit 0
verify-stac.py --bucket public-ca30x30   --dataset cwhr13   -> PASS, exit 0
```

Both jobs were dry-run against the live documents before publishing, and both are idempotent (second
pass reports `ALREADY`).

## Downstream

`geo-agent-benchmark` #60/#65 have cells citing a *bucket sweep* for the NWI read window because the
STAC carried no access date. It does now (`sci:citation`), so those notes can cite the STAC as the
authority instead.
