### PR TITLE
fix(#579): reconcile Step 7 with the merged decision, and test the new licence finding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,6 +374,15 @@ ends up over- or under-published.
   description says the terms "require confirmation".
 - Do not invent a terms URL to clear the gate. If no public terms page exists, the finding
   stands; record the facts in the description and say so in the issue.
+- **One sanctioned exception, and only this one: data contributed directly to us, where no terms
+  were ever published.** Here "no public terms page" is not a gap to be researched — it is the
+  complete answer, so a permanently-red finding would be recording a fact as a defect. Publish the
+  statement of terms beside the data (`s3://<bucket>/<dataset>/LICENSE.md`) and link it. The
+  document must **grant nothing**: it records what was and was not given. `verify-stac.py` reports
+  `license-terms-self-hosted` (ADVISORY) whenever a licence link resolves to our own bucket, so this
+  can never be mistaken for a verified upstream grant. Worked example: `high-seas/mpa-candidates`
+  (#579). This does **not** licence guessing anywhere else — for data with a real publisher, an
+  absent terms page still leaves the finding standing.
 
 ## Hex sizing and resolution
 

--- a/tests/test_verify_stac.py
+++ b/tests/test_verify_stac.py
@@ -545,6 +545,52 @@ class HexFidMatchesFlat(unittest.TestCase):
         self.assertEqual(mcp.sql, [], "no witness → must not query")
 
 
+class SelfHostedLicenseTerms(unittest.TestCase):
+    """A licence link pointing at our OWN bucket means WE authored the terms, not upstream.
+    Legitimate only for directly-contributed data with no published terms — a colleague's
+    contribution with no citation, no attribution, no URL (data-workflows#579). Reported
+    ADVISORY so the case stays visible in every audit instead of being re-litigated, and so
+    it can never be mistaken for a verified upstream grant."""
+
+    NRP = "https://s3-west.nrp-nautilus.io"
+
+    def _doc(self, license_href=None, license_="proprietary", children=False):
+        links = [
+            {"rel": "self", "href": f"{self.NRP}/public-x/d/stac-collection.json"},
+            {"rel": "root", "href": f"{self.NRP}/public-data/stac/catalog.json"},
+            {"rel": "parent", "href": f"{self.NRP}/public-x/stac-collection.json"},
+        ]
+        if license_href:
+            links.append({"rel": "license", "href": license_href, "type": "text/markdown"})
+        if children:
+            links.append({"rel": "child", "href": f"{self.NRP}/public-x/d/c/stac-collection.json"})
+        return {"type": "Collection", "id": "d", "license": license_, "links": links}
+
+    def test_self_hosted_terms_clears_hard_but_is_advisory(self):
+        f = vs.check_license(self._doc(f"{self.NRP}/public-x/d/LICENSE.md"))
+        self.assertEqual([x.code for x in f], ["license-terms-self-hosted"])
+        self.assertEqual(f[0].severity, vs.ADVISORY)
+
+    def test_upstream_terms_link_is_silent(self):
+        # The ordinary case: terms hosted by the publisher. No finding at all.
+        self.assertEqual(vs.check_license(self._doc("https://example.gov/terms")), [])
+
+    def test_missing_link_is_still_hard(self):
+        # The advisory must not have weakened the rule it sits beside.
+        f = vs.check_license(self._doc(None))
+        self.assertEqual([x.code for x in f], ["license-link-missing"])
+        self.assertEqual(f[0].severity, vs.HARD)
+
+    def test_meta_collection_exemption_survives(self):
+        # 'other' + child links = the real licences live on the children.
+        self.assertEqual(vs.check_license(self._doc(None, "other", children=True)), [])
+
+    def test_advisory_fires_regardless_of_spdx_value(self):
+        # Self-hosting terms under a real SPDX id is odd enough to surface too.
+        f = vs.check_license(self._doc(f"{self.NRP}/public-x/d/LICENSE.md", "CC-BY-4.0"))
+        self.assertIn("license-terms-self-hosted", [x.code for x in f])
+
+
 class CatalogNotCollection(unittest.TestCase):
     """A STAC Catalog (the root) is structural — it has no license or extent, and the root
     has no parent. The Collection checks must skip it (data-workflows#509)."""


### PR DESCRIPTION
Two loose ends from #599, both of which I should have caught before it merged.

## 1. `AGENTS.md` Step 7 contradicted the skill

After #599 merged, `main` held both of these at once:

- **Step 7:** "Do not invent a terms URL to clear the gate. If no public terms page exists, *the finding stands*."
- **`stac-authoring`** (added by #599): publish a terms statement beside the data and link it.

So a reader following AGENTS.md alone would do the opposite of a reader following the skill. Step 7 now carries the exception explicitly, scoped as narrowly as the case actually is: **data contributed directly to us, where no terms were ever published** — where "no public terms page" is the complete answer rather than a gap to research, so a permanently-red finding would be filing a fact as a defect. For anything with a real publisher, an absent terms page still leaves the finding standing.

The bright line moves by exactly one case, and now says so in both places.

## 2. The new finding had no test

`#599` added a branch to `check_license` and no test for it. `tests/test_verify_stac.py` already had a `check_license` case to extend, so that was an omission rather than a missing harness — and the green `unittest` check on #599 only meant the *pre-existing* suite still passed.

Five cases now pin it, including the two that matter most as regressions:

| case | asserts |
|---|---|
| self-hosted terms link | clears HARD, reports `license-terms-self-hosted` as ADVISORY |
| upstream terms link | **silent** — no finding for the ordinary case |
| **no licence link at all** | **still HARD** `license-link-missing` — the advisory did not weaken the rule beside it |
| **`other` + child links** | **meta-collection exemption still applies** |
| self-hosted under a real SPDX id | advisory still fires |

```
python3 -m pytest tests/ -q   ->  66 passed
```
