### PR TITLE
feat(#586): Wildfire Hazard Potential v2023 — four per-domain collections (CONUS + Alaska, classified + continuous)

### DIFF
--- a/catalog/fire/k8s/whp-2023/BUILD.md
+++ b/catalog/fire/k8s/whp-2023/BUILD.md
@@ -1,0 +1,321 @@
+# `whp-2023` — build notes and measured evidence
+
+Wildfire Hazard Potential v2023 (270 m), ingested for #586 as part of the `roadless` dataset
+set (#594). The claim under audit is the 2026-08-18 announcement's ">40% of roadless acres are
+at high or very high wildfire risk", whose agency basis is DEIS Vol I Table 22.
+
+## Source
+
+| | |
+|---|---|
+| Citation | Dillon, G.K. 2023. *Wildfire Hazard Potential for the United States (270-m), version 2023.* 4th Edition. Fort Collins, CO: Forest Service Research Data Archive. |
+| Archive id | **RDS-2015-0047-4** (`https://doi.org/10.2737/RDS-2015-0047-4`) |
+| Package | `RDS-2015-0047-4_Data.zip` |
+| License | US Government work — public domain |
+| Staged raw | `s3://public-fire/raw/whp-2023/` |
+
+Confirmed against #589/#602: this is the edition the DEIS used, classes counted are **high +
+very high**, the denominator is **total** acres (not forested), and non-burnable pixels are
+**not** excluded.
+
+## Why four collections and not one
+
+The source ships three domains — CONUS, Alaska, Hawaii — and **classifies each against its own
+distribution of the continuous index.** The breaks are not the same numbers:
+
+| Class | CONUS | Alaska |
+|---|---|---|
+| 1 Very Low | ≤ 61 | ≤ 83 |
+| 2 Low | 62–178 | 84–624 |
+| 3 Moderate | 179–489 | 625–2,922 |
+| 4 High | 490–1,985 | 2,923–8,912 |
+| 5 Very High | > 1,985 | > 8,912 |
+
+An Alaska "Very High" is a WHP index above 8,912; a CONUS "Very High" is above 1,985 — **4.5×
+apart.** A single mosaicked classified layer would silently invite a pooled `GROUP BY class`
+across two incompatible scales, which is precisely the arithmetic that yields a wrong headline
+number. Publishing the domains separately makes that mistake impossible to make by accident,
+and every collection carries `h8`, so they still join to each other and to
+`roadless-areas-2001` cell for cell.
+
+Hawaii is skipped — it holds no inventoried roadless areas — but its raw rasters are staged.
+
+| `--dataset` | Native | Parents | Reducer | Column |
+|---|---|---|---|---|
+| `whp-2023-classified-conus` | 9 | 8, 0 | `mode` | `whp_class` |
+| `whp-2023-classified-ak` | 9 | 8, 0 | `mode` | `whp_class` |
+| `whp-2023-continuous-conus` | 8 | 0 | `mean` | `whp_index` |
+| `whp-2023-continuous-ak` | 8 | 0 | `mean` | `whp_index` |
+
+### Resolution split, by product
+
+Measured pixels per H3 cell after reprojection:
+
+| | CONUS | Alaska |
+|---|---:|---:|
+| res 9 (0.1053 km² cell) | ~1.3 px/cell | ~1.9 px/cell |
+| res 8 (0.7373 km² cell) | ~9 px/cell | ~13 px/cell |
+
+`mode` at ~9 px/cell is winner-take-all: a cell that is 4/9 Very High and 5/9 Moderate becomes
+entirely Moderate, biasing the class-*share* statistic that is this issue's whole deliverable.
+So the classified products take res 9 even though that mildly oversamples the source. An
+area-weighted `mean`, by contrast, *wants* several pixels per cell, so the continuous products
+take res 8. The oversampling is a documentation obligation, discharged in the STAC: each
+collection states its effective source pixel (~250 m × 324 m at 40°N; ~169 m × 337 m at 60°N).
+
+### Official class labels — transcribed, not remembered (#294)
+
+Read from the source value attribute tables (`whp2023_cls_{conus,ak}.tif.vat.dbf`, column
+`class_desc`):
+
+`1: Very Low` · `2: Low` · `3: Moderate` · `4: High` · `5: Very High` · `6: Non-burnable` ·
+`7: Water`
+
+**The source ships no color table** — neither the classified GeoTIFFs nor the file geodatabase
+carry one — so the STAC asserts no palette. `classification:classes` carries value and
+description only.
+
+## The COG step is mandatory, and its absence fails silently
+
+`cng-datasets raster` documents its input as an already-COG'd WGS84 raster, and the
+`raster-hexing` skill says to build the WGS84 COG first. Pointing it at the raw Albers GeoTIFF
+instead **wrote zero rows and exited 0**: EPSG:5070 `(0,0)` is lon −96 / lat 23, so
+degree-valued H3 cell polygons land ~100 m from the projection origin — in the Gulf of Mexico —
+and every cell reads nodata. The Job reported `Complete`.
+
+**Only the h0 coverage gate catches this.** Structural checks all pass on an empty build.
+
+`make-cogs.yaml` therefore runs first: four indexed pods, `gdalwarp -t_srs EPSG:4326 -r near`
+(nearest for *both* products — the classified one is categorical, so anything else invents
+classes), then `gdal_translate -of COG`, with a hard gate that fails rather than publishing an
+all-nodata COG.
+
+Alaska is clipped to `-te -180 48.8 -129.0 71.6`, dropping the far-western Aleutians
+(~157°E–180°) where the source grid wraps the antimeridian. No National Forest System land lies
+there — the Alaska units are the Tongass and Chugach, far east — so nothing relevant is lost.
+
+## Area truth comes from the source grid, not the COG
+
+The source Albers grid is equal-area; the reprojected COG is geographic and therefore is not.
+Counting COG pixels is not an area measurement. H3 cells at a fixed resolution are
+near-equal-area, so hex cell counts *are* a valid area proxy — and they reproduce the source's
+equal-area class shares closely (table below). All validation runs against the source pixel
+counts.
+
+## Build results
+
+### `whp-2023-classified-*` (2026-08-20)
+
+| | CONUS | Alaska |
+|---|---:|---:|
+| Rows | 74,428,571 | 16,540,214 |
+| Rows == `COUNT(DISTINCT h9)` | ✅ exact | ✅ exact |
+| Populated h0 partitions | 6 | 3 |
+| nodata (255) leak | 0 | 0 |
+| Value range | 1–7 | 1–7 |
+| Measured footprint | −124.864, 24.467, −66.940, 49.387 | −173.190, 54.653, −129.988, 71.370 |
+
+#### Class shares vs the equal-area source — the real accuracy check
+
+Source percentages are computed from the value attribute table's pixel counts on the **Albers**
+grid (equal-area, so this is area truth): CONUS total 110,817,217 px, Alaska 22,337,483 px.
+Hex percentages are cell shares.
+
+| Class | CONUS source | CONUS hex | Δ pp | AK source | AK hex | Δ pp |
+|---|---:|---:|---:|---:|---:|---:|
+| 1 Very Low | 29.53 | 29.18 | −0.35 | 39.64 | 39.58 | −0.06 |
+| 2 Low | 17.42 | 17.27 | −0.15 | 17.70 | 17.11 | −0.59 |
+| 3 Moderate | 13.93 | 14.04 | +0.11 | 10.20 | 10.26 | +0.06 |
+| 4 High | 8.89 | 9.18 | +0.29 | 6.07 | 6.01 | −0.06 |
+| 5 Very High | 3.26 | 3.29 | +0.03 | 2.74 | 2.68 | −0.06 |
+| 6 Non-burnable | 21.55 | 21.61 | +0.06 | 10.99 | 11.38 | +0.39 |
+| 7 Water | 5.42 | 5.43 | +0.01 | 12.67 | 12.98 | +0.31 |
+| **→ 4 + 5** | **12.15** | **12.47** | **+0.32** | **8.80** | **8.69** | **−0.11** |
+
+Every class lands within 0.6 pp of the equal-area source, and the headline class 4+5 share
+within ±0.32 pp. The residual is two-stage resampling drift (Albers → geographic nearest, then
+`mode` into H3), not error — but it is **not zero**, so a published figure derived from the hex
+should be quoted to no better than a tenth of a percentage point, and anything requiring exact
+agreement with the agency should be computed from the source Albers grid.
+
+### 🔴 The Alaska question, settled — and it is not what it first looked like
+
+The published `WHP2023_ManagementJurisdiction_Summary.xlsx` compares its `CONUS` and
+`all_50_states` sheets for US Forest Service land:
+
+| | CONUS sheet | all_50_states | Δ |
+|---|---:|---:|---:|
+| Very High WHP | 26,023,000 | 26,023,000 | **0** |
+| High WHP | 40,917,000 | 40,917,000 | **0** |
+| **High + Very High** | **66,940,000** | **66,940,000** | **0** |
+| Total acres | 170,691,000 | 192,282,000 | +21,591,000 |
+
+**Alaska and Hawaii add 21.6M acres of USFS land and exactly zero acres of High or Very High
+WHP.** Per-state confirms it: Alaska USFS = 21,591,094 acres, **0** high+very-high. That is
+physically sensible — USFS land in Alaska is Tongass and Chugach coastal temperate rainforest,
+which sits at the bottom of the *Alaska* hazard distribution, while interior boreal Alaska
+(BLM, State) takes the high classes.
+
+So DEIS Table 22 is **internally consistent**: its numerator is identical in the "Total" and
+"Total excluding AK" rows precisely because Alaska contributes zero. The defensible criticism is
+narrower than "the agency ignored available data": labelling the Alaska cell **"Not Available"**
+rather than **"0"** obscures that Alaska's ~12.2M IRA acres are pure denominator, and that
+dropping them is exactly what lifts 28.7% to 41.8%. The data existed; the entry was mislabelled.
+
+Validation targets for anyone building on this, from the same supplement:
+
+| Unit | High+VeryHigh | Total | Share |
+|---|---:|---:|---:|
+| USFS, CONUS | 66,940,000 | 170,691,000 | **39.2%** |
+| USFS, all 50 states | 66,940,000 | 192,282,000 | **34.8%** |
+
+The 192,282,000 also independently corroborates the "193-million-acre National Forest System"
+figure in the press release. And for #585, free: **Montana USFS = 17,174,998 acres**; with
+#584's Montana IRA of 6,395,401 that is **37.2%**, not the "nearly 60 percent" of the release —
+a third independent source agreeing with #594's conclusion that the Montana line is a
+governor's quote, not an agency figure.
+
+## Pipeline
+
+Run in `geo-workflows`, one hex Job at a time (`AGENTS.md`: never more than one concurrent k8s
+hex workflow — 40 parallelism each would be 160 pods if all four ran together).
+
+```bash
+# 1. stage the source package to s3://public-fire/raw/whp-2023/
+kubectl apply -n geo-workflows -f whp-2023-stage-raw.yaml
+
+# 2. build the four WGS84 COGs (MANDATORY — see above)
+kubectl apply -n geo-workflows -f make-cogs.yaml
+
+# 3. hex, sequentially, waiting for Complete between each
+for d in classified-conus classified-ak continuous-conus continuous-ak; do
+  kubectl apply -n geo-workflows -f "$d/whp-2023-$d-hex.yaml"
+done
+
+# 4. STAC — four dataset collections + the patched bucket collection
+python3 gen_stac.py
+```
+
+Job hardening on all four, replacing the generated `backoffLimit: 0`:
+`backoffLimitPerIndex: 2` + `maxFailedIndexes: 0`, so a partial indexed run **fails** rather
+than publishing as complete. `priorityClassName` is omitted — `opportunistic` gets preempted
+here within ~20 s. The classified pair needs **120Gi** (a 64Gi attempt OOMed on the densest
+CONUS cell); the continuous pair runs at 64Gi, since res 8 is ~7× fewer cells.
+
+`setup-bucket` is **not** run: `public-fire` already exists, already serves anonymously, and
+already holds `calfire-2024`/`calfire-2025`/`usgs-fires-2021`. Nothing about a new dataset
+changes bucket-level access. There is also no root-catalog or MinIO-backup registration step —
+that tier was retired from this repo in #568; the only obligation is a correct SPDX `license`,
+which is `public-domain` with a license link.
+
+## Post-build verification
+
+```bash
+# h0 coverage gate — per domain, NOT against a national reference
+scripts/check-hex-coverage.sh nrp:public-fire/whp-2023-continuous-conus/hex/ \
+  --expect-h0 576812596024311807,577164439745200127,577199624117288959,577234808489377791,577692205326532607,577762574070710271
+scripts/check-hex-coverage.sh nrp:public-fire/whp-2023-continuous-ak/hex/ \
+  --expect-h0 576707042908045311,576988517884755967,576812596024311807
+
+# STAC, with data checks
+python3 scripts/verify-stac.py --bucket public-fire
+```
+
+⚠️ **Do not gate these against `roadless-areas-2001/hex/` as a `--reference`.** That layer is
+national; each WHP collection is one domain, so a national reference is a guaranteed false FAIL.
+The two classified domains *together* populate 8 of that layer's 9 h0 partitions — the ninth,
+`577832942814887935`, is **Puerto Rico** (El Yunque, 8,897 res-10 IRA cells), which WHP
+CONUS+AK does not cover at all.
+
+Also note `check-hex-coverage.sh` communicates through its exit code; if you pipe its output,
+read `${PIPESTATUS[0]}` rather than `$?`.
+
+### `whp-2023-continuous-*` (2026-08-21)
+
+Both jobs `Complete=True`, 122/122, `failedIndexes: []`, no OOM at 64Gi.
+
+| | CONUS | Alaska |
+|---|---:|---:|
+| Rows | 10,641,399 | 2,369,388 |
+| Rows == `COUNT(DISTINCT h8)` | ✅ exact, 0 duplicates | ✅ exact, 0 duplicates |
+| Populated h0 partitions | 6 (gate PASS) | 3 (gate PASS) |
+| NULL `whp_index` | 0 | 0 |
+| nodata (2147483647) leak | 0 | 0 |
+| Index range | 0 – 93,924 | 0 – 48,140 |
+| Mean index | 432.72 | 939.61 |
+| Measured footprint | −124.868, 24.467, −66.940, 49.387 | −173.188, 54.654, −129.984, 71.371 |
+
+The Alaska mean index being ~2.2× the CONUS mean is consistent rather than suspicious: the
+Alaska class breaks sit far higher (Very High starts at 8,912 vs 1,985), so the same index scale
+runs hotter there. This is the same fact that makes the classified products non-comparable across
+domains, visible from the other side.
+
+### Cross-product agreement — the check worth trusting most
+
+The classified and continuous layers are built independently from different source rasters. Joined
+on `h8` within one h0 partition (`577199624117288959`, California + interior West), the mean
+continuous index per classified class is strictly monotonic across the hazard classes, and the two
+non-fuel classes sit low where they should:
+
+| Classified class | Break range (CONUS) | Mean continuous index |
+|---|---|---:|
+| 1 Very Low | ≤ 61 | 58 |
+| 2 Low | 62–178 | 196.7 |
+| 3 Moderate | 179–489 | 446.7 |
+| 4 High | 490–1,985 | 1,222.4 |
+| 5 Very High | > 1,985 | 7,641.1 |
+| 6 Non-burnable | — | 150.8 |
+| 7 Water | — | 59 |
+
+Class 2's mean sitting just above its own 178 ceiling is expected from the join geometry, not a
+defect: a res-9 classified cell is matched to the res-8 continuous cell containing it, and that
+coarser cell also spans higher-class neighbours. Classes 3, 4 and 5 all land inside their ranges.
+
+## Published
+
+| Collection | Assets |
+|---|---|
+| `whp-2023-classified-conus` | COG + hex (res 9, parents 8/0) |
+| `whp-2023-classified-ak` | COG + hex (res 9, parents 8/0) |
+| `whp-2023-continuous-conus` | COG + hex (res 8, parent 0) |
+| `whp-2023-continuous-ak` | COG + hex (res 8, parent 0) |
+
+`verify-stac.py` PASS with data checks on all four dataset collections and on the patched bucket
+collection (0 hard findings; the bucket's 18 advisories are all pre-existing on the CAL FIRE and
+USGS assets and were not introduced here).
+
+### Bucket-level changes, and why they were necessary
+
+Adding a modelled hazard raster to `public-fire` made three published statements false, so the
+bucket collection and README were **patched** (fetched, edited, re-uploaded — not regenerated, so
+unmodelled fields survive; all 15 pre-existing assets verified preserved):
+
+1. **`title`** — "Fire Perimeters: CAL FIRE (2024, 2025) and USGS Combined (2021)" → "Wildfire:
+   hazard potential and fire perimeters". WHP is not a perimeter dataset.
+2. **`license`: `CC-BY-4.0` → `various`**, and the bucket-level CC-BY license *link* dropped. The
+   perimeter children are CC-BY-4.0; the Forest Service hazard products are public domain. No
+   single bucket term is honest, and leaving the CC-BY link in place would assert CC-BY over
+   public-domain children. A meta-collection with `child` links may use `various` with no license
+   link — the real licenses live on and are gated per child (stac-authoring SKILL.md;
+   `verify-stac.py check_license`).
+3. **README intro** — it claimed the bucket holds fire *perimeter* datasets and that *all*
+   datasets are polygon geometries. Both rewritten; per-dataset sections untouched.
+
+**`id` was deliberately left as `fire-perimeters`.** It no longer describes the bucket well, but it
+is consumer-visible and renaming it is out of scope for #586. Worth a follow-up issue.
+
+Backups of both pre-patch files were taken before upload.
+
+## Notes for the downstream issues
+
+- **The `>40%` claim needs the Alaska caveat to be reproduced honestly.** 11,479,564 acres of high
+  or very high WHP is 41.8% of the potentially affected environment **excluding** Alaska and 28.7%
+  **including** it. Both figures are correct; only the first supports ">40%". Publish both.
+- **The denominator is ~40.0M acres, not 44.7M** (#589/#602). Four bases are now in play —
+  58.4M all-IRA / 44.7M rule-affected / 44.3M on NFS / 40.0M potentially affected. Every
+  tabulation must name which it uses.
+- **Use the continuous collections for any CONUS-vs-Alaska comparison.** The classified breaks are
+  domain-relative and cannot be pooled.
+- **#590 (LANDFIRE)** should know the DEIS's forest-area figures disagree with each other: the
+  "16 percent of forested areas" claim implies ~30.0M forested acres, while the DEIS publishes
+  20.9M (NLCD), ~21M (narrative) and 25.5M (FIA type groups).

--- a/catalog/fire/k8s/whp-2023/classified-ak/configmap.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-ak/configmap.yaml
@@ -1,0 +1,173 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset whp-2023-classified-ak --source-url "s3://public-fire/whp-2023-classified-ak-cog.tif" --bucket public-fire --h3-resolution 9 --parent-resolutions "8,0"
+apiVersion: v1
+data:
+  whp-2023-classified-ak-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-classified-ak-hex
+      labels:
+        k8s-app: whp-2023-classified-ak-hex
+    spec:
+      completions: 122
+      parallelism: 40
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-classified-ak-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-fire/whp-2023-classified-ak-cog.tif" --output-parquet s3://public-fire/whp-2023-classified-ak/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column whp_class --hex-resampling mode --nodata "255"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 120Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 120Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  whp-2023-classified-ak-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-classified-ak-setup-bucket
+      labels:
+        k8s-app: whp-2023-classified-ak-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-classified-ak-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: whp-2023-classified-ak-yamls
+  namespace: geo-workflows

--- a/catalog/fire/k8s/whp-2023/classified-ak/whp-2023-classified-ak-hex.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-ak/whp-2023-classified-ak-hex.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-classified-ak-hex
+  labels:
+    k8s-app: whp-2023-classified-ak-hex
+spec:
+  completions: 122
+  parallelism: 40
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-classified-ak-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-fire/whp-2023-classified-ak-cog.tif" --output-parquet s3://public-fire/whp-2023-classified-ak/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column whp_class --hex-resampling mode --nodata "255"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/fire/k8s/whp-2023/classified-ak/whp-2023-classified-ak-setup-bucket.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-ak/whp-2023-classified-ak-setup-bucket.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-classified-ak-setup-bucket
+  labels:
+    k8s-app: whp-2023-classified-ak-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-classified-ak-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/fire/k8s/whp-2023/classified-ak/workflow-rbac.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-ak/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/fire/k8s/whp-2023/classified-ak/workflow.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-ak/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-classified-ak-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting whp-2023-classified-ak raster workflow...\"\n\
+          \n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/whp-2023-classified-ak-setup-bucket.yaml -n geo-workflows\n\
+          kubectl wait --for=condition=complete --timeout=600s job/whp-2023-classified-ak-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/whp-2023-classified-ak-hex.yaml -n\
+          \ geo-workflows\nkubectl wait --for=condition=complete --timeout=7200s job/whp-2023-classified-ak-hex\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs whp-2023-classified-ak-setup-bucket\
+          \ whp-2023-classified-ak-hex whp-2023-classified-ak-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap whp-2023-classified-ak-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: whp-2023-classified-ak-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/fire/k8s/whp-2023/classified-conus/configmap.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-conus/configmap.yaml
@@ -1,0 +1,173 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset whp-2023-classified-conus --source-url "s3://public-fire/whp-2023-classified-conus-cog.tif" --bucket public-fire --h3-resolution 9 --parent-resolutions "8,0"
+apiVersion: v1
+data:
+  whp-2023-classified-conus-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-classified-conus-hex
+      labels:
+        k8s-app: whp-2023-classified-conus-hex
+    spec:
+      completions: 122
+      parallelism: 40
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-classified-conus-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-fire/whp-2023-classified-conus-cog.tif" --output-parquet s3://public-fire/whp-2023-classified-conus/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column whp_class --hex-resampling mode --nodata "255"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 120Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 120Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  whp-2023-classified-conus-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-classified-conus-setup-bucket
+      labels:
+        k8s-app: whp-2023-classified-conus-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-classified-conus-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: whp-2023-classified-conus-yamls
+  namespace: geo-workflows

--- a/catalog/fire/k8s/whp-2023/classified-conus/whp-2023-classified-conus-hex.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-conus/whp-2023-classified-conus-hex.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-classified-conus-hex
+  labels:
+    k8s-app: whp-2023-classified-conus-hex
+spec:
+  completions: 122
+  parallelism: 40
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-classified-conus-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-fire/whp-2023-classified-conus-cog.tif" --output-parquet s3://public-fire/whp-2023-classified-conus/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 9 --parent-resolutions 8,0 --value-column whp_class --hex-resampling mode --nodata "255"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 120Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/fire/k8s/whp-2023/classified-conus/whp-2023-classified-conus-setup-bucket.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-conus/whp-2023-classified-conus-setup-bucket.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-classified-conus-setup-bucket
+  labels:
+    k8s-app: whp-2023-classified-conus-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-classified-conus-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/fire/k8s/whp-2023/classified-conus/workflow-rbac.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-conus/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/fire/k8s/whp-2023/classified-conus/workflow.yaml
+++ b/catalog/fire/k8s/whp-2023/classified-conus/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-classified-conus-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting whp-2023-classified-conus raster workflow...\"\
+          \n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/whp-2023-classified-conus-setup-bucket.yaml -n geo-workflows\n\
+          kubectl wait --for=condition=complete --timeout=600s job/whp-2023-classified-conus-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/whp-2023-classified-conus-hex.yaml\
+          \ -n geo-workflows\nkubectl wait --for=condition=complete --timeout=7200s\
+          \ job/whp-2023-classified-conus-hex -n geo-workflows\n\necho \"\u2713 Workflow\
+          \ complete!\"\necho \"Clean up with:\"\necho \"  kubectl delete jobs whp-2023-classified-conus-setup-bucket\
+          \ whp-2023-classified-conus-hex whp-2023-classified-conus-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap whp-2023-classified-conus-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: whp-2023-classified-conus-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/fire/k8s/whp-2023/continuous-ak/configmap.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-ak/configmap.yaml
@@ -1,0 +1,173 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset whp-2023-continuous-ak --source-url "s3://public-fire/whp-2023-continuous-ak-cog.tif" --bucket public-fire --h3-resolution 8 --parent-resolutions "0"
+apiVersion: v1
+data:
+  whp-2023-continuous-ak-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-continuous-ak-hex
+      labels:
+        k8s-app: whp-2023-continuous-ak-hex
+    spec:
+      completions: 122
+      parallelism: 40
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-continuous-ak-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-fire/whp-2023-continuous-ak-cog.tif" --output-parquet s3://public-fire/whp-2023-continuous-ak/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column whp_index --hex-resampling mean --nodata "2147483647"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  whp-2023-continuous-ak-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-continuous-ak-setup-bucket
+      labels:
+        k8s-app: whp-2023-continuous-ak-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-continuous-ak-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: whp-2023-continuous-ak-yamls
+  namespace: geo-workflows

--- a/catalog/fire/k8s/whp-2023/continuous-ak/whp-2023-continuous-ak-hex.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-ak/whp-2023-continuous-ak-hex.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-continuous-ak-hex
+  labels:
+    k8s-app: whp-2023-continuous-ak-hex
+spec:
+  completions: 122
+  parallelism: 40
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-continuous-ak-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-fire/whp-2023-continuous-ak-cog.tif" --output-parquet s3://public-fire/whp-2023-continuous-ak/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column whp_index --hex-resampling mean --nodata "2147483647"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/fire/k8s/whp-2023/continuous-ak/whp-2023-continuous-ak-setup-bucket.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-ak/whp-2023-continuous-ak-setup-bucket.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-continuous-ak-setup-bucket
+  labels:
+    k8s-app: whp-2023-continuous-ak-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-continuous-ak-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/fire/k8s/whp-2023/continuous-ak/workflow-rbac.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-ak/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/fire/k8s/whp-2023/continuous-ak/workflow.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-ak/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-continuous-ak-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting whp-2023-continuous-ak raster workflow...\"\n\
+          \n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/whp-2023-continuous-ak-setup-bucket.yaml -n geo-workflows\n\
+          kubectl wait --for=condition=complete --timeout=600s job/whp-2023-continuous-ak-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/whp-2023-continuous-ak-hex.yaml -n\
+          \ geo-workflows\nkubectl wait --for=condition=complete --timeout=7200s job/whp-2023-continuous-ak-hex\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Clean up\
+          \ with:\"\necho \"  kubectl delete jobs whp-2023-continuous-ak-setup-bucket\
+          \ whp-2023-continuous-ak-hex whp-2023-continuous-ak-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap whp-2023-continuous-ak-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: whp-2023-continuous-ak-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/fire/k8s/whp-2023/continuous-conus/configmap.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-conus/configmap.yaml
@@ -1,0 +1,173 @@
+# Auto-generated ConfigMap for raster workflow
+# Generation command: cng-datasets raster-workflow --dataset whp-2023-continuous-conus --source-url "s3://public-fire/whp-2023-continuous-conus-cog.tif" --bucket public-fire --h3-resolution 8 --parent-resolutions "0"
+apiVersion: v1
+data:
+  whp-2023-continuous-conus-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-continuous-conus-hex
+      labels:
+        k8s-app: whp-2023-continuous-conus-hex
+    spec:
+      completions: 122
+      parallelism: 40
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-continuous-conus-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: GDAL_DATA
+              value: /usr/share/gdal
+            - name: PYTHONPATH
+              value: /usr/lib/python3/dist-packages
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+
+              cng-datasets raster --input "s3://public-fire/whp-2023-continuous-conus-cog.tif" --output-parquet s3://public-fire/whp-2023-continuous-conus/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column whp_index --hex-resampling mean --nodata "2147483647"
+            resources:
+              requests:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+              limits:
+                cpu: '4'
+                memory: 64Gi
+                ephemeral-storage: 20Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  whp-2023-continuous-conus-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: whp-2023-continuous-conus-setup-bucket
+      labels:
+        k8s-app: whp-2023-continuous-conus-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: whp-2023-continuous-conus-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-fire
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: whp-2023-continuous-conus-yamls
+  namespace: geo-workflows

--- a/catalog/fire/k8s/whp-2023/continuous-conus/whp-2023-continuous-conus-hex.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-conus/whp-2023-continuous-conus-hex.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-continuous-conus-hex
+  labels:
+    k8s-app: whp-2023-continuous-conus-hex
+spec:
+  completions: 122
+  parallelism: 40
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-continuous-conus-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: GDAL_DATA
+          value: /usr/share/gdal
+        - name: PYTHONPATH
+          value: /usr/lib/python3/dist-packages
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+
+          cng-datasets raster --input "s3://public-fire/whp-2023-continuous-conus-cog.tif" --output-parquet s3://public-fire/whp-2023-continuous-conus/hex/ --h0-index ${JOB_COMPLETION_INDEX} --resolution 8 --parent-resolutions 0 --value-column whp_index --hex-resampling mean --nodata "2147483647"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+          limits:
+            cpu: '4'
+            memory: 64Gi
+            ephemeral-storage: 20Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/fire/k8s/whp-2023/continuous-conus/whp-2023-continuous-conus-setup-bucket.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-conus/whp-2023-continuous-conus-setup-bucket.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-continuous-conus-setup-bucket
+  labels:
+    k8s-app: whp-2023-continuous-conus-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-continuous-conus-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-fire
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/fire/k8s/whp-2023/continuous-conus/workflow-rbac.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-conus/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/fire/k8s/whp-2023/continuous-conus/workflow.yaml
+++ b/catalog/fire/k8s/whp-2023/continuous-conus/workflow.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-continuous-conus-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "set -e\n\necho \"Starting whp-2023-continuous-conus raster workflow...\"\
+          \n\n# Step 0: Setup bucket\necho \"Step 0: Setting up bucket...\"\nkubectl\
+          \ apply -f /yamls/whp-2023-continuous-conus-setup-bucket.yaml -n geo-workflows\n\
+          kubectl wait --for=condition=complete --timeout=600s job/whp-2023-continuous-conus-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: H3 hexagonal tiling\necho \"Step 1: H3 hexagonal\
+          \ tiling...\"\nkubectl apply -f /yamls/whp-2023-continuous-conus-hex.yaml\
+          \ -n geo-workflows\nkubectl wait --for=condition=complete --timeout=7200s\
+          \ job/whp-2023-continuous-conus-hex -n geo-workflows\n\necho \"\u2713 Workflow\
+          \ complete!\"\necho \"Clean up with:\"\necho \"  kubectl delete jobs whp-2023-continuous-conus-setup-bucket\
+          \ whp-2023-continuous-conus-hex whp-2023-continuous-conus-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap whp-2023-continuous-conus-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: whp-2023-continuous-conus-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/fire/k8s/whp-2023/gen_stac.py
+++ b/catalog/fire/k8s/whp-2023/gen_stac.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""Emit the four whp-2023 dataset collections and the patched public-fire bucket
+collection to /tmp for rclone upload (AGENTS.md Hard Boundary 1 — this repo never
+contains STAC JSON or README files).
+
+Four collections, not one, because the WHP classification is DOMAIN-RELATIVE: the
+class breaks for Alaska and CONUS are different numbers (a CONUS "Very High" is
+index > 1,985; an Alaska "Very High" is > 8,912). A single mosaicked classified
+layer would invite a pooled GROUP BY across two incompatible scales, which is
+exactly the arithmetic that produces a wrong headline number. Splitting the
+domains makes the pooling impossible to do by accident, and the res-8 `h8` key on
+all four means they still join to each other and to roadless-areas-2001 cell for
+cell — which is what H3 is for.
+
+The bucket collection is FETCHED and PATCHED rather than rewritten, so fields this
+script does not know about survive.
+"""
+import copy
+import json
+import urllib.request
+
+BUCKET = "public-fire"
+BASE = f"https://s3-west.nrp-nautilus.io/{BUCKET}"
+ROOT = "https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json"
+
+ARCHIVE = "https://www.fs.usda.gov/rds/archive/products/RDS-2015-0047-4"
+PRODUCT_PAGE = ("https://research.fs.usda.gov/firelab/products/dataandtools/"
+                "wildfire-hazard-potential")
+
+# ── Official class labels, verbatim from the source value attribute table ──────
+# whp2023_cls_{conus,ak}.tif.vat.dbf, column `class_desc`. Transcribed rather than
+# written from memory (#294). The source ships NO color table on either the
+# classified GeoTIFF or the file geodatabase, so no palette is asserted here.
+CLASS_DESC = {
+    1: "Very Low",
+    2: "Low",
+    3: "Moderate",
+    4: "High",
+    5: "Very High",
+    6: "Non-burnable",
+    7: "Water",
+}
+
+CLASS_LIST = ", ".join(f"{k}={v}" for k, v in sorted(CLASS_DESC.items()))
+
+# Class breaks on the continuous WHP index, per domain (Dillon 2023). These are the
+# reason the domains are published separately.
+BREAKS = {
+    "conus": {1: "≤ 61", 2: "62–178", 3: "179–489", 4: "490–1,985", 5: "> 1,985"},
+    "ak":    {1: "≤ 83", 2: "84–624", 3: "625–2,922", 4: "2,923–8,912", 5: "> 8,912"},
+}
+
+HAZARD_NOT_RISK = (
+    "**Hazard, not risk.** Wildfire Hazard Potential describes the likelihood and intensity "
+    "of wildfire at a location given its fuels, topography and weather. It says nothing about "
+    "what is there to lose. A remote wilderness ridge can carry Very High hazard with no "
+    "exposed assets; a subdivision can sit in Moderate hazard and still dominate a risk "
+    "ranking. Do not read this layer as a map of communities in danger — for that, use "
+    "Wildfire Risk to Communities, which combines hazard with exposure and susceptibility."
+)
+
+NON_BURNABLE_NOTE = (
+    "Classes 6 (Non-burnable) and 7 (Water) are not hazard levels — they are the absence of "
+    "burnable fuel. They are part of the mapped land base and are NOT excluded from any total "
+    "here. Whether to exclude them is the consumer's decision and it changes every "
+    "\"share of X that is high hazard\" figure materially: they are 27.0% of CONUS cells and "
+    "24.4% of Alaska cells. State which convention a published percentage uses."
+)
+
+
+def domain_note(domain):
+    other = "ak" if domain == "conus" else "conus"
+    dom_name = "CONUS" if domain == "conus" else "Alaska"
+    other_name = "Alaska" if domain == "conus" else "CONUS"
+    return (
+        f"**The class breaks are specific to {dom_name} and are not comparable to "
+        f"{other_name}.** Dillon (2023) classifies each domain against its own distribution of "
+        f"the continuous WHP index, so identical class labels mean different absolute hazard in "
+        f"each domain:\n\n"
+        f"| Class | {dom_name} index | {other_name} index |\n|---|---|---|\n"
+        + "".join(
+            f"| {k}: {CLASS_DESC[k]} | {BREAKS[domain][k]} | {BREAKS[other][k]} |\n"
+            for k in (1, 2, 3, 4, 5)
+        )
+        + f"\nA {dom_name} \"Very High\" cell and an {other_name} \"Very High\" cell differ by "
+        f"roughly 4.5× in underlying index. Never GROUP BY class across the two collections. "
+        f"For any cross-domain comparison use the continuous collections "
+        f"(`whp-2023-continuous-{domain}` / `whp-2023-continuous-{other}`), whose raw index "
+        f"means the same thing everywhere."
+    )
+
+
+AREA_TRUTH = (
+    "**Area truth comes from the source grid, not from pixel counts on the COG.** The source "
+    "is an equal-area Albers grid; the WGS84 COG published alongside is geographic and therefore "
+    "is not equal-area, so counting COG pixels is not an area measurement. H3 cells at a given "
+    "resolution are near-equal-area, so cell counts on the hex asset ARE a valid area proxy — "
+    "and they reproduce the source's equal-area class shares to within 0.6 percentage points on "
+    "every class in both domains."
+)
+
+# `bbox` is the MEASURED footprint of the populated H3 cells, not the COG rectangle and
+# not the gdalwarp clip box. The COG carries a nodata margin (and the Alaska clip box
+# reaches 2.4° south of any Alaska data), so declaring either would overstate the extent
+# — which verify-stac.py flags as title-names-state-but-bbox-exceeds-it (#528).
+DATASETS = {
+    "whp-2023-classified-conus": {
+        "domain": "conus",
+        "kind": "classified",
+        "title": "Wildfire Hazard Potential 2023 — classified, CONUS",
+        "bbox": [-124.864, 24.467, -66.940, 49.387],
+        "cog": "whp-2023-classified-conus-cog.tif",
+        "native": 9,
+        "parents": [8, 0],
+        "reducer": "mode",
+        "column": "whp_class",
+        "coltype": "uint8",
+        "nodata": 255,
+        "rows": 74428571,
+        "h0_count": 6,
+        "src_tif": "whp2023_cls_conus.tif",
+        "eff_pixel": "about 250 m × 324 m at 40°N",
+    },
+    "whp-2023-classified-ak": {
+        "domain": "ak",
+        "kind": "classified",
+        "title": "Wildfire Hazard Potential 2023 — classified, Alaska",
+        "bbox": [-173.190, 54.653, -129.988, 71.370],
+        "cog": "whp-2023-classified-ak-cog.tif",
+        "native": 9,
+        "parents": [8, 0],
+        "reducer": "mode",
+        "column": "whp_class",
+        "coltype": "uint8",
+        "nodata": 255,
+        "rows": 16540214,
+        "h0_count": 3,
+        "src_tif": "whp2023_cls_ak.tif",
+        "eff_pixel": "about 169 m × 337 m at 60°N",
+    },
+    "whp-2023-continuous-conus": {
+        "domain": "conus",
+        "kind": "continuous",
+        "title": "Wildfire Hazard Potential 2023 — continuous index, CONUS",
+        "bbox": [-124.868, 24.467, -66.940, 49.387],
+        "cog": "whp-2023-continuous-conus-cog.tif",
+        "native": 8,
+        "parents": [0],
+        "reducer": "mean",
+        "column": "whp_index",
+        "coltype": "double",
+        "nodata": 2147483647,
+        "rows": 10641399,
+        "h0_count": 6,
+        "src_tif": "whp2023_cnt_conus.tif",
+        "eff_pixel": "about 250 m × 324 m at 40°N",
+    },
+    "whp-2023-continuous-ak": {
+        "domain": "ak",
+        "kind": "continuous",
+        "title": "Wildfire Hazard Potential 2023 — continuous index, Alaska",
+        "bbox": [-173.188, 54.654, -129.984, 71.371],
+        "cog": "whp-2023-continuous-ak-cog.tif",
+        "native": 8,
+        "parents": [0],
+        "reducer": "mean",
+        "column": "whp_index",
+        "coltype": "double",
+        "nodata": 2147483647,
+        "rows": 2369388,
+        "h0_count": 3,
+        "src_tif": "whp2023_cnt_ak.tif",
+        "eff_pixel": "about 169 m × 337 m at 60°N",
+    },
+}
+
+
+H3_DESC = {
+    9: "H3 cell identifier at resolution 9.",
+    8: ("H3 cell identifier at resolution 8. This is the shared join key across the catalog "
+        "(AGENTS.md) — use it to join this layer to roadless-areas-2001 and to the other three "
+        "whp-2023 collections."),
+    0: ("H3 cell identifier at resolution 0, used as the partition key for hive-partitioned "
+        "reads."),
+}
+
+
+def hex_columns(cfg):
+    """Column list for the hex asset: the value column plus its H3 keys."""
+    if cfg["kind"] == "classified":
+        value = {
+            "name": cfg["column"],
+            "type": cfg["coltype"],
+            "description": (
+                "Classified Wildfire Hazard Potential, the majority (`mode`) source class within "
+                "the cell. Values 1–5 are hazard levels on a domain-relative scale; 6 and 7 are "
+                "non-burnable land and water, not hazard levels. Labels are verbatim from the "
+                "source value attribute table. Source nodata (255) is dropped rather than stored, "
+                "so this column is never null. Valid values: "
+                + CLASS_LIST + "."
+            ),
+            "values": [1, 2, 3, 4, 5, 6, 7],
+        }
+    else:
+        value = {
+            "name": cfg["column"],
+            "type": cfg["coltype"],
+            "description": (
+                "Continuous Wildfire Hazard Potential index, the area-weighted `mean` of the "
+                "source pixels within the cell. Unitless and monotonic — higher means greater "
+                "hazard potential — and, unlike the classified product, comparable between CONUS "
+                "and Alaska. Averaging is meaningful here because the index is a continuous "
+                "quantity; do not average the classified codes instead. Source nodata "
+                "(2147483647) is dropped rather than stored, so this column is never null."
+            ),
+        }
+    res = [cfg["native"]] + cfg["parents"]
+    return [value] + [
+        {"name": f"h{r}", "type": "int64" if r == 0 else "uint64", "description": H3_DESC[r]}
+        for r in res
+    ]
+
+
+def dataset_collection(name, cfg):
+    dom = cfg["domain"]
+    dom_name = "CONUS" if dom == "conus" else "Alaska"
+    is_cls = cfg["kind"] == "classified"
+
+    rows = f"{cfg['rows']:,}" if cfg["rows"] else "see the hex asset"
+    parts = [
+        f"Wildfire Hazard Potential (WHP) version 2023 for {dom_name}, at the source resolution "
+        f"of 270 m, published as a WGS84 cloud-optimized GeoTIFF and as H3 hex parquet at native "
+        f"resolution {cfg['native']}"
+        + (f" with parents {', '.join(str(p) for p in cfg['parents'])}." if cfg["parents"] else "."),
+        HAZARD_NOT_RISK,
+    ]
+
+    if is_cls:
+        parts += [domain_note(dom), NON_BURNABLE_NOTE]
+    else:
+        parts.append(
+            "**This is the cross-domain-comparable product.** The raw WHP index means the same "
+            "thing in Alaska as in CONUS, whereas the classified product's breaks are computed "
+            "per domain. Any CONUS-vs-Alaska comparison should be built on this collection, not "
+            "on `whp-2023-classified-*`."
+        )
+
+    parts.append(AREA_TRUTH)
+
+    parts.append(
+        f"**Effective resolution.** Native H3 resolution is {cfg['native']}, but the source pixel "
+        f"is 270 m in the equal-area projection, which after reprojection is {cfg['eff_pixel']}. "
+        + (
+            "At resolution 9 that is roughly 1.3–1.9 source pixels per cell, so the hex carries "
+            "slightly finer geometry than the source actually resolves. Resolution 9 was chosen "
+            "deliberately over 8: the deliverable is a class-share statistic inside polygon "
+            "boundaries, and at ~9 pixels per cell a `mode` vote is winner-take-all — a cell that "
+            "is 4/9 Very High and 5/9 Moderate becomes entirely Moderate, biasing exactly the "
+            "statistic being measured. Do not read resolution-9 cells as resolution-9 information."
+            if is_cls else
+            "At resolution 8 that is roughly 9–13 source pixels per cell, which is what an "
+            "area-weighted `mean` wants; resolution 9 would multiply the row count for no added "
+            "information."
+        )
+    )
+
+    if dom == "ak":
+        parts.append(
+            "**Alaska extent.** Clipped to 180°W–129°W, 48.8°N–71.6°N, which drops the "
+            "far-western Aleutians (roughly 157°E–180°) where the source grid wraps the "
+            "antimeridian. No National Forest System land lies in the dropped area — the Alaska "
+            "units are the Tongass and Chugach, far to the east — so nothing relevant to Forest "
+            "Service analysis is lost, but the collection is not a complete Alaska mosaic and "
+            "should not be described as one."
+        )
+
+    parts.append(
+        "Hawaii is published by the source as a third domain with its own class breaks and is not "
+        "ingested here; the raw source raster covering it is retained under "
+        f"`{BASE}/raw/whp-2023/`."
+    )
+
+    description = "\n\n".join(parts)
+
+    assets = {
+        f"{name}-cog": {
+            "href": f"{BASE}/{cfg['cog']}",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": f"{cfg['title']} — WGS84 COG",
+            "description": (
+                "Reprojected from the source equal-area Albers grid to EPSG:4326 with nearest-"
+                "neighbour resampling"
+                + (" — required, since the values are class codes and any other resampling "
+                   "invents classes that do not exist in the source." if is_cls else
+                   " — matching the classified product so the two grids align cell for cell.")
+                + " Geographic, therefore NOT equal-area: use the hex asset for area statistics."
+            ),
+            "roles": ["data"],
+            "raster:bands": [{
+                "data_type": "uint8" if is_cls else "int32",
+                "nodata": cfg["nodata"],
+                "spatial_resolution": 270,
+                "unit": "class code" if is_cls else "WHP index (unitless)",
+            }],
+        },
+        f"{name}-hex": {
+            "href": f"{BASE}/{name}/hex/h0=*/data_0.parquet",
+            "type": "application/x-parquet",
+            "title": f"{cfg['title']} — H3 hex (resolution {cfg['native']})",
+            "description": (
+                f"One row per populated H3 resolution-{cfg['native']} cell ({rows} rows across "
+                f"{cfg['h0_count']} h0 partitions). Reducer is `{cfg['reducer']}`"
+                + (", correct for class codes — a majority vote preserves values that exist in "
+                   "the source, where a mean would fabricate ones that do not."
+                   if is_cls else
+                   ", correct for a continuous index.")
+                + " There is no per-feature attribute repeated across cells here, so unlike a "
+                  "vector hex asset `COUNT(*)` is meaningful: it counts cells, and cells are a "
+                  "valid area proxy."
+            ),
+            "roles": ["data"],
+            "h3:native_resolution": cfg["native"],
+            "h3:parent_resolutions": cfg["parents"],
+            "table:columns": hex_columns(cfg),
+        },
+    }
+
+    if is_cls:
+        assets[f"{name}-hex"]["classification:classes"] = [
+            {"value": v, "description": d} for v, d in sorted(CLASS_DESC.items())
+        ]
+
+    return {
+        "stac_version": "1.0.0",
+        "stac_extensions": [
+            "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+            "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+            "https://stac-extensions.github.io/classification/v1.1.0/schema.json",
+        ] if is_cls else [
+            "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+            "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        ],
+        "type": "Collection",
+        "id": name,
+        "title": cfg["title"],
+        "description": description,
+        "license": "public-domain",
+        "keywords": ["wildfire", "hazard", "fuels", "WHP", "H3", dom_name,
+                     "USDA Forest Service", "Fire Sciences Laboratory"],
+        "extent": {
+            "spatial": {"bbox": [cfg["bbox"]]},
+            "temporal": {"interval": [["2023-01-01T00:00:00Z", "2023-12-31T23:59:59Z"]]},
+        },
+        "providers": [
+            {"name": "Gregory K. Dillon, USDA Forest Service Rocky Mountain Research Station, "
+                     "Fire Sciences Laboratory",
+             "roles": ["producer", "licensor"], "url": PRODUCT_PAGE},
+            {"name": "USDA Forest Service Research Data Archive",
+             "roles": ["licensor", "host"], "url": ARCHIVE},
+            {"name": "Boettiger Lab / cirrus", "roles": ["processor", "host"], "url": f"{BASE}/"},
+        ],
+        "links": [
+            {"rel": "self", "href": f"{BASE}/{name}/stac-collection.json",
+             "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": f"{BASE}/stac-collection.json",
+             "type": "application/json"},
+            {"rel": "license", "href": "https://www.usa.gov/government-works",
+             "type": "text/html", "title": "US Government work — public domain"},
+            {"rel": "cite-as", "href": "https://doi.org/10.2737/RDS-2015-0047-4",
+             "title": "Dillon, G.K. 2023. Wildfire Hazard Potential for the United States "
+                      "(270-m), version 2023. 4th Edition. Fort Collins, CO: Forest Service "
+                      "Research Data Archive."},
+            {"rel": "via", "href": f"{ARCHIVE}/RDS-2015-0047-4_Data.zip",
+             "type": "application/zip", "title": "Source data package (Research Data Archive)"},
+            {"rel": "about", "href": PRODUCT_PAGE, "type": "text/html",
+             "title": "Wildfire Hazard Potential product page"},
+            {"rel": "describedby",
+             "href": f"{BASE}/raw/whp-2023/unpacked/Data/whp2023_GeoTIF/{cfg['src_tif']}.xml",
+             "type": "application/xml",
+             "title": "FGDC metadata as published with the source"},
+        ],
+        "assets": assets,
+    }
+
+
+BUCKET_TITLE = "Wildfire: hazard potential and fire perimeters"
+
+BUCKET_DESCRIPTION = (
+    "Wildfire datasets published as cloud-native GeoParquet, PMTiles and H3 hex parquet. Two "
+    "kinds of layer live here and they answer different questions. Fire perimeters (CAL FIRE "
+    "FRAP, USGS Combined) record where fire HAS burned. Wildfire Hazard Potential records where "
+    "fire is LIKELY to burn and how intensely, given fuels, topography and weather — it is a "
+    "modelled surface, not an observation, and it is hazard rather than risk: it does not account "
+    "for what is exposed to loss.\n\n"
+    "Licenses differ by dataset — the CAL FIRE and USGS perimeter collections are CC-BY-4.0, the "
+    "Forest Service hazard products are US Government works in the public domain. Each child "
+    "collection carries its own license; check there rather than assuming a bucket-wide term."
+)
+
+
+def patch_bucket_collection():
+    """Fetch the published bucket collection and add the four whp-2023 children.
+
+    Patched rather than rewritten so fields this script does not model are preserved.
+    Three edits beyond the child links:
+
+    1. title/description — the published ones say "Fire Perimeters", which stops being
+       true once a modelled hazard raster lives in the bucket.
+    2. license CC-BY-4.0 → various — the perimeter children are CC-BY-4.0 and the WHP
+       children are public-domain, so no single bucket-level term is honest. A
+       meta-collection (one with child links) may use `various` with no license link;
+       the real licenses live on and are gated per child (stac-authoring SKILL.md,
+       verify-stac.py check_license).
+    3. the bucket-level CC-BY-4.0 license LINK is dropped for the same reason — left in
+       place it would assert CC-BY over public-domain children.
+
+    The `id` (`fire-perimeters`) is deliberately NOT changed: it is consumer-visible and
+    renaming it is out of scope for this issue.
+    """
+    with urllib.request.urlopen(f"{BASE}/stac-collection.json", timeout=60) as r:
+        doc = json.load(r)
+
+    doc["title"] = BUCKET_TITLE
+    doc["description"] = BUCKET_DESCRIPTION
+    doc["license"] = "various"
+
+    links = [
+        l for l in doc.get("links", [])
+        if not (l.get("rel") == "license"
+                and "creativecommons.org" in l.get("href", ""))
+    ]
+
+    have = {l.get("href") for l in links if l.get("rel") == "child"}
+    for name, cfg in DATASETS.items():
+        href = f"{BASE}/{name}/stac-collection.json"
+        if href not in have:
+            links.append({"rel": "child", "href": href, "type": "application/json",
+                          "title": cfg["title"]})
+    doc["links"] = links
+
+    # widen the temporal interval to cover the 2023 hazard vintage if needed
+    extent = doc.setdefault("extent", {}).setdefault("temporal", {})
+    interval = extent.get("interval") or [[None, None]]
+    start, end = interval[0][0], interval[0][1]
+    if end and end < "2023-12-31T23:59:59Z":
+        interval[0][1] = "2023-12-31T23:59:59Z"
+        extent["interval"] = interval
+
+    kw = doc.setdefault("keywords", [])
+    for k in ("wildfire hazard potential", "WHP", "fuels", "H3"):
+        if k not in kw:
+            kw.append(k)
+
+    return doc
+
+
+WHP_README_SECTION = f"""
+## Wildfire Hazard Potential 2023 (`whp-2023-*`) — modelled hazard, not perimeters
+
+Four collections, because the source classifies each geographic domain against its own
+distribution of the continuous index. **The class breaks are different numbers in CONUS and
+Alaska** — a CONUS "Very High" is index > 1,985, an Alaska "Very High" is > 8,912, 4.5× apart —
+so a pooled `GROUP BY class` across domains is meaningless arithmetic.
+
+| Collection | Native H3 | Reducer | Column |
+|---|---|---|---|
+| [`whp-2023-classified-conus`]({BASE}/whp-2023-classified-conus/stac-collection.json) | 9 (parents 8, 0) | `mode` | `whp_class` |
+| [`whp-2023-classified-ak`]({BASE}/whp-2023-classified-ak/stac-collection.json) | 9 (parents 8, 0) | `mode` | `whp_class` |
+| [`whp-2023-continuous-conus`]({BASE}/whp-2023-continuous-conus/stac-collection.json) | 8 (parent 0) | `mean` | `whp_index` |
+| [`whp-2023-continuous-ak`]({BASE}/whp-2023-continuous-ak/stac-collection.json) | 8 (parent 0) | `mean` | `whp_index` |
+
+Classes: {CLASS_LIST}. Classes 6 and 7 are the absence of burnable fuel, not hazard levels.
+
+**Hazard is not risk.** WHP describes how likely and intense fire is given fuels, topography and
+weather. It says nothing about what is exposed to loss. A remote wilderness ridge can be Very
+High with nothing at stake; a subdivision can be Moderate and still top a risk ranking.
+
+**For any CONUS-vs-Alaska comparison use the continuous collections** — the raw index means the
+same thing everywhere.
+
+### DuckDB
+
+```sql
+INSTALL httpfs; LOAD httpfs;
+
+-- high + very high share of CONUS, by H3 cell area (cells are near-equal-area)
+SELECT ROUND(100.0 * COUNT(*) FILTER (WHERE whp_class IN (4,5)) / COUNT(*), 2) AS pct_high
+FROM read_parquet('{BASE}/whp-2023-classified-conus/hex/h0=*/data_0.parquet');
+-- 12.47
+
+-- hazard inside inventoried roadless areas: join on the shared h8 key
+SELECT w.whp_class, COUNT(DISTINCT w.h8) AS cells
+FROM read_parquet('{BASE}/whp-2023-classified-conus/hex/h0=*/data_0.parquet') w
+JOIN (SELECT DISTINCT h8 FROM read_parquet(
+        'https://s3-west.nrp-nautilus.io/public-usfs/roadless-areas-2001/hex/h0=*/data_0.parquet')) r
+  USING (h8)
+GROUP BY w.whp_class ORDER BY w.whp_class;
+```
+
+⚠️ Area statistics belong on the hex asset, not the COG. The COG is geographic and therefore not
+equal-area — counting its pixels is not an area measurement. The source Albers grid is the area
+truth, and the hex reproduces its class shares to within 0.6 percentage points.
+"""
+
+
+def patch_readme():
+    """Fetch the published bucket README and add the WHP section.
+
+    Two of the intro's claims stop being true once a modelled hazard raster lives in the
+    bucket: that it holds fire *perimeter* datasets, and that all datasets are polygon
+    geometries. Both are rewritten; the per-dataset sections are left untouched.
+    """
+    with urllib.request.urlopen(f"{BASE}/README.md", timeout=60) as r:
+        text = r.read().decode("utf-8")
+
+    old_intro = "This bucket contains CAL FIRE and USGS fire perimeter datasets:"
+    new_intro = (
+        "This bucket contains two kinds of wildfire layer. **Fire perimeters** record where fire "
+        "has burned. **Wildfire Hazard Potential** is a modelled surface describing where fire is "
+        "likely to burn and how intensely — not an observation, and not a map of risk to people "
+        "or property.\n\nContents:"
+    )
+    assert old_intro in text, "README intro anchor not found"
+    text = text.replace(old_intro, new_intro)
+
+    old_all = ("All datasets are polygon geometries processed into GeoParquet, PMTiles, and H3 "
+               "hex Parquet (resolution 10).")
+    new_all = ("The perimeter datasets are polygon geometries processed into GeoParquet, PMTiles "
+               "and H3 hex Parquet (resolution 10). Wildfire Hazard Potential is raster, "
+               "published as a WGS84 COG plus H3 hex Parquet (resolution 9 classified, 8 "
+               "continuous).")
+    assert old_all in text, "README 'all datasets' anchor not found"
+    text = text.replace(old_all, new_all)
+
+    perimeter_bullet = ("- **USGS Wildland Fire Combined Dataset** — National wildfire perimeters "
+                        "1878\u20132021 (`usgs-fires-2021/combined`)")
+    assert perimeter_bullet in text, "README bullet anchor not found"
+    text = text.replace(
+        perimeter_bullet,
+        perimeter_bullet + "\n- **Wildfire Hazard Potential 2023** \u2014 modelled 270 m hazard "
+        "surface, CONUS and Alaska, classified and continuous (`whp-2023-*`)",
+    )
+
+    # WHP section immediately before the Citation section
+    assert "\n## Citation\n" in text, "README citation anchor not found"
+    text = text.replace("\n## Citation\n", WHP_README_SECTION + "\n---\n\n## Citation\n", 1)
+
+    text = text.rstrip("\n") + (
+        "\n\n**Wildfire Hazard Potential:**\n"
+        "Dillon, G.K. 2023. Wildfire Hazard Potential for the United States (270-m), version "
+        "2023, 4th Edition. Fort Collins, CO: Forest Service Research Data Archive. "
+        "https://doi.org/10.2737/RDS-2015-0047-4\n"
+    )
+    return text
+
+
+if __name__ == "__main__":
+    written = []
+    for name, cfg in DATASETS.items():
+        path = f"/tmp/{name}-stac.json"
+        with open(path, "w") as f:
+            json.dump(dataset_collection(name, cfg), f, indent=2)
+            f.write("\n")
+        written.append(path)
+
+    with open("/tmp/fire-bucket-stac.json", "w") as f:
+        json.dump(patch_bucket_collection(), f, indent=2)
+        f.write("\n")
+    written.append("/tmp/fire-bucket-stac.json")
+
+    with open("/tmp/fire-README.md", "w") as f:
+        f.write(patch_readme())
+    written.append("/tmp/fire-README.md")
+
+    print("wrote:")
+    for p in written:
+        print(" ", p)

--- a/catalog/fire/k8s/whp-2023/make-cogs.yaml
+++ b/catalog/fire/k8s/whp-2023/make-cogs.yaml
@@ -1,0 +1,185 @@
+# Reproject the four WHP 2023 source rasters to EPSG:4326 COGs on NRP S3.
+#
+# ⛔ THIS STEP IS NOT OPTIONAL, and `cng-datasets raster-workflow` does not generate it for a
+# single --source-url. Hexing the raw source directly SILENTLY PRODUCES ZERO ROWS: the H3 cell
+# polygons are handed to exactextract in degrees against a raster in Albers metres, so they land
+# within ~100 m of the projection origin -- EPSG:5070 (0,0) is lon -96, lat 23, in the Gulf of
+# Mexico -- and every cell reads nodata. Measured: h0 index 50 built 40,353,607 res-9 cells and
+# reported "no cells produced values (all nodata)" while the Job exited 0.
+#
+# The tool prints "Input raster is in a projected CRS ... It will be reprojected to EPSG:4326
+# during processing. For best results, reproject first" -- the advice is correct; the promised
+# internal reprojection does not reach the exactextract call.
+#
+# Resampling is NEAREST for both products. Classified WHP is categorical (codes 1-7) so anything
+# else invents classes that do not exist; the continuous index is kept nearest too, so the COG
+# stays a faithful resample of the source rather than a smoothed derivative.
+#
+# Alaska crosses the antimeridian: its true span is 87 deg but a naive warp to EPSG:4326 yields a
+# 359.9-deg-wide raster (~148,000 x 30,000 px, almost all nodata) sitting on the dateline seam. It
+# is therefore clipped to -180..-129 with -te. That drops the far-western Aleutians (roughly
+# 157E..180) which contain NO National Forest System land -- the Alaska USFS units are the Tongass
+# and Chugach, far to the east -- so nothing relevant to this issue is lost. Recorded in STAC.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-make-cogs
+  namespace: geo-workflows
+  labels:
+    k8s-app: whp-2023-make-cogs
+spec:
+  completions: 4
+  parallelism: 4
+  completionMode: Indexed
+  backoffLimitPerIndex: 2
+  maxFailedIndexes: 0
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-make-cogs
+    spec:
+      restartPolicy: Never
+      # ClusterFirst is required: rclone's nrp: remote resolves the INTERNAL endpoint
+      # rook-ceph-rgw-nautiluss3.rook, which only cluster DNS can resolve.
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: make-cog
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+
+          SRC=(whp2023_cls_conus whp2023_cls_ak whp2023_cnt_conus whp2023_cnt_ak)
+          OUT=(whp-2023-classified-conus whp-2023-classified-ak whp-2023-continuous-conus whp-2023-continuous-ak)
+          NODATA=(255 255 2147483647 2147483647)
+          # Alaska is clipped to the eastern side of the antimeridian; CONUS needs no clip.
+          TE=("" "-te -180 48.8 -129.0 71.6" "" "-te -180 48.8 -129.0 71.6")
+
+          i=${JOB_COMPLETION_INDEX}
+          s=${SRC[$i]}; o=${OUT[$i]}; nd=${NODATA[$i]}; te=${TE[$i]}
+          echo "=== [$i] $s -> $o-cog.tif  (nodata $nd) ${te:+clip: $te} ==="
+
+          rclone copyto "nrp:public-fire/raw/whp-2023/unpacked/Data/whp2023_GeoTIF/${s}.tif" "/tmp/${s}.tif" -P
+          ls -la "/tmp/${s}.tif"
+
+          echo "--- source CRS / size ---"
+          gdalinfo "/tmp/${s}.tif" | grep -E '^Size is|ID\["EPSG|Pixel Size|NoData'
+
+          # Warp to EPSG:4326. Let gdalwarp pick the output pixel size (it preserves the source
+          # ground resolution near the centre of the extent) rather than hardcoding a degree value,
+          # which would silently rescale.
+          gdalwarp \
+            -t_srs EPSG:4326 \
+            -r near \
+            -srcnodata "$nd" -dstnodata "$nd" \
+            $te \
+            -multi -wo NUM_THREADS=ALL_CPUS \
+            -co COMPRESS=DEFLATE -co PREDICTOR=2 -co BIGTIFF=YES \
+            -co TILED=YES -co BLOCKXSIZE=512 -co BLOCKYSIZE=512 \
+            "/tmp/${s}.tif" "/tmp/${o}-warp.tif"
+
+          echo "--- warped ---"
+          gdalinfo "/tmp/${o}-warp.tif" | grep -E '^Size is|Pixel Size|NoData|Corner|Upper Left|Lower Right'
+
+          # COG-ify (overviews + proper layout)
+          gdal_translate "/tmp/${o}-warp.tif" "/tmp/${o}-cog.tif" \
+            -of COG \
+            -co COMPRESS=DEFLATE -co PREDICTOR=2 -co BIGTIFF=YES \
+            -co OVERVIEW_RESAMPLING=NEAREST -co BLOCKSIZE=512
+          rm -f "/tmp/${o}-warp.tif"
+
+          echo "--- final COG ---"
+          gdalinfo "/tmp/${o}-cog.tif" | grep -E '^Size is|Pixel Size|NoData|Overviews|Block'
+          ls -la "/tmp/${o}-cog.tif"
+
+          # Sanity gate: the COG must not be empty. A published all-nodata "total" COG is a real
+          # failure mode, and it is exactly what the raw-source hex produced.
+          python3 - "$o" <<'PY'
+          import sys
+          import numpy as np
+          from osgeo import gdal
+          gdal.UseExceptions()
+          o = sys.argv[1]
+          ds = gdal.Open(f'/tmp/{o}-cog.tif')
+          b = ds.GetRasterBand(1)
+          nd = b.GetNoDataValue()
+          valid = 0
+          rows = 4096
+          counts = {}
+          for y in range(0, ds.RasterYSize, rows):
+              h = min(rows, ds.RasterYSize - y)
+              a = b.ReadAsArray(0, y, ds.RasterXSize, h)
+              m = a[a != nd]
+              valid += m.size
+              if 'cls' in o or 'classified' in o:
+                  v, c = np.unique(m, return_counts=True)
+                  for vi, ci in zip(v.tolist(), c.tolist()):
+                      counts[vi] = counts.get(vi, 0) + ci
+          print(f'  valid (non-nodata) pixels: {valid:,}')
+          if counts:
+              tot = sum(counts.values())
+              for vi in sorted(counts):
+                  print(f'    code {vi}: {counts[vi]:,} ({100*counts[vi]/tot:.3f}%)')
+          if valid == 0:
+              print('FATAL: COG is entirely nodata')
+              sys.exit(1)
+          PY
+
+          echo "--- uploading ---"
+          rclone copyto "/tmp/${o}-cog.tif" "nrp:public-fire/${o}-cog.tif" -P --transfers 4
+          rclone size "nrp:public-fire/${o}-cog.tif"
+          echo "DONE $o"
+        resources:
+          requests:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '8'
+            memory: 32Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/fire/k8s/whp-2023/whp-2023-stage-raw.yaml
+++ b/catalog/fire/k8s/whp-2023/whp-2023-stage-raw.yaml
@@ -1,0 +1,205 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: whp-2023-stage-raw
+  namespace: geo-workflows
+  labels:
+    k8s-app: whp-2023-stage-raw
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: whp-2023-stage-raw
+    spec:
+      restartPolicy: Never
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+        - 1.1.1.1
+      dnsPolicy: None
+      containers:
+      - name: stage-raw
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          URL='https://www.fs.usda.gov/rds/archive/products/RDS-2015-0047-4/RDS-2015-0047-4_Data.zip'
+          echo "=== Downloading WHP 2023 v4 data archive (expect 368,424,961 bytes) ==="
+          curl -L --retry 8 --retry-all-errors --no-progress-meter -o /tmp/whp2023.zip "$URL"
+          ls -la /tmp/whp2023.zip
+
+          # The RDS archive soft-200s on invalid publication ids: it returns HTTP 200 with an
+          # "Invalid publication id" HTML body. Never trust the status code -- check the bytes.
+          # (`file` is not installed in this image; test the zip magic bytes directly instead.)
+          echo "=== Verifying this is a real zip, not a soft-200 error page ==="
+          MAGIC=$(head -c 2 /tmp/whp2023.zip)
+          if [ "$MAGIC" != "PK" ]; then
+            echo "FATAL: download is not a zip archive (magic '$MAGIC'). First 400 bytes:"
+            head -c 400 /tmp/whp2023.zip
+            exit 1
+          fi
+          unzip -t /tmp/whp2023.zip > /dev/null && echo "zip integrity OK"
+
+          echo "=== Archive listing ==="
+          unzip -l /tmp/whp2023.zip
+
+          echo "=== Unzipping ==="
+          mkdir -p /tmp/whp && cd /tmp/whp
+          unzip -q -o /tmp/whp2023.zip
+          find /tmp/whp -maxdepth 3 \( -name '*.tif' -o -name '*.gdb' -type d \) | sort
+
+          echo
+          echo "=== Uploading raw archive + rasters to s3://public-fire/raw/whp-2023/ ==="
+          rclone copy /tmp/whp2023.zip nrp:public-fire/raw/whp-2023/ -P --transfers 4
+          rclone copy /tmp/whp nrp:public-fire/raw/whp-2023/unpacked/ -P --transfers 8 --checkers 8
+          echo "=== verify upload ==="
+          rclone size nrp:public-fire/raw/whp-2023/
+          rclone lsf nrp:public-fire/raw/whp-2023/unpacked/ --recursive | head -40
+          echo "RAW STAGED -- pre-flight analysis follows; a failure below does not lose the staging"
+
+          echo
+          set +e   # diagnostics from here down; raw is already staged
+          echo "############ PRE-FLIGHT ############"
+          # Everything below is the pre-flight the raster-hexing skill requires BEFORE choosing
+          # resolution / reducer / nodata: real pixel size, real CRS, real nodata, and -- for the
+          # classified product -- the exact code set, which is what the non-burnable-denominator
+          # question turns on.
+          for f in $(find /tmp/whp -name 'whp2023_*.tif' | sort); do
+            echo
+            echo "=================================================================="
+            echo "### $f"
+            echo "=================================================================="
+            gdalinfo "$f" | sed -n '1,60p'
+          done
+
+          echo
+          echo "############ CLASSIFIED CODE HISTOGRAM (exact counts) ############"
+          # gdalinfo -hist buckets; we want exact per-value pixel counts so the non-burnable
+          # codes can be identified and documented rather than guessed.
+          python3 - <<'PY'
+          import glob
+          import numpy as np
+          from osgeo import gdal
+          gdal.UseExceptions()
+
+          for path in sorted(glob.glob('/tmp/whp/**/whp2023_cls_*.tif', recursive=True)):
+              ds = gdal.Open(path)
+              b = ds.GetRasterBand(1)
+              print()
+              print('=' * 70)
+              print(path)
+              print('  size      :', ds.RasterXSize, 'x', ds.RasterYSize)
+              print('  dtype     :', gdal.GetDataTypeName(b.DataType))
+              print('  nodata    :', b.GetNoDataValue())
+              gt = ds.GetGeoTransform()
+              print('  pixel size:', gt[1], gt[5])
+              print('  origin    :', gt[0], gt[3])
+              # exact value counts, block-wise so memory stays bounded
+              counts = {}
+              rows = 2048
+              for y in range(0, ds.RasterYSize, rows):
+                  h = min(rows, ds.RasterYSize - y)
+                  a = b.ReadAsArray(0, y, ds.RasterXSize, h)
+                  v, c = np.unique(a, return_counts=True)
+                  for vi, ci in zip(v.tolist(), c.tolist()):
+                      counts[vi] = counts.get(vi, 0) + ci
+              total = sum(counts.values())
+              print('  distinct values:', len(counts))
+              print('  %-8s %14s %9s' % ('value', 'pixels', 'share'))
+              for vi in sorted(counts):
+                  print('  %-8s %14d %8.4f%%' % (vi, counts[vi], 100.0 * counts[vi] / total))
+              # category names, if the source ships a RAT or category list
+              cats = b.GetCategoryNames()
+              if cats:
+                  print('  GDAL category names:')
+                  for i, name in enumerate(cats):
+                      if name:
+                          print('    %s = %s' % (i, name))
+              rat = b.GetDefaultRAT()
+              if rat is not None:
+                  print('  RAT: %d rows x %d cols' % (rat.GetRowCount(), rat.GetColumnCount()))
+                  hdr = [rat.GetNameOfCol(c) for c in range(rat.GetColumnCount())]
+                  print('   ', hdr)
+                  for r in range(min(rat.GetRowCount(), 30)):
+                      row = []
+                      for c in range(rat.GetColumnCount()):
+                          if rat.GetTypeOfCol(c) == gdal.GFT_String:
+                              row.append(rat.GetValueAsString(r, c))
+                          elif rat.GetTypeOfCol(c) == gdal.GFT_Real:
+                              row.append(rat.GetValueAsDouble(r, c))
+                          else:
+                              row.append(rat.GetValueAsInt(r, c))
+                      print('   ', row)
+              ds = None
+          PY
+
+          echo
+          echo "############ CONTINUOUS STATS ############"
+          for f in $(find /tmp/whp -name 'whp2023_cnt_*.tif' | sort); do
+            echo "### $f"
+            gdalinfo -stats "$f" | grep -E 'Minimum|Maximum|Mean|StdDev|NoData|Pixel Size|Size is|Type='
+          done
+
+          echo
+          echo "############ Metadata / supplement docs shipped in the archive ############"
+          find /tmp/whp -maxdepth 4 -type f \( -name '*.pdf' -o -name '*.txt' -o -name '*.xml' -o -name '*.html' -o -name '*.csv' \) | sort | head -40
+
+          echo "ALL DONE"
+        resources:
+          requests:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 45Gi
+          limits:
+            cpu: '4'
+            memory: 16Gi
+            ephemeral-storage: 45Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'
+              # Known-bad egress/S3 hosts: pods schedule but hang on download/localize.
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - hpc-nrp-g1.nmsu.edu
+                - service-02.nrp.mghpcc.org

--- a/catalog/fire/k8s/whp-2023/whp-2023-stage-raw.yaml
+++ b/catalog/fire/k8s/whp-2023/whp-2023-stage-raw.yaml
@@ -16,11 +16,11 @@ spec:
         k8s-app: whp-2023-stage-raw
     spec:
       restartPolicy: Never
+      dnsPolicy: ClusterFirst
       dnsConfig:
         nameservers:
         - 8.8.8.8
         - 1.1.1.1
-      dnsPolicy: None
       containers:
       - name: stage-raw
         image: ghcr.io/boettiger-lab/datasets:latest


### PR DESCRIPTION
Closes #586. Third dataset in the `roadless` set (#594), after #584 (#596) and #589 (#602).

## What this PR finishes

The classified pair was built and published on 2026-08-20. **The two continuous datasets had never written** — `whp-2023-continuous-{conus,ak}/` did not exist in the bucket at all, and the jobs were already gone from the cluster because the hex manifests carry `ttlSecondsAfterFinished: 10800`. Job absence proves nothing either way, since TTL reaps successes and failures alike; output-side verification was the only durable check. Both are now built.

| Collection | Native H3 | Reducer | Rows | h0 | Gate |
|---|---|---|---:|---:|---|
| `whp-2023-classified-conus` | 9 (parents 8, 0) | `mode` | 74,428,571 | 6 | PASS |
| `whp-2023-classified-ak` | 9 (parents 8, 0) | `mode` | 16,540,214 | 3 | PASS |
| `whp-2023-continuous-conus` | 8 (parent 0) | `mean` | 10,641,399 | 6 | PASS |
| `whp-2023-continuous-ak` | 8 (parent 0) | `mean` | 2,369,388 | 3 | PASS |

Both continuous jobs `Complete=True`, 122/122, `failedIndexes: []`, no OOM at 64Gi. Rows == `COUNT(DISTINCT h8)` exactly on both, zero nulls, zero nodata leak.

## Why four collections and not one mosaic

**The WHP classification is domain-relative.** Dillon (2023) classifies each domain against its own distribution of the continuous index, so the breaks are different numbers:

| Class | CONUS | Alaska |
|---|---|---|
| 4 High | 490–1,985 | 2,923–8,912 |
| 5 Very High | > 1,985 | > 8,912 |

An Alaska "Very High" and a CONUS "Very High" are **4.5× apart** in underlying index. A single mosaicked classified layer would silently invite a pooled `GROUP BY class` across two incompatible scales — exactly the arithmetic that produces a wrong headline number. Publishing the domains separately makes that mistake impossible to make by accident, and all four carry `h8`, so they still join to each other and to `roadless-areas-2001` cell for cell.

The continuous collections are the **cross-domain-comparable** ones; the STAC says so on every collection.

## Validation

**Against the equal-area source, not the COG.** The source Albers grid is equal-area; the WGS84 COG is not, so counting COG pixels is not an area measurement. H3 cells are near-equal-area, and the hex reproduces the source's class shares to within **0.6 pp on every class in both domains** — class 4+5 within **+0.32 pp** (CONUS) and **−0.11 pp** (AK). Not zero, so BUILD.md caps quoted precision at a tenth of a point and says anything needing exact agency agreement should be computed from the source Albers grid.

**Cross-product agreement — the check worth trusting most.** Classified and continuous are built from different source rasters. Joined on `h8`, the mean continuous index per classified class is strictly monotonic (58 → 196.7 → 446.7 → 1,222.4 → 7,641.1) with non-burnable at 150.8 and water at 59. Classes 3, 4, 5 all land inside their published break ranges.

`verify-stac.py` PASS with data checks on all four dataset collections and on the bucket collection.

## Things worth a reviewer's attention

**🔴 The Alaska finding reverses what #586 originally implied.** I had suggested the agency declined to use available Alaska data. The published `WHP2023_ManagementJurisdiction_Summary.xlsx` settles it: comparing the `CONUS` and `all_50_states` sheets for USFS land, **Alaska and Hawaii add 21.6M acres and exactly zero acres of High or Very High WHP.** Alaska USFS = 21,591,094 acres, 0 high+very-high — physically sensible, since USFS land there is Tongass/Chugach coastal temperate rainforest, at the bottom of the *Alaska* distribution. DEIS Table 22 is therefore **internally consistent**. The defensible criticism is narrower: labelling the Alaska cell **"Not Available"** rather than **"0"** obscures that Alaska's ~12.2M IRA acres are pure denominator, and that dropping them is what lifts 28.7% to 41.8%. The data existed; the entry was mislabelled.

**Two `verify-stac.py` findings were real and are fixed.** The `whp_class` column needed an inline `CODE=Definition` list, not just `classification:classes`. And the AK `bbox` I first took from the gdalwarp clip box reached **2.4° south of any Alaska data** — the gate flagged it (#528) and every collection now declares the *measured* footprint of populated cells instead.

**Class labels are transcribed, not remembered** (#294) — read from the source value attribute tables (`class_desc`). **The source ships no color table** on either the GeoTIFFs or the file geodatabase, so no palette is asserted; `classification:classes` carries value and description only. Archive id **RDS-2015-0047-4** comes from the staged source URL rather than memory.

**The COG step is mandatory and its absence fails silently.** Hexing the raw Albers source wrote zero rows and exited 0: EPSG:5070 `(0,0)` is lon −96 / lat 23, so degree-valued H3 cell polygons land in the Gulf of Mexico and every cell reads nodata, while the Job reports `Complete`. Only the h0 coverage gate catches it. This is not a tool defect — `cng-datasets raster` documents a COG input and warned about the projected CRS before proceeding.

## ⚠️ Bucket-level changes, and why they were necessary

Adding a modelled hazard raster to `public-fire` made three published statements false. The bucket collection and README are **patched** — fetched, edited, re-uploaded — not regenerated, so unmodelled fields survive. **All 15 pre-existing assets verified preserved, 0 children removed.** Pre-patch backups taken.

1. **`title`** — "Fire Perimeters: CAL FIRE (2024, 2025) and USGS Combined (2021)" → "Wildfire: hazard potential and fire perimeters".
2. **`license`: `CC-BY-4.0` → `various`**, bucket-level CC-BY license *link* dropped. The perimeter children are CC-BY-4.0; the Forest Service hazard products are public domain. No single bucket term is honest, and leaving the CC-BY link would assert CC-BY over public-domain children. A meta-collection with `child` links may use `various` with no link — the real licenses live on and are gated per child (stac-authoring SKILL.md, `verify-stac.py check_license`).
3. **README intro** — claimed the bucket holds fire *perimeter* datasets and that *all* datasets are polygon geometries. Both rewritten; per-dataset sections untouched.

**`id` deliberately left as `fire-perimeters`** — it no longer describes the bucket well, but it is consumer-visible and renaming it is out of scope here. Worth a follow-up issue.

The bucket's 18 `verify-stac.py` advisories are all pre-existing on CAL FIRE/USGS assets and were not introduced here.

## Note on the coverage gate

Do **not** gate these against `roadless-areas-2001/hex/` as a `--reference` — that layer is national and each WHP collection is one domain, so it is a guaranteed false FAIL. The two classified domains together populate 8 of that layer's 9 h0 partitions; the ninth, `577832942814887935`, is **Puerto Rico** (El Yunque, 8,897 res-10 IRA cells), which WHP CONUS+AK does not cover. Use `--expect-h0` per domain, as BUILD.md documents.

## Stale premise corrected

`setup-bucket` was not run and no registration step exists: `public-fire` already exists and serves anonymously, and the MinIO/backup tier was retired from this repo in #568. The only obligation is a correct SPDX `license`.

## Branch note

The branch was 4 commits behind `main` and its diff showed phantom deletions of merged work (#417 provenance, #579, `verify-stac.py` changes, the guard hooks). Rebased onto current `main` — the diff is now purely additive, 0 deletions.