### PR TITLE
feat(#578): rebuild the three WGFD crucial-range layers into public-wgfd

### DIFF
--- a/catalog/wgfd/gen_stac.py
+++ b/catalog/wgfd/gen_stac.py
@@ -1,0 +1,297 @@
+"""Author the STAC for the three public-wgfd crucial-range collections (#578).
+
+Every value here is MEASURED from the published data (schemas, RANGE value sets, bboxes,
+feature counts, build times, raw sha256) — nothing transcribed from the old public-wyoming
+STAC except the licence fact and the provider identities, which are statements about
+upstream rather than about our build.
+
+One schema is written identically to every asset (the mcp-data-server#303 fold is
+first-seen-wins, so divergent text silently drops a version). Hex-only guidance therefore
+lives in the hex asset DESCRIPTION, never as a per-column clause.
+"""
+import json
+
+NRP = "https://s3-west.nrp-nautilus.io"
+BUCKET = "public-wgfd"
+ROOT = f"{NRP}/public-data/stac/catalog.json"
+PARENT = f"{NRP}/{BUCKET}/stac-collection.json"
+
+TABLE_EXT = "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+SCI_EXT = "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+
+# --- measured -------------------------------------------------------------------------
+D = {
+    "elk-crucial": dict(
+        species="elk", Species="Elk",
+        features=150, h8=28617, cells=1159248,
+        bbox=[-111.049, 40.999, -104.981, 44.988],
+        ranges={"CRUWYL": 91, "CRUWIN": 57, "CRUSWR": 2},
+        acres=(747.09, 592503.3, 4442987),
+        sha256="3d56458f6bf2d6d6bcd1b648c1716cf7188bd40ab2641e85d370172f35b03fd2",
+        raw_bytes=2324827,
+        built={"parquet": "2026-08-21T23:29:26Z", "pmtiles": "2026-08-21T23:29:37Z",
+               "hex": "2026-08-21T23:31:13Z"},
+        partitions=2,
+    ),
+    "mule-deer-crucial": dict(
+        species="mule deer", Species="Mule deer",
+        features=145, h8=40955, cells=None,
+        bbox=[-111.048, 40.996, -104.056, 45.0],
+        ranges={"CRUWYL": 116, "CRUWIN": 29},
+        acres=(231.46, 1352702.2, 6431769),
+        sha256="e464111b26c949cfd81e060ab9ddea0b98fb303b9f154dd99ca0c1474b2ce81b",
+        raw_bytes=2619807,
+        built={"parquet": "2026-08-21T23:32:13Z", "pmtiles": "2026-08-21T23:32:26Z",
+               "hex": "2026-08-21T23:33:52Z"},
+        partitions=1,
+    ),
+    "pronghorn-crucial": dict(
+        species="pronghorn", Species="Pronghorn",
+        features=105, h8=36879, cells=None,
+        bbox=[-111.047, 40.998, -104.305, 44.857],
+        ranges={"CRUWYL": 101, "CRUSWR": 3, "CRUWIN": 1},
+        acres=(730.41, 1327564.2, 5972722),
+        sha256="16f9a3dcb61a48ca315072615c1f4cdf4ce5da8701582fdb5a8f16576d848350",
+        raw_bytes=3110805,
+        built={"parquet": "2026-08-21T23:34:54Z", "pmtiles": "2026-08-21T23:35:08Z",
+               "hex": "2026-08-21T23:36:21Z"},
+        partitions=1,
+    ),
+}
+
+# WGFD seasonal-range terminology. CRU = crucial; the suffix is the seasonal type.
+RANGE_DEFS = {
+    "CRUWIN": "crucial winter range",
+    "CRUWYL": "crucial winter/yearlong range",
+    "CRUSWR": "crucial severe winter relief range",
+    "CRUSSF": "crucial spring/summer/fall range",
+    "CRUYRL": "crucial yearlong range",
+    "CRUOUT": "crucial range outside other seasonal types",
+}
+
+ACCESS_DATE = "2026-02-25"   # when the source GeoJSON was pulled from the WGFD ArcGIS Hub
+
+
+def col_defs(ds):
+    d = D[ds]
+    present = sorted(d["ranges"], key=lambda c: -d["ranges"][c])
+    listed = ", ".join(f"{c}={RANGE_DEFS[c]}" for c in present)
+    return {
+        "_cng_fid": ("int64",
+            "Identifier assigned to every polygon during conversion, unique within this "
+            "dataset. Count features or remove repeated rows with COUNT(DISTINCT _cng_fid)."),
+        "OGC_FID": ("int64",
+            "Sequential record number carried over from the source GeoJSON export."),
+        "OBJECTID": ("int32",
+            "Feature identifier assigned by the Wyoming Game & Fish Department in the "
+            "published layer. Unique for every polygon in this dataset."),
+        "RANGE": ("string",
+            "Seasonal range designation. Every polygon here is crucial range, so each code "
+            f"combines the crucial prefix CRU with the seasonal type. Values: {listed}."),
+        "Acres": ("double",
+            "Area of the range polygon in acres, as published by the Wyoming Game & Fish "
+            "Department."),
+        "SQMiles": ("double",
+            "Area of the range polygon in square miles, as published by the Wyoming Game & "
+            "Fish Department."),
+        "geom": ("geometry", "Polygon geometry of the range, in EPSG:4326."),
+        "h10": ("uint64",
+            "H3 cell identifier at resolution 10, the native resolution of this hex table."),
+        "h9": ("uint64", "H3 cell identifier at resolution 9."),
+        "h8": ("uint64",
+            "H3 cell identifier at resolution 8, the resolution shared across this catalog "
+            "for joining datasets to one another."),
+        "h0": ("int64",
+            "H3 cell identifier at resolution 0, used as the partition key for "
+            "hive-partitioned reads."),
+    }
+
+
+FLAT_COLS = ["_cng_fid", "OGC_FID", "OBJECTID", "RANGE", "Acres", "SQMiles", "geom"]
+HEX_COLS = ["_cng_fid", "OGC_FID", "OBJECTID", "RANGE", "Acres", "SQMiles",
+            "h10", "h9", "h8", "h0"]
+PMT_COLS = ["_cng_fid", "OGC_FID", "OBJECTID", "RANGE", "Acres", "SQMiles"]
+
+
+def columns(ds, names, lean=False):
+    defs = col_defs(ds)
+    present = sorted(D[ds]["ranges"], key=lambda c: -D[ds]["ranges"][c])
+    out = []
+    for n in names:
+        t, desc = defs[n]
+        c = {"name": n, "type": t}
+        if not lean:
+            c["description"] = desc
+        if n == "RANGE":
+            c["values"] = present
+        out.append(c)
+    return out
+
+
+def collection(ds):
+    d = D[ds]
+    sp, Sp = d["species"], d["Species"]
+    lo, hi, total = d["acres"]
+    present = sorted(d["ranges"], key=lambda c: -d["ranges"][c])
+    breakdown = ", ".join(f"{c} ({d['ranges'][c]})" for c in present)
+
+    description = (
+        f"Crucial seasonal habitat range for {sp} in Wyoming, mapped by the Wyoming Game & "
+        f"Fish Department. Crucial ranges are the seasonal habitats the department identifies "
+        f"as a determining factor in the population's ability to sustain itself, so they carry "
+        f"more management weight than ordinary seasonal range. This dataset holds "
+        f"{d['features']:,} polygons covering about {total:,.0f} acres, broken down by range "
+        f"type as {breakdown}.\n\n"
+        f"Coverage is the state of Wyoming. That is the full extent of the source: the Wyoming "
+        f"Game & Fish Department maps range within its own jurisdiction, so this is a complete "
+        f"dataset rather than a regional excerpt of something larger.\n\n"
+        f"The department publishes crucial range as a separate layer from full {sp} seasonal "
+        f"range, and every polygon here is crucial, which is why each RANGE code begins with "
+        f"CRU."
+    )
+
+    citation = (
+        f"Wyoming Game & Fish Department, {Sp} Crucial Range. Accessed {ACCESS_DATE} from the "
+        f"WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com). The department publishes through "
+        f"an ArcGIS Hub endpoint with no stable versioned download URL, so the retained source "
+        f"is the anchor: s3://{BUCKET}/raw/{ds}.geojson, {d['raw_bytes']:,} bytes, SHA-256 "
+        f"{d['sha256']}. Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, "
+        f"UC Berkeley."
+    )
+
+    hex_desc = (
+        f"{Sp} crucial range as H3 cells at resolution 10, with resolution 9, 8 and 0 "
+        f"identifiers alongside for rolling up or joining to other datasets. There is one row "
+        f"for each combination of a range polygon and a cell it covers, so a polygon that spans "
+        f"many cells appears on many rows, and the per-polygon values Acres and SQMiles are "
+        f"repeated on every one of its cells. Reduce to one row per polygon before totalling "
+        f"either of them:\n\n"
+        f"SELECT SUM(Acres) FROM (SELECT DISTINCT _cng_fid, Acres FROM …)\n\n"
+        f"For the ground area of a set of cells, aggregate the cell areas over distinct cells "
+        f"rather than these published columns. Covers {d['h8']:,} resolution 8 cells across "
+        f"{d['partitions']} resolution 0 partition"
+        f"{'s' if d['partitions'] != 1 else ''}."
+    )
+
+    assets = {
+        f"{ds}-parquet": {
+            "href": f"{NRP}/{BUCKET}/{ds}.parquet",
+            "type": "application/x-parquet",
+            "roles": ["data"],
+            "title": f"{Sp} crucial range — GeoParquet",
+            "created": d["built"]["parquet"],
+            "description": (
+                f"{Sp} crucial range polygons as GeoParquet, one row per polygon, in EPSG:4326. "
+                f"Query directly with DuckDB over HTTP."),
+            "table:columns": columns(ds, FLAT_COLS),
+        },
+        f"{ds}-pmtiles": {
+            "href": f"{NRP}/{BUCKET}/{ds}.pmtiles",
+            "type": "application/vnd.pmtiles",
+            "roles": ["visual"],
+            "title": f"{Sp} crucial range — PMTiles",
+            "created": d["built"]["pmtiles"],
+            "description": (
+                f"Vector tiles for web maps. In MapLibre GL JS the source layer is "
+                f"\"{ds}\"; style or filter on RANGE to separate the crucial range types."),
+            "vector:layers": [ds],
+            "table:columns": columns(ds, PMT_COLS, lean=True),
+        },
+        f"{ds}-hex": {
+            "href": f"{NRP}/{BUCKET}/{ds}/hex/h0=*/data_0.parquet",
+            "type": "application/x-parquet",
+            "roles": ["data"],
+            "title": f"{Sp} crucial range — H3 resolution 10",
+            "created": d["built"]["hex"],
+            "description": hex_desc,
+            "h3:native_resolution": 10,
+            "h3:parent_resolutions": [9, 8, 0],
+            "table:columns": columns(ds, HEX_COLS),
+        },
+    }
+
+    return {
+        "type": "Collection",
+        "stac_version": "1.0.0",
+        "stac_extensions": [TABLE_EXT, SCI_EXT],
+        "id": f"wgfd-{ds}",
+        "title": f"{Sp} Crucial Range (Wyoming)",
+        "description": description,
+        "license": "other",
+        "sci:citation": citation,
+        "created": d["built"]["parquet"],
+        "updated": d["built"]["hex"],
+        "keywords": ["Wyoming", sp, "wildlife", "habitat", "crucial range", "seasonal range",
+                     "WGFD", "big game"],
+        "extent": {
+            "spatial": {"bbox": [d["bbox"]]},
+            "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+        },
+        "providers": [
+            {"name": "Wyoming Game & Fish Department", "roles": ["producer", "licensor"],
+             "url": "https://wyoming-wgfd.opendata.arcgis.com/"},
+            {"name": "Boettiger Lab, UC Berkeley", "roles": ["processor", "host"],
+             "url": "https://github.com/boettiger-lab"},
+        ],
+        "links": [
+            {"rel": "self", "href": f"{NRP}/{BUCKET}/{ds}/stac-collection.json",
+             "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": PARENT, "type": "application/json"},
+            {"rel": "license", "href": "https://wgfd.wyo.gov/geospatial-data",
+             "type": "text/html"},
+            {"rel": "about", "href": "https://wyoming-wgfd.opendata.arcgis.com/",
+             "type": "text/html", "title": "WGFD ArcGIS Hub (upstream distribution)"},
+        ],
+        "assets": assets,
+    }
+
+
+def bucket_collection():
+    return {
+        "type": "Collection",
+        "stac_version": "1.0.0",
+        "id": "wgfd",
+        "title": "Wyoming Game & Fish Department (WGFD)",
+        "description": (
+            "Wildlife habitat data published by the Wyoming Game & Fish Department. The "
+            "department maps big-game seasonal ranges and other habitat layers across Wyoming, "
+            "its area of jurisdiction, so these datasets cover the state in full rather than "
+            "being regional excerpts of a national product.\n\n"
+            "Datasets are grouped here by the agency that produces them, which is how they are "
+            "found and cited upstream."),
+        "license": "other",
+        "extent": {
+            "spatial": {"bbox": [[-111.049, 40.996, -104.056, 45.0]]},
+            "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+        },
+        "providers": [
+            {"name": "Wyoming Game & Fish Department", "roles": ["producer", "licensor"],
+             "url": "https://wyoming-wgfd.opendata.arcgis.com/"},
+            {"name": "Boettiger Lab, UC Berkeley", "roles": ["processor", "host"],
+             "url": "https://github.com/boettiger-lab"},
+        ],
+        "links": [
+            {"rel": "self", "href": PARENT, "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": ROOT, "type": "application/json"},
+            {"rel": "license", "href": "https://wgfd.wyo.gov/geospatial-data",
+             "type": "text/html"},
+        ] + [
+            {"rel": "child", "href": f"{NRP}/{BUCKET}/{ds}/stac-collection.json",
+             "type": "application/json", "title": collection(ds)["title"]}
+            for ds in D
+        ],
+    }
+
+
+if __name__ == "__main__":
+    import os
+    out = os.environ.get("OUT", "/tmp/wgfd-stac")
+    os.makedirs(out, exist_ok=True)
+    for ds in D:
+        p = f"{out}/{ds}.json"
+        json.dump(collection(ds), open(p, "w"), indent=2)
+        print("wrote", p)
+    json.dump(bucket_collection(), open(f"{out}/bucket.json", "w"), indent=2)
+    print("wrote", f"{out}/bucket.json")

--- a/catalog/wgfd/k8s/elk-crucial/configmap.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: elk-crucial-setup-bucket.yaml, elk-crucial-convert.yaml, elk-crucial-pmtiles.yaml, elk-crucial-hex.yaml, elk-crucial-repartition.yaml
+# Generation command: cng-datasets workflow --dataset elk-crucial --source-url s3://public-wgfd/raw/elk-crucial.geojson --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap elk-crucial-yamls \
+#     --from-file=elk-crucial-setup-bucket.yaml \
+#     --from-file=elk-crucial-convert.yaml \
+#     --from-file=elk-crucial-pmtiles.yaml \
+#     --from-file=elk-crucial-hex.yaml \
+#     --from-file=elk-crucial-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  elk-crucial-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-crucial-convert
+      labels:
+        k8s-app: elk-crucial-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-crucial-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/elk-crucial.geojson \
+                s3://public-wgfd/elk-crucial.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-crucial-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-crucial-hex
+      labels:
+        k8s-app: elk-crucial-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-crucial-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: elk-crucial
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/elk-crucial.parquet --output s3://public-wgfd/elk-crucial/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-crucial-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-crucial-pmtiles
+      labels:
+        k8s-app: elk-crucial-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-crucial-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: elk-crucial
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-crucial-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-crucial-repartition
+      labels:
+        k8s-app: elk-crucial-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-crucial-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/elk-crucial/chunks --output-dir s3://public-wgfd/elk-crucial/hex --source-parquet s3://public-wgfd/elk-crucial.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-crucial-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-crucial-setup-bucket
+      labels:
+        k8s-app: elk-crucial-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-crucial-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: elk-crucial-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/elk-crucial/elk-crucial-convert.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/elk-crucial-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-crucial-convert
+  labels:
+    k8s-app: elk-crucial-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-crucial-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/elk-crucial.geojson \
+            s3://public-wgfd/elk-crucial.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-crucial/elk-crucial-hex.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/elk-crucial-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-crucial-hex
+  labels:
+    k8s-app: elk-crucial-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-crucial-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: elk-crucial
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/elk-crucial.parquet --output s3://public-wgfd/elk-crucial/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-crucial/elk-crucial-pmtiles.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/elk-crucial-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-crucial-pmtiles
+  labels:
+    k8s-app: elk-crucial-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-crucial-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: elk-crucial
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-crucial/elk-crucial-repartition.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/elk-crucial-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-crucial-repartition
+  labels:
+    k8s-app: elk-crucial-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-crucial-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/elk-crucial/chunks --output-dir s3://public-wgfd/elk-crucial/hex --source-parquet s3://public-wgfd/elk-crucial.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-crucial/elk-crucial-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/elk-crucial-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-crucial-setup-bucket
+  labels:
+    k8s-app: elk-crucial-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-crucial-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-crucial/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/elk-crucial/workflow.yaml
+++ b/catalog/wgfd/k8s/elk-crucial/workflow.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-crucial-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting elk-crucial workflow...\"\n\n# Step 0: Setup\
+          \ bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/elk-crucial-setup-bucket.yaml -n geo-workflows\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/elk-crucial-setup-bucket -n geo-workflows\n\n# Step\
+          \ 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/elk-crucial-convert.yaml -n geo-workflows\n\necho \"Waiting for\
+          \ GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/elk-crucial-convert -n geo-workflows\n\n# Step 2:\
+          \ Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/elk-crucial-pmtiles.yaml -n geo-workflows\nkubectl\
+          \ apply -f /yamls/elk-crucial-hex.yaml -n geo-workflows\n\necho \"Waiting\
+          \ for hex tiling to complete (PMTiles continues in background)...\"\necho\
+          \ \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/elk-crucial-hex -n geo-workflows\n\necho \"Step\
+          \ 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/elk-crucial-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/elk-crucial-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs elk-crucial-setup-bucket elk-crucial-convert\
+          \ elk-crucial-pmtiles elk-crucial-hex elk-crucial-repartition elk-crucial-workflow\
+          \ -n geo-workflows\"\necho \"  kubectl delete configmap elk-crucial-yamls\
+          \ -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: elk-crucial-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/elk-seasonal/configmap.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: elk-seasonal-setup-bucket.yaml, elk-seasonal-convert.yaml, elk-seasonal-pmtiles.yaml, elk-seasonal-hex.yaml, elk-seasonal-repartition.yaml
+# Generation command: cng-datasets workflow --dataset elk-seasonal --source-url s3://public-wgfd/raw/elk-seasonal.geojson --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap elk-seasonal-yamls \
+#     --from-file=elk-seasonal-setup-bucket.yaml \
+#     --from-file=elk-seasonal-convert.yaml \
+#     --from-file=elk-seasonal-pmtiles.yaml \
+#     --from-file=elk-seasonal-hex.yaml \
+#     --from-file=elk-seasonal-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  elk-seasonal-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-seasonal-convert
+      labels:
+        k8s-app: elk-seasonal-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-seasonal-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/elk-seasonal.geojson \
+                s3://public-wgfd/elk-seasonal.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-seasonal-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-seasonal-hex
+      labels:
+        k8s-app: elk-seasonal-hex
+    spec:
+      completions: 1
+      parallelism: 1
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-seasonal-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: elk-seasonal
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/elk-seasonal.parquet --output s3://public-wgfd/elk-seasonal/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-seasonal-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-seasonal-pmtiles
+      labels:
+        k8s-app: elk-seasonal-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-seasonal-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: elk-seasonal
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/elk-seasonal.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-seasonal-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-seasonal-repartition
+      labels:
+        k8s-app: elk-seasonal-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-seasonal-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/elk-seasonal/chunks --output-dir s3://public-wgfd/elk-seasonal/hex --source-parquet s3://public-wgfd/elk-seasonal.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  elk-seasonal-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: elk-seasonal-setup-bucket
+      labels:
+        k8s-app: elk-seasonal-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: elk-seasonal-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: elk-seasonal-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-convert.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-seasonal-convert
+  labels:
+    k8s-app: elk-seasonal-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-seasonal-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/elk-seasonal.geojson \
+            s3://public-wgfd/elk-seasonal.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-hex.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-seasonal-hex
+  labels:
+    k8s-app: elk-seasonal-hex
+spec:
+  completions: 1
+  parallelism: 1
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-seasonal-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: elk-seasonal
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/elk-seasonal.parquet --output s3://public-wgfd/elk-seasonal/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-pmtiles.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-seasonal-pmtiles
+  labels:
+    k8s-app: elk-seasonal-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-seasonal-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: elk-seasonal
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/elk-seasonal.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-repartition.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-seasonal-repartition
+  labels:
+    k8s-app: elk-seasonal-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-seasonal-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/elk-seasonal/chunks --output-dir s3://public-wgfd/elk-seasonal/hex --source-parquet s3://public-wgfd/elk-seasonal.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/elk-seasonal-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-seasonal-setup-bucket
+  labels:
+    k8s-app: elk-seasonal-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: elk-seasonal-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/elk-seasonal/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/elk-seasonal/workflow.yaml
+++ b/catalog/wgfd/k8s/elk-seasonal/workflow.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elk-seasonal-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting elk-seasonal workflow...\"\n\n# Step 0: Setup\
+          \ bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/elk-seasonal-setup-bucket.yaml -n geo-workflows\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/elk-seasonal-setup-bucket -n geo-workflows\n\n# Step\
+          \ 1: Convert to optimized GeoParquet (needed by both pmtiles and hex jobs)\n\
+          echo \"Step 1: Converting to optimized GeoParquet...\"\nkubectl apply -f\
+          \ /yamls/elk-seasonal-convert.yaml -n geo-workflows\n\necho \"Waiting for\
+          \ GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/elk-seasonal-convert -n geo-workflows\n\n# Step 2:\
+          \ Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/elk-seasonal-pmtiles.yaml -n geo-workflows\nkubectl\
+          \ apply -f /yamls/elk-seasonal-hex.yaml -n geo-workflows\n\necho \"Waiting\
+          \ for hex tiling to complete (PMTiles continues in background)...\"\necho\
+          \ \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/elk-seasonal-hex -n geo-workflows\n\necho \"Step\
+          \ 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/elk-seasonal-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/elk-seasonal-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs elk-seasonal-setup-bucket elk-seasonal-convert\
+          \ elk-seasonal-pmtiles elk-seasonal-hex elk-seasonal-repartition elk-seasonal-workflow\
+          \ -n geo-workflows\"\necho \"  kubectl delete configmap elk-seasonal-yamls\
+          \ -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: elk-seasonal-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/mule-deer-crucial/configmap.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: mule-deer-crucial-setup-bucket.yaml, mule-deer-crucial-convert.yaml, mule-deer-crucial-pmtiles.yaml, mule-deer-crucial-hex.yaml, mule-deer-crucial-repartition.yaml
+# Generation command: cng-datasets workflow --dataset mule-deer-crucial --source-url s3://public-wgfd/raw/mule-deer-crucial.geojson --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap mule-deer-crucial-yamls \
+#     --from-file=mule-deer-crucial-setup-bucket.yaml \
+#     --from-file=mule-deer-crucial-convert.yaml \
+#     --from-file=mule-deer-crucial-pmtiles.yaml \
+#     --from-file=mule-deer-crucial-hex.yaml \
+#     --from-file=mule-deer-crucial-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  mule-deer-crucial-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-crucial-convert
+      labels:
+        k8s-app: mule-deer-crucial-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-crucial-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/mule-deer-crucial.geojson \
+                s3://public-wgfd/mule-deer-crucial.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-crucial-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-crucial-hex
+      labels:
+        k8s-app: mule-deer-crucial-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-crucial-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: mule-deer-crucial
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/mule-deer-crucial.parquet --output s3://public-wgfd/mule-deer-crucial/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-crucial-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-crucial-pmtiles
+      labels:
+        k8s-app: mule-deer-crucial-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-crucial-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: mule-deer-crucial
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-crucial-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-crucial-repartition
+      labels:
+        k8s-app: mule-deer-crucial-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-crucial-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/mule-deer-crucial/chunks --output-dir s3://public-wgfd/mule-deer-crucial/hex --source-parquet s3://public-wgfd/mule-deer-crucial.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-crucial-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-crucial-setup-bucket
+      labels:
+        k8s-app: mule-deer-crucial-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-crucial-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mule-deer-crucial-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-convert.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-crucial-convert
+  labels:
+    k8s-app: mule-deer-crucial-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-crucial-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/mule-deer-crucial.geojson \
+            s3://public-wgfd/mule-deer-crucial.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-hex.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-crucial-hex
+  labels:
+    k8s-app: mule-deer-crucial-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-crucial-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: mule-deer-crucial
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/mule-deer-crucial.parquet --output s3://public-wgfd/mule-deer-crucial/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-pmtiles.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-crucial-pmtiles
+  labels:
+    k8s-app: mule-deer-crucial-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-crucial-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: mule-deer-crucial
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-repartition.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-crucial-repartition
+  labels:
+    k8s-app: mule-deer-crucial-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-crucial-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/mule-deer-crucial/chunks --output-dir s3://public-wgfd/mule-deer-crucial/hex --source-parquet s3://public-wgfd/mule-deer-crucial.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/mule-deer-crucial-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-crucial-setup-bucket
+  labels:
+    k8s-app: mule-deer-crucial-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-crucial-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-crucial/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/mule-deer-crucial/workflow.yaml
+++ b/catalog/wgfd/k8s/mule-deer-crucial/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-crucial-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting mule-deer-crucial workflow...\"\n\n# Step 0:\
+          \ Setup bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/mule-deer-crucial-setup-bucket.yaml -n geo-workflows\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/mule-deer-crucial-setup-bucket -n geo-workflows\n\n\
+          # Step 1: Convert to optimized GeoParquet (needed by both pmtiles and hex\
+          \ jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\nkubectl\
+          \ apply -f /yamls/mule-deer-crucial-convert.yaml -n geo-workflows\n\necho\
+          \ \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/mule-deer-crucial-convert -n geo-workflows\n\n# Step\
+          \ 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/mule-deer-crucial-pmtiles.yaml -n geo-workflows\n\
+          kubectl apply -f /yamls/mule-deer-crucial-hex.yaml -n geo-workflows\n\n\
+          echo \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/mule-deer-crucial-hex -n geo-workflows\n\necho \"\
+          Step 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/mule-deer-crucial-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/mule-deer-crucial-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs mule-deer-crucial-setup-bucket\
+          \ mule-deer-crucial-convert mule-deer-crucial-pmtiles mule-deer-crucial-hex\
+          \ mule-deer-crucial-repartition mule-deer-crucial-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap mule-deer-crucial-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mule-deer-crucial-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/mule-deer-seasonal/configmap.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: mule-deer-seasonal-setup-bucket.yaml, mule-deer-seasonal-convert.yaml, mule-deer-seasonal-pmtiles.yaml, mule-deer-seasonal-hex.yaml, mule-deer-seasonal-repartition.yaml
+# Generation command: cng-datasets workflow --dataset mule-deer-seasonal --source-url s3://public-wgfd/raw/mule-deer-seasonal.geojson --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap mule-deer-seasonal-yamls \
+#     --from-file=mule-deer-seasonal-setup-bucket.yaml \
+#     --from-file=mule-deer-seasonal-convert.yaml \
+#     --from-file=mule-deer-seasonal-pmtiles.yaml \
+#     --from-file=mule-deer-seasonal-hex.yaml \
+#     --from-file=mule-deer-seasonal-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  mule-deer-seasonal-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-seasonal-convert
+      labels:
+        k8s-app: mule-deer-seasonal-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-seasonal-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/mule-deer-seasonal.geojson \
+                s3://public-wgfd/mule-deer-seasonal.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-seasonal-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-seasonal-hex
+      labels:
+        k8s-app: mule-deer-seasonal-hex
+    spec:
+      completions: 1
+      parallelism: 1
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-seasonal-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: mule-deer-seasonal
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/mule-deer-seasonal.parquet --output s3://public-wgfd/mule-deer-seasonal/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-seasonal-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-seasonal-pmtiles
+      labels:
+        k8s-app: mule-deer-seasonal-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-seasonal-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: mule-deer-seasonal
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-seasonal.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-seasonal-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-seasonal-repartition
+      labels:
+        k8s-app: mule-deer-seasonal-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-seasonal-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/mule-deer-seasonal/chunks --output-dir s3://public-wgfd/mule-deer-seasonal/hex --source-parquet s3://public-wgfd/mule-deer-seasonal.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  mule-deer-seasonal-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: mule-deer-seasonal-setup-bucket
+      labels:
+        k8s-app: mule-deer-seasonal-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: mule-deer-seasonal-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: mule-deer-seasonal-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-convert.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-seasonal-convert
+  labels:
+    k8s-app: mule-deer-seasonal-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-seasonal-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/mule-deer-seasonal.geojson \
+            s3://public-wgfd/mule-deer-seasonal.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-hex.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-seasonal-hex
+  labels:
+    k8s-app: mule-deer-seasonal-hex
+spec:
+  completions: 1
+  parallelism: 1
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-seasonal-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: mule-deer-seasonal
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/mule-deer-seasonal.parquet --output s3://public-wgfd/mule-deer-seasonal/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-pmtiles.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-seasonal-pmtiles
+  labels:
+    k8s-app: mule-deer-seasonal-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-seasonal-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: mule-deer-seasonal
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-seasonal.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-repartition.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-seasonal-repartition
+  labels:
+    k8s-app: mule-deer-seasonal-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-seasonal-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/mule-deer-seasonal/chunks --output-dir s3://public-wgfd/mule-deer-seasonal/hex --source-parquet s3://public-wgfd/mule-deer-seasonal.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/mule-deer-seasonal-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-seasonal-setup-bucket
+  labels:
+    k8s-app: mule-deer-seasonal-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: mule-deer-seasonal-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/mule-deer-seasonal/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/mule-deer-seasonal/workflow.yaml
+++ b/catalog/wgfd/k8s/mule-deer-seasonal/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mule-deer-seasonal-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting mule-deer-seasonal workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/mule-deer-seasonal-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/mule-deer-seasonal-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/mule-deer-seasonal-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/mule-deer-seasonal-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/mule-deer-seasonal-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/mule-deer-seasonal-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/mule-deer-seasonal-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/mule-deer-seasonal-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/mule-deer-seasonal-repartition -n geo-workflows\n\n\
+          echo \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still be\
+          \ running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs mule-deer-seasonal-setup-bucket mule-deer-seasonal-convert\
+          \ mule-deer-seasonal-pmtiles mule-deer-seasonal-hex mule-deer-seasonal-repartition\
+          \ mule-deer-seasonal-workflow -n geo-workflows\"\necho \"  kubectl delete\
+          \ configmap mule-deer-seasonal-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: mule-deer-seasonal-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/pronghorn-crucial/configmap.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: pronghorn-crucial-setup-bucket.yaml, pronghorn-crucial-convert.yaml, pronghorn-crucial-pmtiles.yaml, pronghorn-crucial-hex.yaml, pronghorn-crucial-repartition.yaml
+# Generation command: cng-datasets workflow --dataset pronghorn-crucial --source-url s3://public-wgfd/raw/pronghorn-crucial.geojson --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap pronghorn-crucial-yamls \
+#     --from-file=pronghorn-crucial-setup-bucket.yaml \
+#     --from-file=pronghorn-crucial-convert.yaml \
+#     --from-file=pronghorn-crucial-pmtiles.yaml \
+#     --from-file=pronghorn-crucial-hex.yaml \
+#     --from-file=pronghorn-crucial-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  pronghorn-crucial-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-crucial-convert
+      labels:
+        k8s-app: pronghorn-crucial-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-crucial-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/pronghorn-crucial.geojson \
+                s3://public-wgfd/pronghorn-crucial.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-crucial-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-crucial-hex
+      labels:
+        k8s-app: pronghorn-crucial-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-crucial-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: pronghorn-crucial
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/pronghorn-crucial.parquet --output s3://public-wgfd/pronghorn-crucial/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-crucial-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-crucial-pmtiles
+      labels:
+        k8s-app: pronghorn-crucial-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-crucial-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: pronghorn-crucial
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-crucial-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-crucial-repartition
+      labels:
+        k8s-app: pronghorn-crucial-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-crucial-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/pronghorn-crucial/chunks --output-dir s3://public-wgfd/pronghorn-crucial/hex --source-parquet s3://public-wgfd/pronghorn-crucial.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-crucial-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-crucial-setup-bucket
+      labels:
+        k8s-app: pronghorn-crucial-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-crucial-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: pronghorn-crucial-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-convert.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-crucial-convert
+  labels:
+    k8s-app: pronghorn-crucial-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-crucial-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/pronghorn-crucial.geojson \
+            s3://public-wgfd/pronghorn-crucial.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-hex.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-crucial-hex
+  labels:
+    k8s-app: pronghorn-crucial-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-crucial-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: pronghorn-crucial
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/pronghorn-crucial.parquet --output s3://public-wgfd/pronghorn-crucial/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-pmtiles.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-crucial-pmtiles
+  labels:
+    k8s-app: pronghorn-crucial-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-crucial-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: pronghorn-crucial
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-repartition.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-crucial-repartition
+  labels:
+    k8s-app: pronghorn-crucial-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-crucial-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/pronghorn-crucial/chunks --output-dir s3://public-wgfd/pronghorn-crucial/hex --source-parquet s3://public-wgfd/pronghorn-crucial.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/pronghorn-crucial-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-crucial-setup-bucket
+  labels:
+    k8s-app: pronghorn-crucial-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-crucial-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-crucial/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/pronghorn-crucial/workflow.yaml
+++ b/catalog/wgfd/k8s/pronghorn-crucial/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-crucial-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting pronghorn-crucial workflow...\"\n\n# Step 0:\
+          \ Setup bucket with public access and CORS\necho \"Step 0: Setting up bucket...\"\
+          \nkubectl apply -f /yamls/pronghorn-crucial-setup-bucket.yaml -n geo-workflows\n\
+          \necho \"Waiting for bucket setup to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=600s job/pronghorn-crucial-setup-bucket -n geo-workflows\n\n\
+          # Step 1: Convert to optimized GeoParquet (needed by both pmtiles and hex\
+          \ jobs)\necho \"Step 1: Converting to optimized GeoParquet...\"\nkubectl\
+          \ apply -f /yamls/pronghorn-crucial-convert.yaml -n geo-workflows\n\necho\
+          \ \"Waiting for GeoParquet conversion to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/pronghorn-crucial-convert -n geo-workflows\n\n# Step\
+          \ 2: Run pmtiles and hex tiling in parallel (both use the converted geoparquet)\n\
+          echo \"Step 2: H3 hexagonal tiling and PMTiles generation (parallel)...\"\
+          \nkubectl apply -f /yamls/pronghorn-crucial-pmtiles.yaml -n geo-workflows\n\
+          kubectl apply -f /yamls/pronghorn-crucial-hex.yaml -n geo-workflows\n\n\
+          echo \"Waiting for hex tiling to complete (PMTiles continues in background)...\"\
+          \necho \"Timeout set to 48 hours (172800s)...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=172800s job/pronghorn-crucial-hex -n geo-workflows\n\necho \"\
+          Step 3: Repartitioning by h0...\"\nkubectl apply -f /yamls/pronghorn-crucial-repartition.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for repartition to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=3600s job/pronghorn-crucial-repartition\
+          \ -n geo-workflows\n\necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles\
+          \ job may still be running in the background\"\necho \"\"\necho \"Clean\
+          \ up with:\"\necho \"  kubectl delete jobs pronghorn-crucial-setup-bucket\
+          \ pronghorn-crucial-convert pronghorn-crucial-pmtiles pronghorn-crucial-hex\
+          \ pronghorn-crucial-repartition pronghorn-crucial-workflow -n geo-workflows\"\
+          \necho \"  kubectl delete configmap pronghorn-crucial-yamls -n geo-workflows\"\
+          \n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: pronghorn-crucial-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/pronghorn-seasonal/configmap.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: pronghorn-seasonal-setup-bucket.yaml, pronghorn-seasonal-convert.yaml, pronghorn-seasonal-pmtiles.yaml, pronghorn-seasonal-hex.yaml, pronghorn-seasonal-repartition.yaml
+# Generation command: cng-datasets workflow --dataset pronghorn-seasonal --source-url s3://public-wgfd/raw/pronghorn-seasonal.geojson --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap pronghorn-seasonal-yamls \
+#     --from-file=pronghorn-seasonal-setup-bucket.yaml \
+#     --from-file=pronghorn-seasonal-convert.yaml \
+#     --from-file=pronghorn-seasonal-pmtiles.yaml \
+#     --from-file=pronghorn-seasonal-hex.yaml \
+#     --from-file=pronghorn-seasonal-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  pronghorn-seasonal-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-seasonal-convert
+      labels:
+        k8s-app: pronghorn-seasonal-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-seasonal-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/pronghorn-seasonal.geojson \
+                s3://public-wgfd/pronghorn-seasonal.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-seasonal-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-seasonal-hex
+      labels:
+        k8s-app: pronghorn-seasonal-hex
+    spec:
+      completions: 1
+      parallelism: 1
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-seasonal-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: pronghorn-seasonal
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/pronghorn-seasonal.parquet --output s3://public-wgfd/pronghorn-seasonal/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-seasonal-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-seasonal-pmtiles
+      labels:
+        k8s-app: pronghorn-seasonal-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-seasonal-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: pronghorn-seasonal
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-seasonal.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-seasonal-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-seasonal-repartition
+      labels:
+        k8s-app: pronghorn-seasonal-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-seasonal-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/pronghorn-seasonal/chunks --output-dir s3://public-wgfd/pronghorn-seasonal/hex --source-parquet s3://public-wgfd/pronghorn-seasonal.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  pronghorn-seasonal-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: pronghorn-seasonal-setup-bucket
+      labels:
+        k8s-app: pronghorn-seasonal-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: pronghorn-seasonal-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: pronghorn-seasonal-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-convert.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-seasonal-convert
+  labels:
+    k8s-app: pronghorn-seasonal-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-seasonal-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/pronghorn-seasonal.geojson \
+            s3://public-wgfd/pronghorn-seasonal.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-hex.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-seasonal-hex
+  labels:
+    k8s-app: pronghorn-seasonal-hex
+spec:
+  completions: 1
+  parallelism: 1
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-seasonal-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: pronghorn-seasonal
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/pronghorn-seasonal.parquet --output s3://public-wgfd/pronghorn-seasonal/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-pmtiles.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-seasonal-pmtiles
+  labels:
+    k8s-app: pronghorn-seasonal-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-seasonal-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: pronghorn-seasonal
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-seasonal.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-repartition.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-seasonal-repartition
+  labels:
+    k8s-app: pronghorn-seasonal-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-seasonal-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/pronghorn-seasonal/chunks --output-dir s3://public-wgfd/pronghorn-seasonal/hex --source-parquet s3://public-wgfd/pronghorn-seasonal.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/pronghorn-seasonal-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-seasonal-setup-bucket
+  labels:
+    k8s-app: pronghorn-seasonal-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: pronghorn-seasonal-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/pronghorn-seasonal/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/pronghorn-seasonal/workflow.yaml
+++ b/catalog/wgfd/k8s/pronghorn-seasonal/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pronghorn-seasonal-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting pronghorn-seasonal workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/pronghorn-seasonal-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/pronghorn-seasonal-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/pronghorn-seasonal-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/pronghorn-seasonal-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/pronghorn-seasonal-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/pronghorn-seasonal-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/pronghorn-seasonal-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/pronghorn-seasonal-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/pronghorn-seasonal-repartition -n geo-workflows\n\n\
+          echo \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still be\
+          \ running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs pronghorn-seasonal-setup-bucket pronghorn-seasonal-convert\
+          \ pronghorn-seasonal-pmtiles pronghorn-seasonal-hex pronghorn-seasonal-repartition\
+          \ pronghorn-seasonal-workflow -n geo-workflows\"\necho \"  kubectl delete\
+          \ configmap pronghorn-seasonal-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: pronghorn-seasonal-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/sage-grouse-priority/configmap.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/configmap.yaml
@@ -1,0 +1,434 @@
+# Auto-generated ConfigMap containing job definitions
+# Generated from: sage-grouse-priority-setup-bucket.yaml, sage-grouse-priority-convert.yaml, sage-grouse-priority-pmtiles.yaml, sage-grouse-priority-hex.yaml, sage-grouse-priority-repartition.yaml
+# Generation command: cng-datasets workflow --dataset sage-grouse-priority --source-url s3://public-wgfd/raw/sage-grouse-priority.zip --bucket public-wgfd --h3-resolution 10 --parent-resolutions "9,8,0"
+#
+# This ConfigMap is equivalent to running:
+#   kubectl create configmap sage-grouse-priority-yamls \
+#     --from-file=sage-grouse-priority-setup-bucket.yaml \
+#     --from-file=sage-grouse-priority-convert.yaml \
+#     --from-file=sage-grouse-priority-pmtiles.yaml \
+#     --from-file=sage-grouse-priority-hex.yaml \
+#     --from-file=sage-grouse-priority-repartition.yaml
+#
+# To update: regenerate workflow with cng-datasets and re-apply with kubectl apply -f configmap.yaml
+apiVersion: v1
+data:
+  sage-grouse-priority-convert.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sage-grouse-priority-convert
+      labels:
+        k8s-app: sage-grouse-priority-convert
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sage-grouse-priority-convert
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: convert-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-convert-to-parquet \
+                s3://public-wgfd/raw/sage-grouse-priority.zip \
+                s3://public-wgfd/sage-grouse-priority.parquet \
+                --row-group-size 100000
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sage-grouse-priority-hex.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sage-grouse-priority-hex
+      labels:
+        k8s-app: sage-grouse-priority-hex
+    spec:
+      completions: 200
+      parallelism: 50
+      completionMode: Indexed
+      backoffLimit: 0
+      podFailurePolicy:
+        rules:
+        - action: Ignore
+          onPodConditions:
+          - type: DisruptionTarget
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sage-grouse-priority-hex
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: hex-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: sage-grouse-priority
+            command:
+            - bash
+            - -c
+            - |-
+              set -e
+              cng-datasets vector --input s3://public-wgfd/sage-grouse-priority.parquet --output s3://public-wgfd/sage-grouse-priority/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+                ephemeral-storage: 10Gi
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sage-grouse-priority-pmtiles.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sage-grouse-priority-pmtiles
+      labels:
+        k8s-app: sage-grouse-priority-pmtiles
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sage-grouse-priority-pmtiles
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: pmtiles-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            - name: DATASET
+              value: sage-grouse-priority
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              # Use optimized GeoParquet (has ID column) from convert job
+              # GDAL can read parquet via vsicurl
+              ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/sage-grouse-priority.parquet -progress
+
+              # Generate PMTiles from GeoJSONSeq
+              # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+              # non-power-of-2 logical CPU counts which triggers an internal assertion
+              # failure "N shards not a power of 2" (felt/tippecanoe#216).
+              # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+              # Must be `export`ed: tippecanoe is a child process and reads this from the
+              # environment, not the shell. A plain assignment is invisible to it, so it
+              # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+              export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+              # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+              # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+              # reports the node's full core count, so the thread/shard count blows past the
+              # container's default soft nofile limit (often 1024) and aborts with
+              # "Too many open files". `|| true` keeps going if the limit can't be raised.
+              ulimit -n 65536 || true
+              tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+              # Upload to S3 using rclone
+              rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+              rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+            resources:
+              requests:
+                cpu: '4'
+                memory: 8Gi
+              limits:
+                cpu: '4'
+                memory: 8Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sage-grouse-priority-repartition.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sage-grouse-priority-repartition
+      labels:
+        k8s-app: sage-grouse-priority-repartition
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sage-grouse-priority-repartition
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: repartition-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: TMPDIR
+              value: /tmp
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              cng-datasets repartition --chunks-dir s3://public-wgfd/sage-grouse-priority/chunks --output-dir s3://public-wgfd/sage-grouse-priority/hex --source-parquet s3://public-wgfd/sage-grouse-priority.parquet --cleanup --memory-limit 27GiB
+            resources:
+              requests:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+              limits:
+                cpu: '4'
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+  sage-grouse-priority-setup-bucket.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: sage-grouse-priority-setup-bucket
+      labels:
+        k8s-app: sage-grouse-priority-setup-bucket
+    spec:
+      completions: 1
+      parallelism: 1
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            k8s-app: sage-grouse-priority-setup-bucket
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: setup-bucket-task
+            image: ghcr.io/boettiger-lab/datasets:latest
+            imagePullPolicy: Always
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_S3_ENDPOINT
+              value: rook-ceph-rgw-nautiluss3.rook
+            - name: AWS_PUBLIC_ENDPOINT
+              value: s3-west.nrp-nautilus.io
+            - name: AWS_HTTPS
+              value: 'false'
+            - name: AWS_VIRTUAL_HOSTING
+              value: 'FALSE'
+            - name: BUCKET
+              value: public-wgfd
+            volumeMounts:
+            - name: rclone-config
+              mountPath: /root/.config/rclone
+              readOnly: true
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Setting up bucket with public access and CORS..."
+              cng-datasets storage setup-bucket \
+                --bucket "${BUCKET}" \
+                --remote nrp \
+                --verify
+
+              echo "Bucket setup complete!"
+            resources:
+              requests:
+                cpu: '1'
+                memory: 2Gi
+              limits:
+                cpu: '1'
+                memory: 2Gi
+          volumes:
+          - name: rclone-config
+            secret:
+              secretName: rclone-config
+          priorityClassName: opportunistic
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values:
+                    - 'true'
+kind: ConfigMap
+metadata:
+  name: sage-grouse-priority-yamls
+  namespace: geo-workflows

--- a/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-convert.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-convert.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sage-grouse-priority-convert
+  labels:
+    k8s-app: sage-grouse-priority-convert
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sage-grouse-priority-convert
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: convert-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-convert-to-parquet \
+            s3://public-wgfd/raw/sage-grouse-priority.zip \
+            s3://public-wgfd/sage-grouse-priority.parquet \
+            --row-group-size 100000
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-hex.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-hex.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sage-grouse-priority-hex
+  labels:
+    k8s-app: sage-grouse-priority-hex
+spec:
+  completions: 200
+  parallelism: 50
+  completionMode: Indexed
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+    - action: Ignore
+      onPodConditions:
+      - type: DisruptionTarget
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sage-grouse-priority-hex
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hex-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: sage-grouse-priority
+        command:
+        - bash
+        - -c
+        - |-
+          set -e
+          cng-datasets vector --input s3://public-wgfd/sage-grouse-priority.parquet --output s3://public-wgfd/sage-grouse-priority/chunks --chunk-id ${JOB_COMPLETION_INDEX} --chunk-size 1000 --intermediate-chunk-size 10 --resolution 10 --parent-resolutions 9,8,0
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            ephemeral-storage: 10Gi
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-pmtiles.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-pmtiles.yaml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sage-grouse-priority-pmtiles
+  labels:
+    k8s-app: sage-grouse-priority-pmtiles
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sage-grouse-priority-pmtiles
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pmtiles-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        - name: DATASET
+          value: sage-grouse-priority
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          # Use optimized GeoParquet (has ID column) from convert job
+          # GDAL can read parquet via vsicurl
+          ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /vsicurl/https://s3-west.nrp-nautilus.io/public-wgfd/sage-grouse-priority.parquet -progress
+
+          # Generate PMTiles from GeoJSONSeq
+          # TIPPECANOE_MAX_THREADS must be a power of 2; Kubernetes nodes can expose
+          # non-power-of-2 logical CPU counts which triggers an internal assertion
+          # failure "N shards not a power of 2" (felt/tippecanoe#216).
+          # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
+          # Must be `export`ed: tippecanoe is a child process and reads this from the
+          # environment, not the shell. A plain assignment is invisible to it, so it
+          # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+          export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+          # Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+          # temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+          # reports the node's full core count, so the thread/shard count blows past the
+          # container's default soft nofile limit (often 1024) and aborts with
+          # "Too many open files". `|| true` keeps going if the limit can't be raised.
+          ulimit -n 65536 || true
+          tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z 13 --force /tmp/$DATASET.geojsonl
+
+          # Upload to S3 using rclone
+          rclone copy /tmp/$DATASET.pmtiles nrp:public-wgfd/
+          rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
+        resources:
+          requests:
+            cpu: '4'
+            memory: 8Gi
+          limits:
+            cpu: '4'
+            memory: 8Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-repartition.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-repartition.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sage-grouse-priority-repartition
+  labels:
+    k8s-app: sage-grouse-priority-repartition
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sage-grouse-priority-repartition
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: repartition-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: TMPDIR
+          value: /tmp
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          cng-datasets repartition --chunks-dir s3://public-wgfd/sage-grouse-priority/chunks --output-dir s3://public-wgfd/sage-grouse-priority/hex --source-parquet s3://public-wgfd/sage-grouse-priority.parquet --cleanup --memory-limit 27GiB
+        resources:
+          requests:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            ephemeral-storage: 50Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-setup-bucket.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/sage-grouse-priority-setup-bucket.yaml
@@ -1,0 +1,79 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sage-grouse-priority-setup-bucket
+  labels:
+    k8s-app: sage-grouse-priority-setup-bucket
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 10800
+  template:
+    metadata:
+      labels:
+        k8s-app: sage-grouse-priority-setup-bucket
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-bucket-task
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws
+              key: AWS_SECRET_ACCESS_KEY
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        - name: AWS_PUBLIC_ENDPOINT
+          value: s3-west.nrp-nautilus.io
+        - name: AWS_HTTPS
+          value: 'false'
+        - name: AWS_VIRTUAL_HOSTING
+          value: 'FALSE'
+        - name: BUCKET
+          value: public-wgfd
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - |
+          set -e
+          echo "Setting up bucket with public access and CORS..."
+          cng-datasets storage setup-bucket \
+            --bucket "${BUCKET}" \
+            --remote nrp \
+            --verify
+
+          echo "Bucket setup complete!"
+        resources:
+          requests:
+            cpu: '1'
+            memory: 2Gi
+          limits:
+            cpu: '1'
+            memory: 2Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      priorityClassName: opportunistic
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: feature.node.kubernetes.io/pci-10de.present
+                operator: NotIn
+                values:
+                - 'true'

--- a/catalog/wgfd/k8s/sage-grouse-priority/workflow-rbac.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/workflow-rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cng-datasets-workflow
+  namespace: geo-workflows
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cng-datasets-workflow
+subjects:
+- kind: ServiceAccount
+  name: cng-datasets-workflow

--- a/catalog/wgfd/k8s/sage-grouse-priority/workflow.yaml
+++ b/catalog/wgfd/k8s/sage-grouse-priority/workflow.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sage-grouse-priority-workflow
+  namespace: geo-workflows
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "\nset -e\n\necho \"Starting sage-grouse-priority workflow...\"\n\n# Step\
+          \ 0: Setup bucket with public access and CORS\necho \"Step 0: Setting up\
+          \ bucket...\"\nkubectl apply -f /yamls/sage-grouse-priority-setup-bucket.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for bucket setup to complete...\"\n\
+          kubectl wait --for=condition=complete --timeout=600s job/sage-grouse-priority-setup-bucket\
+          \ -n geo-workflows\n\n# Step 1: Convert to optimized GeoParquet (needed\
+          \ by both pmtiles and hex jobs)\necho \"Step 1: Converting to optimized\
+          \ GeoParquet...\"\nkubectl apply -f /yamls/sage-grouse-priority-convert.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for GeoParquet conversion to complete...\"\
+          \nkubectl wait --for=condition=complete --timeout=3600s job/sage-grouse-priority-convert\
+          \ -n geo-workflows\n\n# Step 2: Run pmtiles and hex tiling in parallel (both\
+          \ use the converted geoparquet)\necho \"Step 2: H3 hexagonal tiling and\
+          \ PMTiles generation (parallel)...\"\nkubectl apply -f /yamls/sage-grouse-priority-pmtiles.yaml\
+          \ -n geo-workflows\nkubectl apply -f /yamls/sage-grouse-priority-hex.yaml\
+          \ -n geo-workflows\n\necho \"Waiting for hex tiling to complete (PMTiles\
+          \ continues in background)...\"\necho \"Timeout set to 48 hours (172800s)...\"\
+          \nkubectl wait --for=condition=complete --timeout=172800s job/sage-grouse-priority-hex\
+          \ -n geo-workflows\n\necho \"Step 3: Repartitioning by h0...\"\nkubectl\
+          \ apply -f /yamls/sage-grouse-priority-repartition.yaml -n geo-workflows\n\
+          \necho \"Waiting for repartition to complete...\"\nkubectl wait --for=condition=complete\
+          \ --timeout=3600s job/sage-grouse-priority-repartition -n geo-workflows\n\
+          \necho \"\u2713 Workflow complete!\"\necho \"Note: PMTiles job may still\
+          \ be running in the background\"\necho \"\"\necho \"Clean up with:\"\necho\
+          \ \"  kubectl delete jobs sage-grouse-priority-setup-bucket sage-grouse-priority-convert\
+          \ sage-grouse-priority-pmtiles sage-grouse-priority-hex sage-grouse-priority-repartition\
+          \ sage-grouse-priority-workflow -n geo-workflows\"\necho \"  kubectl delete\
+          \ configmap sage-grouse-priority-yamls -n geo-workflows\"\n"
+        command:
+        - bash
+        - -c
+        image: bitnami/kubectl:latest
+        name: workflow
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /yamls
+          name: yamls
+      restartPolicy: OnFailure
+      serviceAccountName: cng-datasets-workflow
+      volumes:
+      - configMap:
+          name: sage-grouse-priority-yamls
+        name: yamls
+  ttlSecondsAfterFinished: 10800

--- a/catalog/wgfd/k8s/stac-publish-2.yaml
+++ b/catalog/wgfd/k8s/stac-publish-2.yaml
@@ -1,0 +1,529 @@
+# data-workflows#578 — publish STAC for the four consumer-facing public-wgfd
+# collections and register them as children of the bucket collection.
+# Asserts the bucket collection ends with exactly 7 children (3 crucial + 4 here).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stac-publish-wgfd2
+  namespace: geo-workflows
+data:
+  elk-seasonal.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-elk-seasonal\",\n  \"title\": \"Elk Seasonal Range (Wyoming)\",\n  \"description\"\
+    : \"Seasonal habitat range for elk in Wyoming, mapped by the Wyoming Game & Fish Department. This\
+    \ is the full seasonal picture \\u2014 winter, yearlong, spring/summer/fall and severe-winter-relief\
+    \ range \\u2014 across 484 polygons and about 47,213,967 acres. Read the RANGE column to tell the\
+    \ types apart.\\n\\nCodes beginning with CRU mark crucial range, the subset the department treats\
+    \ as a determining factor in the population's ability to sustain itself. Those codes here are CRUWYL,\
+    \ CRUWIN, CRUSWR. The department also publishes crucial range on its own, which is the wgfd-elk-crucial\
+    \ collection in this catalog; filtering this layer to CRU codes covers the same ground.\\n\\nCoverage\
+    \ is the state of Wyoming, which is the full extent of the source: the department maps range within\
+    \ its own jurisdiction, so this is complete rather than a regional excerpt of something larger.\\\
+    n\\nElk is the only species here whose data includes undetermined (UND) areas.\",\n  \"license\":\
+    \ \"other\",\n  \"sci:citation\": \"Wyoming Game & Fish Department, Elk Seasonal Range. Accessed 2026-02-25\
+    \ from the WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com). The department publishes through an\
+    \ ArcGIS Hub endpoint with no stable versioned download URL, so the retained source is the anchor:\
+    \ s3://public-wgfd/raw/elk-seasonal.geojson, SHA-256 3788f003cd26547fd984b17003318940a1858e0693a074d0e1b4fe7550208c1c.\
+    \ Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"\
+    2026-08-22T00:12:26Z\",\n  \"updated\": \"2026-08-22T00:25:39Z\",\n  \"keywords\": [\n    \"Wyoming\"\
+    ,\n    \"elk\",\n    \"wildlife\",\n    \"habitat\",\n    \"seasonal range\",\n    \"crucial range\"\
+    ,\n    \"WGFD\",\n    \"big game\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n\
+    \        [\n          -111.05,\n          40.995,\n          -104.053,\n          45.007\n       \
+    \ ]\n      ]\n    },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\"\
+    ,\n          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"\
+    Wyoming Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\
+    \n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"\
+    name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\
+    \n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n   \
+    \ {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-seasonal/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"elk-seasonal-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-seasonal.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Elk seasonal range \\u2014 GeoParquet\",\n      \"created\": \"2026-08-22T00:12:26Z\"\
+    ,\n      \"description\": \"Elk seasonal range polygons as GeoParquet, one row per polygon, in EPSG:4326.\
+    \ Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n          \"name\"\
+    : \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier assigned\
+    \ to every polygon during conversion, unique within this dataset. Count features or remove repeated\
+    \ rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n\
+    \          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation assigned by the Wyoming Game & Fish Department. A CRU\
+    \ prefix marks crucial range, the habitat the department identifies as a determining factor in the\
+    \ population's ability to sustain itself. Values: WYL=winter/yearlong range, CRUWYL=crucial winter/yearlong\
+    \ range, WIN=winter range, CRUWIN=crucial winter range, OUT=out \\u2014 occupied only occasionally,\
+    \ outside the identified seasonal ranges, SSF=spring/summer/fall range, YRL=yearlong range, SWR=severe\
+    \ winter relief range, CRUSWR=crucial severe winter relief range, UND=undetermined.\",\n         \
+    \ \"values\": [\n            \"WYL\",\n            \"CRUWYL\",\n            \"WIN\",\n           \
+    \ \"CRUWIN\",\n            \"OUT\",\n            \"SSF\",\n            \"YRL\",\n            \"SWR\"\
+    ,\n            \"CRUSWR\",\n            \"UND\"\n          ]\n        },\n        {\n          \"\
+    name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\": \"Area of the range\
+    \ polygon in acres, as published by the Wyoming Game & Fish Department.\"\n        },\n        {\n\
+    \          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n          \"description\": \"\
+    Area of the range polygon in square miles, as published by the Wyoming Game & Fish Department.\"\n\
+    \        },\n        {\n          \"name\": \"geom\",\n          \"type\": \"geometry\",\n       \
+    \   \"description\": \"Polygon geometry of the range, in EPSG:4326.\"\n        }\n      ]\n    },\n\
+    \    \"elk-seasonal-pmtiles\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-seasonal.pmtiles\"\
+    ,\n      \"type\": \"application/vnd.pmtiles\",\n      \"roles\": [\n        \"visual\"\n      ],\n\
+    \      \"title\": \"Elk seasonal range \\u2014 PMTiles\",\n      \"created\": \"2026-08-22T00:12:47Z\"\
+    ,\n      \"description\": \"Vector tiles for web maps. In MapLibre GL JS the source layer is \\\"\
+    elk-seasonal\\\"; style or filter on RANGE to separate the seasonal range types, or to show only the\
+    \ crucial (CRU) ones.\",\n      \"vector:layers\": [\n        \"elk-seasonal\"\n      ],\n      \"\
+    table:columns\": [\n        {\n          \"name\": \"_cng_fid\",\n          \"type\": \"int64\"\n\
+    \        },\n        {\n          \"name\": \"OGC_FID\",\n          \"type\": \"int64\"\n        },\n\
+    \        {\n          \"name\": \"OBJECTID\",\n          \"type\": \"int32\"\n        },\n       \
+    \ {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"values\": [\n  \
+    \          \"WYL\",\n            \"CRUWYL\",\n            \"WIN\",\n            \"CRUWIN\",\n    \
+    \        \"OUT\",\n            \"SSF\",\n            \"YRL\",\n            \"SWR\",\n            \"\
+    CRUSWR\",\n            \"UND\"\n          ]\n        },\n        {\n          \"name\": \"Acres\"\
+    ,\n          \"type\": \"double\"\n        },\n        {\n          \"name\": \"SQMiles\",\n     \
+    \     \"type\": \"double\"\n        }\n      ]\n    },\n    \"elk-seasonal-hex\": {\n      \"href\"\
+    : \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-seasonal/hex/h0=*/data_0.parquet\",\n      \"\
+    type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n      \"title\"\
+    : \"Elk seasonal range \\u2014 H3 resolution 10\",\n      \"created\": \"2026-08-22T00:25:39Z\",\n\
+    \      \"description\": \"Elk seasonal range as H3 cells at resolution 10, with resolution 9, 8 and\
+    \ 0 identifiers alongside for rolling up or joining to other datasets. There is one row for each combination\
+    \ of a range polygon and a cell it covers, so a polygon spanning many cells appears on many rows,\
+    \ and the per-polygon values Acres and SQMiles are repeated on every one of its cells. Reduce to one\
+    \ row per polygon before totalling any of them:\\n\\nSELECT SUM(Acres) FROM (SELECT DISTINCT _cng_fid,\
+    \ Acres FROM \\u2026)\\n\\nFor the ground area of a set of cells, aggregate the cell areas over distinct\
+    \ cells rather than these published columns. Covers 253,709 resolution 8 cells across 2 resolution\
+    \ 0 partitions.\",\n      \"h3:native_resolution\": 10,\n      \"h3:parent_resolutions\": [\n    \
+    \    9,\n        8,\n        0\n      ],\n      \"table:columns\": [\n        {\n          \"name\"\
+    : \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier assigned\
+    \ to every polygon during conversion, unique within this dataset. Count features or remove repeated\
+    \ rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n\
+    \          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation assigned by the Wyoming Game & Fish Department. A CRU\
+    \ prefix marks crucial range, the habitat the department identifies as a determining factor in the\
+    \ population's ability to sustain itself. Values: WYL=winter/yearlong range, CRUWYL=crucial winter/yearlong\
+    \ range, WIN=winter range, CRUWIN=crucial winter range, OUT=out \\u2014 occupied only occasionally,\
+    \ outside the identified seasonal ranges, SSF=spring/summer/fall range, YRL=yearlong range, SWR=severe\
+    \ winter relief range, CRUSWR=crucial severe winter relief range, UND=undetermined.\",\n         \
+    \ \"values\": [\n            \"WYL\",\n            \"CRUWYL\",\n            \"WIN\",\n           \
+    \ \"CRUWIN\",\n            \"OUT\",\n            \"SSF\",\n            \"YRL\",\n            \"SWR\"\
+    ,\n            \"CRUSWR\",\n            \"UND\"\n          ]\n        },\n        {\n          \"\
+    name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\": \"Area of the range\
+    \ polygon in acres, as published by the Wyoming Game & Fish Department.\"\n        },\n        {\n\
+    \          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n          \"description\": \"\
+    Area of the range polygon in square miles, as published by the Wyoming Game & Fish Department.\"\n\
+    \        },\n        {\n          \"name\": \"h10\",\n          \"type\": \"uint64\",\n          \"\
+    description\": \"H3 cell identifier at resolution 10, the native resolution of this hex table.\"\n\
+    \        },\n        {\n          \"name\": \"h9\",\n          \"type\": \"uint64\",\n          \"\
+    description\": \"H3 cell identifier at resolution 9.\"\n        },\n        {\n          \"name\"\
+    : \"h8\",\n          \"type\": \"uint64\",\n          \"description\": \"H3 cell identifier at resolution\
+    \ 8, the resolution shared across this catalog for joining datasets to one another.\"\n        },\n\
+    \        {\n          \"name\": \"h0\",\n          \"type\": \"int64\",\n          \"description\"\
+    : \"H3 cell identifier at resolution 0, used as the partition key for hive-partitioned reads.\"\n\
+    \        }\n      ]\n    }\n  }\n}"
+  mule-deer-seasonal.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-mule-deer-seasonal\",\n  \"title\": \"Mule deer Seasonal Range (Wyoming)\"\
+    ,\n  \"description\": \"Seasonal habitat range for mule deer in Wyoming, mapped by the Wyoming Game\
+    \ & Fish Department. This is the full seasonal picture \\u2014 winter, yearlong, spring/summer/fall\
+    \ and severe-winter-relief range \\u2014 across 512 polygons and about 60,688,616 acres. Read the\
+    \ RANGE column to tell the types apart.\\n\\nCodes beginning with CRU mark crucial range, the subset\
+    \ the department treats as a determining factor in the population's ability to sustain itself. Those\
+    \ codes here are CRUWYL, CRUWIN. The department also publishes crucial range on its own, which is\
+    \ the wgfd-mule-deer-crucial collection in this catalog; filtering this layer to CRU codes covers\
+    \ the same ground.\\n\\nCoverage is the state of Wyoming, which is the full extent of the source:\
+    \ the department maps range within its own jurisdiction, so this is complete rather than a regional\
+    \ excerpt of something larger.\",\n  \"license\": \"other\",\n  \"sci:citation\": \"Wyoming Game &\
+    \ Fish Department, Mule deer Seasonal Range. Accessed 2026-02-25 from the WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com).\
+    \ The department publishes through an ArcGIS Hub endpoint with no stable versioned download URL, so\
+    \ the retained source is the anchor: s3://public-wgfd/raw/mule-deer-seasonal.geojson, SHA-256 a0ad5426b3924f1a945c26f48e5a4c8943e1aa182bfd6f4350ba15482b980ea0.\
+    \ Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"\
+    2026-08-22T00:26:40Z\",\n  \"updated\": \"2026-08-22T00:48:00Z\",\n  \"keywords\": [\n    \"Wyoming\"\
+    ,\n    \"mule deer\",\n    \"wildlife\",\n    \"habitat\",\n    \"seasonal range\",\n    \"crucial\
+    \ range\",\n    \"WGFD\",\n    \"big game\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\"\
+    : [\n        [\n          -111.05,\n          40.995,\n          -104.052,\n          45.007\n   \
+    \     ]\n      ]\n    },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\"\
+    ,\n          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"\
+    Wyoming Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\
+    \n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"\
+    name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\
+    \n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n   \
+    \ {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-seasonal/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"mule-deer-seasonal-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-seasonal.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Mule deer seasonal range \\u2014 GeoParquet\",\n      \"created\": \"2026-08-22T00:26:40Z\"\
+    ,\n      \"description\": \"Mule deer seasonal range polygons as GeoParquet, one row per polygon,\
+    \ in EPSG:4326. Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n\
+    \          \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"\
+    Identifier assigned to every polygon during conversion, unique within this dataset. Count features\
+    \ or remove repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\"\
+    : \"OGC_FID\",\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number\
+    \ carried over from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\"\
+    ,\n          \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the\
+    \ Wyoming Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\
+    \n        },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n       \
+    \   \"description\": \"Seasonal range designation assigned by the Wyoming Game & Fish Department.\
+    \ A CRU prefix marks crucial range, the habitat the department identifies as a determining factor\
+    \ in the population's ability to sustain itself. Values: WYL=winter/yearlong range, CRUWYL=crucial\
+    \ winter/yearlong range, OUT=out \\u2014 occupied only occasionally, outside the identified seasonal\
+    \ ranges, YRL=yearlong range, SSF=spring/summer/fall range, CRUWIN=crucial winter range, WIN=winter\
+    \ range, SWR=severe winter relief range.\",\n          \"values\": [\n            \"WYL\",\n     \
+    \       \"CRUWYL\",\n            \"OUT\",\n            \"YRL\",\n            \"SSF\",\n          \
+    \  \"CRUWIN\",\n            \"WIN\",\n            \"SWR\"\n          ]\n        },\n        {\n  \
+    \        \"name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\": \"Area\
+    \ of the range polygon in acres, as published by the Wyoming Game & Fish Department.\"\n        },\n\
+    \        {\n          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n          \"description\"\
+    : \"Area of the range polygon in square miles, as published by the Wyoming Game & Fish Department.\"\
+    \n        },\n        {\n          \"name\": \"geom\",\n          \"type\": \"geometry\",\n      \
+    \    \"description\": \"Polygon geometry of the range, in EPSG:4326.\"\n        }\n      ]\n    },\n\
+    \    \"mule-deer-seasonal-pmtiles\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-seasonal.pmtiles\"\
+    ,\n      \"type\": \"application/vnd.pmtiles\",\n      \"roles\": [\n        \"visual\"\n      ],\n\
+    \      \"title\": \"Mule deer seasonal range \\u2014 PMTiles\",\n      \"created\": \"2026-08-22T00:26:55Z\"\
+    ,\n      \"description\": \"Vector tiles for web maps. In MapLibre GL JS the source layer is \\\"\
+    mule-deer-seasonal\\\"; style or filter on RANGE to separate the seasonal range types, or to show\
+    \ only the crucial (CRU) ones.\",\n      \"vector:layers\": [\n        \"mule-deer-seasonal\"\n  \
+    \    ],\n      \"table:columns\": [\n        {\n          \"name\": \"_cng_fid\",\n          \"type\"\
+    : \"int64\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n          \"type\": \"int64\"\
+    \n        },\n        {\n          \"name\": \"OBJECTID\",\n          \"type\": \"int32\"\n      \
+    \  },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"values\"\
+    : [\n            \"WYL\",\n            \"CRUWYL\",\n            \"OUT\",\n            \"YRL\",\n \
+    \           \"SSF\",\n            \"CRUWIN\",\n            \"WIN\",\n            \"SWR\"\n       \
+    \   ]\n        },\n        {\n          \"name\": \"Acres\",\n          \"type\": \"double\"\n   \
+    \     },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"double\"\n        }\n\
+    \      ]\n    },\n    \"mule-deer-seasonal-hex\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-seasonal/hex/h0=*/data_0.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Mule deer seasonal range \\u2014 H3 resolution 10\",\n      \"created\": \"2026-08-22T00:48:00Z\"\
+    ,\n      \"description\": \"Mule deer seasonal range as H3 cells at resolution 10, with resolution\
+    \ 9, 8 and 0 identifiers alongside for rolling up or joining to other datasets. There is one row for\
+    \ each combination of a range polygon and a cell it covers, so a polygon spanning many cells appears\
+    \ on many rows, and the per-polygon values Acres and SQMiles are repeated on every one of its cells.\
+    \ Reduce to one row per polygon before totalling any of them:\\n\\nSELECT SUM(Acres) FROM (SELECT\
+    \ DISTINCT _cng_fid, Acres FROM \\u2026)\\n\\nFor the ground area of a set of cells, aggregate the\
+    \ cell areas over distinct cells rather than these published columns. Covers 325,192 resolution 8\
+    \ cells across 2 resolution 0 partitions.\",\n      \"h3:native_resolution\": 10,\n      \"h3:parent_resolutions\"\
+    : [\n        9,\n        8,\n        0\n      ],\n      \"table:columns\": [\n        {\n        \
+    \  \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier\
+    \ assigned to every polygon during conversion, unique within this dataset. Count features or remove\
+    \ repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation assigned by the Wyoming Game & Fish Department. A CRU\
+    \ prefix marks crucial range, the habitat the department identifies as a determining factor in the\
+    \ population's ability to sustain itself. Values: WYL=winter/yearlong range, CRUWYL=crucial winter/yearlong\
+    \ range, OUT=out \\u2014 occupied only occasionally, outside the identified seasonal ranges, YRL=yearlong\
+    \ range, SSF=spring/summer/fall range, CRUWIN=crucial winter range, WIN=winter range, SWR=severe winter\
+    \ relief range.\",\n          \"values\": [\n            \"WYL\",\n            \"CRUWYL\",\n     \
+    \       \"OUT\",\n            \"YRL\",\n            \"SSF\",\n            \"CRUWIN\",\n          \
+    \  \"WIN\",\n            \"SWR\"\n          ]\n        },\n        {\n          \"name\": \"Acres\"\
+    ,\n          \"type\": \"double\",\n          \"description\": \"Area of the range polygon in acres,\
+    \ as published by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"name\"\
+    : \"SQMiles\",\n          \"type\": \"double\",\n          \"description\": \"Area of the range polygon\
+    \ in square miles, as published by the Wyoming Game & Fish Department.\"\n        },\n        {\n\
+    \          \"name\": \"h10\",\n          \"type\": \"uint64\",\n          \"description\": \"H3 cell\
+    \ identifier at resolution 10, the native resolution of this hex table.\"\n        },\n        {\n\
+    \          \"name\": \"h9\",\n          \"type\": \"uint64\",\n          \"description\": \"H3 cell\
+    \ identifier at resolution 9.\"\n        },\n        {\n          \"name\": \"h8\",\n          \"\
+    type\": \"uint64\",\n          \"description\": \"H3 cell identifier at resolution 8, the resolution\
+    \ shared across this catalog for joining datasets to one another.\"\n        },\n        {\n     \
+    \     \"name\": \"h0\",\n          \"type\": \"int64\",\n          \"description\": \"H3 cell identifier\
+    \ at resolution 0, used as the partition key for hive-partitioned reads.\"\n        }\n      ]\n \
+    \   }\n  }\n}"
+  pronghorn-seasonal.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-pronghorn-seasonal\",\n  \"title\": \"Pronghorn Seasonal Range (Wyoming)\"\
+    ,\n  \"description\": \"Seasonal habitat range for pronghorn in Wyoming, mapped by the Wyoming Game\
+    \ & Fish Department. This is the full seasonal picture \\u2014 winter, yearlong, spring/summer/fall\
+    \ and severe-winter-relief range \\u2014 across 502 polygons and about 120,774,532 acres. Read the\
+    \ RANGE column to tell the types apart.\\n\\nCodes beginning with CRU mark crucial range, the subset\
+    \ the department treats as a determining factor in the population's ability to sustain itself. Those\
+    \ codes here are CRUWYL, CRUSWR, CRUWIN. The department also publishes crucial range on its own, which\
+    \ is the wgfd-pronghorn-crucial collection in this catalog; filtering this layer to CRU codes covers\
+    \ the same ground.\\n\\nCoverage is the state of Wyoming, which is the full extent of the source:\
+    \ the department maps range within its own jurisdiction, so this is complete rather than a regional\
+    \ excerpt of something larger.\\n\\nUpstream the department publishes this layer under the common\
+    \ name antelope.\",\n  \"license\": \"other\",\n  \"sci:citation\": \"Wyoming Game & Fish Department,\
+    \ Pronghorn Seasonal Range. Accessed 2026-02-25 from the WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com).\
+    \ The department publishes through an ArcGIS Hub endpoint with no stable versioned download URL, so\
+    \ the retained source is the anchor: s3://public-wgfd/raw/pronghorn-seasonal.geojson, SHA-256 5b3fdbaccf91296eb3735be66e65fd0135b3bfe0b62dc87c49ddf04b939a9a88.\
+    \ Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"\
+    2026-08-22T00:51:41Z\",\n  \"updated\": \"2026-08-22T01:06:14Z\",\n  \"keywords\": [\n    \"Wyoming\"\
+    ,\n    \"pronghorn\",\n    \"wildlife\",\n    \"habitat\",\n    \"seasonal range\",\n    \"crucial\
+    \ range\",\n    \"WGFD\",\n    \"big game\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\"\
+    : [\n        [\n          -111.048,\n          40.995,\n          -104.052,\n          45.007\n  \
+    \      ]\n      ]\n    },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\"\
+    ,\n          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"\
+    Wyoming Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\
+    \n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"\
+    name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\
+    \n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n   \
+    \ {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-seasonal/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"pronghorn-seasonal-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-seasonal.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Pronghorn seasonal range \\u2014 GeoParquet\",\n      \"created\": \"2026-08-22T00:51:41Z\"\
+    ,\n      \"description\": \"Pronghorn seasonal range polygons as GeoParquet, one row per polygon,\
+    \ in EPSG:4326. Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n\
+    \          \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"\
+    Identifier assigned to every polygon during conversion, unique within this dataset. Count features\
+    \ or remove repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\"\
+    : \"OGC_FID\",\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number\
+    \ carried over from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\"\
+    ,\n          \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the\
+    \ Wyoming Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\
+    \n        },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n       \
+    \   \"description\": \"Seasonal range designation assigned by the Wyoming Game & Fish Department.\
+    \ A CRU prefix marks crucial range, the habitat the department identifies as a determining factor\
+    \ in the population's ability to sustain itself. Values: OUT=out \\u2014 occupied only occasionally,\
+    \ outside the identified seasonal ranges, WYL=winter/yearlong range, CRUWYL=crucial winter/yearlong\
+    \ range, YRL=yearlong range, SSF=spring/summer/fall range, WIN=winter range, SWR=severe winter relief\
+    \ range, CRUSWR=crucial severe winter relief range, CRUWIN=crucial winter range.\",\n          \"\
+    values\": [\n            \"OUT\",\n            \"WYL\",\n            \"CRUWYL\",\n            \"YRL\"\
+    ,\n            \"SSF\",\n            \"WIN\",\n            \"SWR\",\n            \"CRUSWR\",\n   \
+    \         \"CRUWIN\"\n          ]\n        },\n        {\n          \"name\": \"Acres\",\n       \
+    \   \"type\": \"double\",\n          \"description\": \"Area of the range polygon in acres, as published\
+    \ by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"name\": \"SQMiles\"\
+    ,\n          \"type\": \"double\",\n          \"description\": \"Area of the range polygon in square\
+    \ miles, as published by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"\
+    name\": \"geom\",\n          \"type\": \"geometry\",\n          \"description\": \"Polygon geometry\
+    \ of the range, in EPSG:4326.\"\n        }\n      ]\n    },\n    \"pronghorn-seasonal-pmtiles\": {\n\
+    \      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-seasonal.pmtiles\",\n   \
+    \   \"type\": \"application/vnd.pmtiles\",\n      \"roles\": [\n        \"visual\"\n      ],\n   \
+    \   \"title\": \"Pronghorn seasonal range \\u2014 PMTiles\",\n      \"created\": \"2026-08-22T00:51:57Z\"\
+    ,\n      \"description\": \"Vector tiles for web maps. In MapLibre GL JS the source layer is \\\"\
+    pronghorn-seasonal\\\"; style or filter on RANGE to separate the seasonal range types, or to show\
+    \ only the crucial (CRU) ones.\",\n      \"vector:layers\": [\n        \"pronghorn-seasonal\"\n  \
+    \    ],\n      \"table:columns\": [\n        {\n          \"name\": \"_cng_fid\",\n          \"type\"\
+    : \"int64\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n          \"type\": \"int64\"\
+    \n        },\n        {\n          \"name\": \"OBJECTID\",\n          \"type\": \"int32\"\n      \
+    \  },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"values\"\
+    : [\n            \"OUT\",\n            \"WYL\",\n            \"CRUWYL\",\n            \"YRL\",\n \
+    \           \"SSF\",\n            \"WIN\",\n            \"SWR\",\n            \"CRUSWR\",\n      \
+    \      \"CRUWIN\"\n          ]\n        },\n        {\n          \"name\": \"Acres\",\n          \"\
+    type\": \"double\"\n        },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"\
+    double\"\n        }\n      ]\n    },\n    \"pronghorn-seasonal-hex\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-seasonal/hex/h0=*/data_0.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Pronghorn seasonal range \\u2014 H3 resolution 10\",\n      \"created\": \"2026-08-22T01:06:14Z\"\
+    ,\n      \"description\": \"Pronghorn seasonal range as H3 cells at resolution 10, with resolution\
+    \ 9, 8 and 0 identifiers alongside for rolling up or joining to other datasets. There is one row for\
+    \ each combination of a range polygon and a cell it covers, so a polygon spanning many cells appears\
+    \ on many rows, and the per-polygon values Acres and SQMiles are repeated on every one of its cells.\
+    \ Reduce to one row per polygon before totalling any of them:\\n\\nSELECT SUM(Acres) FROM (SELECT\
+    \ DISTINCT _cng_fid, Acres FROM \\u2026)\\n\\nFor the ground area of a set of cells, aggregate the\
+    \ cell areas over distinct cells rather than these published columns. Covers 302,185 resolution 8\
+    \ cells across 1 resolution 0 partition.\",\n      \"h3:native_resolution\": 10,\n      \"h3:parent_resolutions\"\
+    : [\n        9,\n        8,\n        0\n      ],\n      \"table:columns\": [\n        {\n        \
+    \  \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier\
+    \ assigned to every polygon during conversion, unique within this dataset. Count features or remove\
+    \ repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation assigned by the Wyoming Game & Fish Department. A CRU\
+    \ prefix marks crucial range, the habitat the department identifies as a determining factor in the\
+    \ population's ability to sustain itself. Values: OUT=out \\u2014 occupied only occasionally, outside\
+    \ the identified seasonal ranges, WYL=winter/yearlong range, CRUWYL=crucial winter/yearlong range,\
+    \ YRL=yearlong range, SSF=spring/summer/fall range, WIN=winter range, SWR=severe winter relief range,\
+    \ CRUSWR=crucial severe winter relief range, CRUWIN=crucial winter range.\",\n          \"values\"\
+    : [\n            \"OUT\",\n            \"WYL\",\n            \"CRUWYL\",\n            \"YRL\",\n \
+    \           \"SSF\",\n            \"WIN\",\n            \"SWR\",\n            \"CRUSWR\",\n      \
+    \      \"CRUWIN\"\n          ]\n        },\n        {\n          \"name\": \"Acres\",\n          \"\
+    type\": \"double\",\n          \"description\": \"Area of the range polygon in acres, as published\
+    \ by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"name\": \"SQMiles\"\
+    ,\n          \"type\": \"double\",\n          \"description\": \"Area of the range polygon in square\
+    \ miles, as published by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"\
+    name\": \"h10\",\n          \"type\": \"uint64\",\n          \"description\": \"H3 cell identifier\
+    \ at resolution 10, the native resolution of this hex table.\"\n        },\n        {\n          \"\
+    name\": \"h9\",\n          \"type\": \"uint64\",\n          \"description\": \"H3 cell identifier\
+    \ at resolution 9.\"\n        },\n        {\n          \"name\": \"h8\",\n          \"type\": \"uint64\"\
+    ,\n          \"description\": \"H3 cell identifier at resolution 8, the resolution shared across this\
+    \ catalog for joining datasets to one another.\"\n        },\n        {\n          \"name\": \"h0\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"H3 cell identifier at resolution 0,\
+    \ used as the partition key for hive-partitioned reads.\"\n        }\n      ]\n    }\n  }\n}"
+  sage-grouse-priority.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-sage-grouse-priority\",\n  \"title\": \"Greater Sage-Grouse Core Management\
+    \ Areas v4 (Wyoming)\",\n  \"description\": \"Greater sage-grouse Core Management Areas in Wyoming,\
+    \ version 4. These are the highest-priority sage-grouse habitat areas, 33 named areas covering about\
+    \ 15,409,173 acres, identified jointly by the Wyoming Game & Fish Department and the Bureau of Land\
+    \ Management to focus conservation and management. Each polygon is one named Core Management Area.\\\
+    n\\nThis is Wyoming's own Core Area designation \\u2014 a state policy instrument rather than a clip\
+    \ of a range-wide product. Sage-grouse habitat is mapped across the western states by other programs,\
+    \ but those are separate datasets built on different criteria, not wider extents of this one.\",\n\
+    \  \"license\": \"other\",\n  \"sci:citation\": \"Wyoming Game & Fish Department and Bureau of Land\
+    \ Management, Greater Sage-Grouse Core Management Areas version 4. Accessed 2026-02-25 from the WGFD\
+    \ ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com). Distribution is through an ArcGIS Hub endpoint with\
+    \ no stable versioned download URL, so the retained source is the anchor: s3://public-wgfd/raw/sage-grouse-priority.zip,\
+    \ SHA-256 4c7796900bf33208d58541c574aa503481f090caafbc051b663b0428d6a9cfde. Converted to GeoParquet,\
+    \ PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"2026-08-22T01:07:10Z\",\n\
+    \  \"updated\": \"2026-08-22T01:08:47Z\",\n  \"keywords\": [\n    \"Wyoming\",\n    \"sage-grouse\"\
+    ,\n    \"greater sage-grouse\",\n    \"core areas\",\n    \"habitat\",\n    \"WGFD\",\n    \"BLM\"\
+    ,\n    \"sagebrush\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n        [\n  \
+    \        -111.047,\n          41.0,\n          -104.291,\n          45.0\n        ]\n      ]\n   \
+    \ },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\",\n\
+    \          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"Wyoming\
+    \ Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\n   \
+    \   ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"name\"\
+    : \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\n\
+    \      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n    {\n\
+    \      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/sage-grouse-priority/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"sage-grouse-priority-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/sage-grouse-priority.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Sage-grouse Core Management Areas \\u2014 GeoParquet\",\n      \"created\": \"2026-08-22T01:07:10Z\"\
+    ,\n      \"description\": \"Core Management Area polygons as GeoParquet, one row per area, in EPSG:4326.\
+    \ Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n          \"name\"\
+    : \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier assigned\
+    \ to every polygon during conversion, unique within this dataset. Count areas or remove repeated rows\
+    \ with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n    \
+    \      \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over from\
+    \ the source export.\"\n        },\n        {\n          \"name\": \"ID\",\n          \"type\": \"\
+    int64\",\n          \"description\": \"Core Management Area identifier from the published layer.\"\
+    \n        },\n        {\n          \"name\": \"NAME\",\n          \"type\": \"string\",\n        \
+    \  \"description\": \"Name of the Core Management Area, for example a landscape or basin the area\
+    \ is known by.\"\n        },\n        {\n          \"name\": \"Acres\",\n          \"type\": \"double\"\
+    ,\n          \"description\": \"Area of the Core Management Area in acres, as published.\"\n     \
+    \   },\n        {\n          \"name\": \"Shape_Leng\",\n          \"type\": \"double\",\n        \
+    \  \"description\": \"Perimeter of the area polygon in the units of the source projection, carried\
+    \ over from the published layer.\"\n        },\n        {\n          \"name\": \"Shape_Area\",\n \
+    \         \"type\": \"double\",\n          \"description\": \"Area of the polygon in the units of\
+    \ the source projection, carried over from the published layer. Acres is the interpretable value.\"\
+    \n        },\n        {\n          \"name\": \"geom\",\n          \"type\": \"geometry\",\n      \
+    \    \"description\": \"Polygon geometry of the Core Management Area, in EPSG:4326.\"\n        }\n\
+    \      ]\n    },\n    \"sage-grouse-priority-pmtiles\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/sage-grouse-priority.pmtiles\"\
+    ,\n      \"type\": \"application/vnd.pmtiles\",\n      \"roles\": [\n        \"visual\"\n      ],\n\
+    \      \"title\": \"Sage-grouse Core Management Areas \\u2014 PMTiles\",\n      \"created\": \"2026-08-22T01:07:29Z\"\
+    ,\n      \"description\": \"Vector tiles for web maps. In MapLibre GL JS the source layer is \\\"\
+    sage-grouse-priority\\\"; label features with NAME.\",\n      \"vector:layers\": [\n        \"sage-grouse-priority\"\
+    \n      ],\n      \"table:columns\": [\n        {\n          \"name\": \"_cng_fid\",\n          \"\
+    type\": \"int64\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n          \"type\": \"\
+    int64\"\n        },\n        {\n          \"name\": \"ID\",\n          \"type\": \"int64\"\n     \
+    \   },\n        {\n          \"name\": \"NAME\",\n          \"type\": \"string\"\n        },\n   \
+    \     {\n          \"name\": \"Acres\",\n          \"type\": \"double\"\n        },\n        {\n \
+    \         \"name\": \"Shape_Leng\",\n          \"type\": \"double\"\n        },\n        {\n     \
+    \     \"name\": \"Shape_Area\",\n          \"type\": \"double\"\n        }\n      ]\n    },\n    \"\
+    sage-grouse-priority-hex\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/sage-grouse-priority/hex/h0=*/data_0.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Sage-grouse Core Management Areas \\u2014 H3 resolution 10\",\n      \"created\"\
+    : \"2026-08-22T01:08:47Z\",\n      \"description\": \"Core Management Areas as H3 cells at resolution\
+    \ 10, with resolution 9, 8 and 0 identifiers alongside for rolling up or joining to other datasets.\
+    \ There is one row for each combination of a Core Management Area and a cell it covers, so a polygon\
+    \ spanning many cells appears on many rows, and the per-polygon values Acres, Shape_Leng and Shape_Area\
+    \ are repeated on every one of its cells. Reduce to one row per polygon before totalling any of them:\\\
+    n\\nSELECT SUM(Acres) FROM (SELECT DISTINCT _cng_fid, Acres FROM \\u2026)\\n\\nFor the ground area\
+    \ of a set of cells, aggregate the cell areas over distinct cells rather than these published columns.\
+    \ Covers 86,934 resolution 8 cells across 1 resolution 0 partition.\",\n      \"h3:native_resolution\"\
+    : 10,\n      \"h3:parent_resolutions\": [\n        9,\n        8,\n        0\n      ],\n      \"table:columns\"\
+    : [\n        {\n          \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\"\
+    : \"Identifier assigned to every polygon during conversion, unique within this dataset. Count areas\
+    \ or remove repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\"\
+    : \"OGC_FID\",\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number\
+    \ carried over from the source export.\"\n        },\n        {\n          \"name\": \"ID\",\n   \
+    \       \"type\": \"int64\",\n          \"description\": \"Core Management Area identifier from the\
+    \ published layer.\"\n        },\n        {\n          \"name\": \"NAME\",\n          \"type\": \"\
+    string\",\n          \"description\": \"Name of the Core Management Area, for example a landscape\
+    \ or basin the area is known by.\"\n        },\n        {\n          \"name\": \"Acres\",\n      \
+    \    \"type\": \"double\",\n          \"description\": \"Area of the Core Management Area in acres,\
+    \ as published.\"\n        },\n        {\n          \"name\": \"Shape_Leng\",\n          \"type\"\
+    : \"double\",\n          \"description\": \"Perimeter of the area polygon in the units of the source\
+    \ projection, carried over from the published layer.\"\n        },\n        {\n          \"name\"\
+    : \"Shape_Area\",\n          \"type\": \"double\",\n          \"description\": \"Area of the polygon\
+    \ in the units of the source projection, carried over from the published layer. Acres is the interpretable\
+    \ value.\"\n        },\n        {\n          \"name\": \"h10\",\n          \"type\": \"uint64\",\n\
+    \          \"description\": \"H3 cell identifier at resolution 10, the native resolution of this hex\
+    \ table.\"\n        },\n        {\n          \"name\": \"h9\",\n          \"type\": \"uint64\",\n\
+    \          \"description\": \"H3 cell identifier at resolution 9.\"\n        },\n        {\n     \
+    \     \"name\": \"h8\",\n          \"type\": \"uint64\",\n          \"description\": \"H3 cell identifier\
+    \ at resolution 8, the resolution shared across this catalog for joining datasets to one another.\"\
+    \n        },\n        {\n          \"name\": \"h0\",\n          \"type\": \"int64\",\n          \"\
+    description\": \"H3 cell identifier at resolution 0, used as the partition key for hive-partitioned\
+    \ reads.\"\n        }\n      ]\n    }\n  }\n}"
+  publish.py: "\nimport json, subprocess, sys\nNRP='https://s3-west.nrp-nautilus.io'; B='public-wgfd'\n\
+    DS=['elk-seasonal', 'mule-deer-seasonal', 'pronghorn-seasonal', 'sage-grouse-priority']\nPK=f'nrp:{B}/stac-collection.json'\n\
+    for ds in DS:\n    doc=json.load(open(f'/config/{ds}.json'))\n    open('/tmp/o.json','w').write(json.dumps(doc,indent=2));\
+    \ json.load(open('/tmp/o.json'))\n    subprocess.check_call(['rclone','copyto','/tmp/o.json',f'nrp:{B}/{ds}/stac-collection.json'])\n\
+    \    print('published\\t%s' % doc['id'])\n# add each as a child of the bucket collection\nparent=json.loads(subprocess.check_output(['rclone','cat',PK]))\n\
+    added=[]\nfor ds in DS:\n    href=f'{NRP}/{B}/{ds}/stac-collection.json'\n    if any(l.get('rel')=='child'\
+    \ and l.get('href')==href for l in parent['links']): continue\n    title=json.load(open(f'/config/{ds}.json'))['title']\n\
+    \    parent['links'].append({'rel':'child','href':href,'type':'application/json','title':title})\n\
+    \    added.append(ds)\nif added:\n    open('/tmp/p.json','w').write(json.dumps(parent,indent=2));\
+    \ json.load(open('/tmp/p.json'))\n    subprocess.check_call(['rclone','copyto','/tmp/p.json',PK])\n\
+    back=json.loads(subprocess.check_output(['rclone','cat',PK]))\nn=sum(1 for l in back['links'] if l.get('rel')=='child')\n\
+    print('parent\\tchildren=%d\\tadded=%s' % (n, ','.join(added) or 'none'))\nif n!=7: print('FAIL: expected\
+    \ 7 children, got %d'%n); sys.exit(1)\nprint('done')\n"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-publish-wgfd2
+  namespace: geo-workflows
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: publish
+        image: ghcr.io/boettiger-lab/datasets:latest
+        env:
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: cfg
+          mountPath: /config
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - set -uo pipefail; python3 /config/publish.py
+        resources:
+          requests:
+            cpu: '1'
+            memory: 1Gi
+            ephemeral-storage: 1Gi
+          limits:
+            cpu: '1'
+            memory: 1Gi
+            ephemeral-storage: 1Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: cfg
+        configMap:
+          name: stac-publish-wgfd2

--- a/catalog/wgfd/k8s/stac-publish.yaml
+++ b/catalog/wgfd/k8s/stac-publish.yaml
@@ -1,0 +1,444 @@
+# data-workflows#578 — publish the three public-wgfd STAC collections, the new
+# bucket-level collection, and register public-wgfd in the ROOT catalog.
+#
+# Touching the root is normally forbidden; this is the sanctioned case, a brand-new
+# top-level sub-catalog (AGENTS.md Step 6). The job asserts the root child count grows
+# by exactly one, so a concurrent edit or a double-run cannot silently duplicate it.
+#
+# Every value in these documents was measured from the published data (schemas, RANGE
+# value sets, bboxes, feature counts, build times, raw SHA-256). Pre-publish gate was
+# clean for all four before this job was written. Idempotent.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stac-publish-wgfd
+  namespace: geo-workflows
+data:
+  elk-crucial.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-elk-crucial\",\n  \"title\": \"Elk Crucial Range (Wyoming)\",\n  \"description\"\
+    : \"Crucial seasonal habitat range for elk in Wyoming, mapped by the Wyoming Game & Fish Department.\
+    \ Crucial ranges are the seasonal habitats the department identifies as a determining factor in the\
+    \ population's ability to sustain itself, so they carry more management weight than ordinary seasonal\
+    \ range. This dataset holds 150 polygons covering about 4,442,987 acres, broken down by range type\
+    \ as CRUWYL (91), CRUWIN (57), CRUSWR (2).\\n\\nCoverage is the state of Wyoming. That is the full\
+    \ extent of the source: the Wyoming Game & Fish Department maps range within its own jurisdiction,\
+    \ so this is a complete dataset rather than a regional excerpt of something larger.\\n\\nThe department\
+    \ publishes crucial range as a separate layer from full elk seasonal range, and every polygon here\
+    \ is crucial, which is why each RANGE code begins with CRU.\",\n  \"license\": \"other\",\n  \"sci:citation\"\
+    : \"Wyoming Game & Fish Department, Elk Crucial Range. Accessed 2026-02-25 from the WGFD ArcGIS Hub\
+    \ (wyoming-wgfd.opendata.arcgis.com). The department publishes through an ArcGIS Hub endpoint with\
+    \ no stable versioned download URL, so the retained source is the anchor: s3://public-wgfd/raw/elk-crucial.geojson,\
+    \ 2,324,827 bytes, SHA-256 3d56458f6bf2d6d6bcd1b648c1716cf7188bd40ab2641e85d370172f35b03fd2. Converted\
+    \ to GeoParquet, PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"2026-08-21T23:29:26Z\"\
+    ,\n  \"updated\": \"2026-08-21T23:31:13Z\",\n  \"keywords\": [\n    \"Wyoming\",\n    \"elk\",\n \
+    \   \"wildlife\",\n    \"habitat\",\n    \"crucial range\",\n    \"seasonal range\",\n    \"WGFD\"\
+    ,\n    \"big game\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n        [\n   \
+    \       -111.049,\n          40.999,\n          -104.981,\n          44.988\n        ]\n      ]\n\
+    \    },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\"\
+    ,\n          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"\
+    Wyoming Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\
+    \n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"\
+    name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\
+    \n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n   \
+    \ {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"elk-crucial-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Elk crucial range \\u2014 GeoParquet\",\n      \"created\": \"2026-08-21T23:29:26Z\"\
+    ,\n      \"description\": \"Elk crucial range polygons as GeoParquet, one row per polygon, in EPSG:4326.\
+    \ Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n          \"name\"\
+    : \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier assigned\
+    \ to every polygon during conversion, unique within this dataset. Count features or remove repeated\
+    \ rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n\
+    \          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation. Every polygon here is crucial range, so each code combines\
+    \ the crucial prefix CRU with the seasonal type. Values: CRUWYL=crucial winter/yearlong range, CRUWIN=crucial\
+    \ winter range, CRUSWR=crucial severe winter relief range.\",\n          \"values\": [\n         \
+    \   \"CRUWYL\",\n            \"CRUWIN\",\n            \"CRUSWR\"\n          ]\n        },\n      \
+    \  {\n          \"name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\":\
+    \ \"Area of the range polygon in acres, as published by the Wyoming Game & Fish Department.\"\n  \
+    \      },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n        \
+    \  \"description\": \"Area of the range polygon in square miles, as published by the Wyoming Game\
+    \ & Fish Department.\"\n        },\n        {\n          \"name\": \"geom\",\n          \"type\":\
+    \ \"geometry\",\n          \"description\": \"Polygon geometry of the range, in EPSG:4326.\"\n   \
+    \     }\n      ]\n    },\n    \"elk-crucial-pmtiles\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial.pmtiles\"\
+    ,\n      \"type\": \"application/vnd.pmtiles\",\n      \"roles\": [\n        \"visual\"\n      ],\n\
+    \      \"title\": \"Elk crucial range \\u2014 PMTiles\",\n      \"created\": \"2026-08-21T23:29:37Z\"\
+    ,\n      \"description\": \"Vector tiles for web maps. In MapLibre GL JS the source layer is \\\"\
+    elk-crucial\\\"; style or filter on RANGE to separate the crucial range types.\",\n      \"vector:layers\"\
+    : [\n        \"elk-crucial\"\n      ],\n      \"table:columns\": [\n        {\n          \"name\"\
+    : \"_cng_fid\",\n          \"type\": \"int64\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n     \
+    \     \"type\": \"int32\"\n        },\n        {\n          \"name\": \"RANGE\",\n          \"type\"\
+    : \"string\",\n          \"values\": [\n            \"CRUWYL\",\n            \"CRUWIN\",\n       \
+    \     \"CRUSWR\"\n          ]\n        },\n        {\n          \"name\": \"Acres\",\n          \"\
+    type\": \"double\"\n        },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"\
+    double\"\n        }\n      ]\n    },\n    \"elk-crucial-hex\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial/hex/h0=*/data_0.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Elk crucial range \\u2014 H3 resolution 10\",\n      \"created\": \"2026-08-21T23:31:13Z\"\
+    ,\n      \"description\": \"Elk crucial range as H3 cells at resolution 10, with resolution 9, 8 and\
+    \ 0 identifiers alongside for rolling up or joining to other datasets. There is one row for each combination\
+    \ of a range polygon and a cell it covers, so a polygon that spans many cells appears on many rows,\
+    \ and the per-polygon values Acres and SQMiles are repeated on every one of its cells. Reduce to one\
+    \ row per polygon before totalling either of them:\\n\\nSELECT SUM(Acres) FROM (SELECT DISTINCT _cng_fid,\
+    \ Acres FROM \\u2026)\\n\\nFor the ground area of a set of cells, aggregate the cell areas over distinct\
+    \ cells rather than these published columns. Covers 28,617 resolution 8 cells across 2 resolution\
+    \ 0 partitions.\",\n      \"h3:native_resolution\": 10,\n      \"h3:parent_resolutions\": [\n    \
+    \    9,\n        8,\n        0\n      ],\n      \"table:columns\": [\n        {\n          \"name\"\
+    : \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier assigned\
+    \ to every polygon during conversion, unique within this dataset. Count features or remove repeated\
+    \ rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n\
+    \          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation. Every polygon here is crucial range, so each code combines\
+    \ the crucial prefix CRU with the seasonal type. Values: CRUWYL=crucial winter/yearlong range, CRUWIN=crucial\
+    \ winter range, CRUSWR=crucial severe winter relief range.\",\n          \"values\": [\n         \
+    \   \"CRUWYL\",\n            \"CRUWIN\",\n            \"CRUSWR\"\n          ]\n        },\n      \
+    \  {\n          \"name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\":\
+    \ \"Area of the range polygon in acres, as published by the Wyoming Game & Fish Department.\"\n  \
+    \      },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n        \
+    \  \"description\": \"Area of the range polygon in square miles, as published by the Wyoming Game\
+    \ & Fish Department.\"\n        },\n        {\n          \"name\": \"h10\",\n          \"type\": \"\
+    uint64\",\n          \"description\": \"H3 cell identifier at resolution 10, the native resolution\
+    \ of this hex table.\"\n        },\n        {\n          \"name\": \"h9\",\n          \"type\": \"\
+    uint64\",\n          \"description\": \"H3 cell identifier at resolution 9.\"\n        },\n      \
+    \  {\n          \"name\": \"h8\",\n          \"type\": \"uint64\",\n          \"description\": \"\
+    H3 cell identifier at resolution 8, the resolution shared across this catalog for joining datasets\
+    \ to one another.\"\n        },\n        {\n          \"name\": \"h0\",\n          \"type\": \"int64\"\
+    ,\n          \"description\": \"H3 cell identifier at resolution 0, used as the partition key for\
+    \ hive-partitioned reads.\"\n        }\n      ]\n    }\n  }\n}"
+  mule-deer-crucial.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-mule-deer-crucial\",\n  \"title\": \"Mule deer Crucial Range (Wyoming)\"\
+    ,\n  \"description\": \"Crucial seasonal habitat range for mule deer in Wyoming, mapped by the Wyoming\
+    \ Game & Fish Department. Crucial ranges are the seasonal habitats the department identifies as a\
+    \ determining factor in the population's ability to sustain itself, so they carry more management\
+    \ weight than ordinary seasonal range. This dataset holds 145 polygons covering about 6,431,769 acres,\
+    \ broken down by range type as CRUWYL (116), CRUWIN (29).\\n\\nCoverage is the state of Wyoming. That\
+    \ is the full extent of the source: the Wyoming Game & Fish Department maps range within its own jurisdiction,\
+    \ so this is a complete dataset rather than a regional excerpt of something larger.\\n\\nThe department\
+    \ publishes crucial range as a separate layer from full mule deer seasonal range, and every polygon\
+    \ here is crucial, which is why each RANGE code begins with CRU.\",\n  \"license\": \"other\",\n \
+    \ \"sci:citation\": \"Wyoming Game & Fish Department, Mule deer Crucial Range. Accessed 2026-02-25\
+    \ from the WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com). The department publishes through an\
+    \ ArcGIS Hub endpoint with no stable versioned download URL, so the retained source is the anchor:\
+    \ s3://public-wgfd/raw/mule-deer-crucial.geojson, 2,619,807 bytes, SHA-256 e464111b26c949cfd81e060ab9ddea0b98fb303b9f154dd99ca0c1474b2ce81b.\
+    \ Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"\
+    2026-08-21T23:32:13Z\",\n  \"updated\": \"2026-08-21T23:33:52Z\",\n  \"keywords\": [\n    \"Wyoming\"\
+    ,\n    \"mule deer\",\n    \"wildlife\",\n    \"habitat\",\n    \"crucial range\",\n    \"seasonal\
+    \ range\",\n    \"WGFD\",\n    \"big game\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\"\
+    : [\n        [\n          -111.048,\n          40.996,\n          -104.056,\n          45.0\n    \
+    \    ]\n      ]\n    },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\"\
+    ,\n          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"\
+    Wyoming Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\
+    \n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"\
+    name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\
+    \n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n   \
+    \ {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"mule-deer-crucial-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Mule deer crucial range \\u2014 GeoParquet\",\n      \"created\": \"2026-08-21T23:32:13Z\"\
+    ,\n      \"description\": \"Mule deer crucial range polygons as GeoParquet, one row per polygon, in\
+    \ EPSG:4326. Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n   \
+    \       \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier\
+    \ assigned to every polygon during conversion, unique within this dataset. Count features or remove\
+    \ repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation. Every polygon here is crucial range, so each code combines\
+    \ the crucial prefix CRU with the seasonal type. Values: CRUWYL=crucial winter/yearlong range, CRUWIN=crucial\
+    \ winter range.\",\n          \"values\": [\n            \"CRUWYL\",\n            \"CRUWIN\"\n   \
+    \       ]\n        },\n        {\n          \"name\": \"Acres\",\n          \"type\": \"double\",\n\
+    \          \"description\": \"Area of the range polygon in acres, as published by the Wyoming Game\
+    \ & Fish Department.\"\n        },\n        {\n          \"name\": \"SQMiles\",\n          \"type\"\
+    : \"double\",\n          \"description\": \"Area of the range polygon in square miles, as published\
+    \ by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"name\": \"geom\",\n\
+    \          \"type\": \"geometry\",\n          \"description\": \"Polygon geometry of the range, in\
+    \ EPSG:4326.\"\n        }\n      ]\n    },\n    \"mule-deer-crucial-pmtiles\": {\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial.pmtiles\",\n      \"type\": \"application/vnd.pmtiles\"\
+    ,\n      \"roles\": [\n        \"visual\"\n      ],\n      \"title\": \"Mule deer crucial range \\\
+    u2014 PMTiles\",\n      \"created\": \"2026-08-21T23:32:26Z\",\n      \"description\": \"Vector tiles\
+    \ for web maps. In MapLibre GL JS the source layer is \\\"mule-deer-crucial\\\"; style or filter on\
+    \ RANGE to separate the crucial range types.\",\n      \"vector:layers\": [\n        \"mule-deer-crucial\"\
+    \n      ],\n      \"table:columns\": [\n        {\n          \"name\": \"_cng_fid\",\n          \"\
+    type\": \"int64\"\n        },\n        {\n          \"name\": \"OGC_FID\",\n          \"type\": \"\
+    int64\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n          \"type\": \"int32\"\n\
+    \        },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n        \
+    \  \"values\": [\n            \"CRUWYL\",\n            \"CRUWIN\"\n          ]\n        },\n     \
+    \   {\n          \"name\": \"Acres\",\n          \"type\": \"double\"\n        },\n        {\n   \
+    \       \"name\": \"SQMiles\",\n          \"type\": \"double\"\n        }\n      ]\n    },\n    \"\
+    mule-deer-crucial-hex\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial/hex/h0=*/data_0.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Mule deer crucial range \\u2014 H3 resolution 10\",\n      \"created\": \"2026-08-21T23:33:52Z\"\
+    ,\n      \"description\": \"Mule deer crucial range as H3 cells at resolution 10, with resolution\
+    \ 9, 8 and 0 identifiers alongside for rolling up or joining to other datasets. There is one row for\
+    \ each combination of a range polygon and a cell it covers, so a polygon that spans many cells appears\
+    \ on many rows, and the per-polygon values Acres and SQMiles are repeated on every one of its cells.\
+    \ Reduce to one row per polygon before totalling either of them:\\n\\nSELECT SUM(Acres) FROM (SELECT\
+    \ DISTINCT _cng_fid, Acres FROM \\u2026)\\n\\nFor the ground area of a set of cells, aggregate the\
+    \ cell areas over distinct cells rather than these published columns. Covers 40,955 resolution 8 cells\
+    \ across 1 resolution 0 partition.\",\n      \"h3:native_resolution\": 10,\n      \"h3:parent_resolutions\"\
+    : [\n        9,\n        8,\n        0\n      ],\n      \"table:columns\": [\n        {\n        \
+    \  \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier\
+    \ assigned to every polygon during conversion, unique within this dataset. Count features or remove\
+    \ repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation. Every polygon here is crucial range, so each code combines\
+    \ the crucial prefix CRU with the seasonal type. Values: CRUWYL=crucial winter/yearlong range, CRUWIN=crucial\
+    \ winter range.\",\n          \"values\": [\n            \"CRUWYL\",\n            \"CRUWIN\"\n   \
+    \       ]\n        },\n        {\n          \"name\": \"Acres\",\n          \"type\": \"double\",\n\
+    \          \"description\": \"Area of the range polygon in acres, as published by the Wyoming Game\
+    \ & Fish Department.\"\n        },\n        {\n          \"name\": \"SQMiles\",\n          \"type\"\
+    : \"double\",\n          \"description\": \"Area of the range polygon in square miles, as published\
+    \ by the Wyoming Game & Fish Department.\"\n        },\n        {\n          \"name\": \"h10\",\n\
+    \          \"type\": \"uint64\",\n          \"description\": \"H3 cell identifier at resolution 10,\
+    \ the native resolution of this hex table.\"\n        },\n        {\n          \"name\": \"h9\",\n\
+    \          \"type\": \"uint64\",\n          \"description\": \"H3 cell identifier at resolution 9.\"\
+    \n        },\n        {\n          \"name\": \"h8\",\n          \"type\": \"uint64\",\n          \"\
+    description\": \"H3 cell identifier at resolution 8, the resolution shared across this catalog for\
+    \ joining datasets to one another.\"\n        },\n        {\n          \"name\": \"h0\",\n       \
+    \   \"type\": \"int64\",\n          \"description\": \"H3 cell identifier at resolution 0, used as\
+    \ the partition key for hive-partitioned reads.\"\n        }\n      ]\n    }\n  }\n}"
+  pronghorn-crucial.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"stac_extensions\"\
+    : [\n    \"https://stac-extensions.github.io/table/v1.2.0/schema.json\",\n    \"https://stac-extensions.github.io/scientific/v1.0.0/schema.json\"\
+    \n  ],\n  \"id\": \"wgfd-pronghorn-crucial\",\n  \"title\": \"Pronghorn Crucial Range (Wyoming)\"\
+    ,\n  \"description\": \"Crucial seasonal habitat range for pronghorn in Wyoming, mapped by the Wyoming\
+    \ Game & Fish Department. Crucial ranges are the seasonal habitats the department identifies as a\
+    \ determining factor in the population's ability to sustain itself, so they carry more management\
+    \ weight than ordinary seasonal range. This dataset holds 105 polygons covering about 5,972,722 acres,\
+    \ broken down by range type as CRUWYL (101), CRUSWR (3), CRUWIN (1).\\n\\nCoverage is the state of\
+    \ Wyoming. That is the full extent of the source: the Wyoming Game & Fish Department maps range within\
+    \ its own jurisdiction, so this is a complete dataset rather than a regional excerpt of something\
+    \ larger.\\n\\nThe department publishes crucial range as a separate layer from full pronghorn seasonal\
+    \ range, and every polygon here is crucial, which is why each RANGE code begins with CRU.\",\n  \"\
+    license\": \"other\",\n  \"sci:citation\": \"Wyoming Game & Fish Department, Pronghorn Crucial Range.\
+    \ Accessed 2026-02-25 from the WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com). The department\
+    \ publishes through an ArcGIS Hub endpoint with no stable versioned download URL, so the retained\
+    \ source is the anchor: s3://public-wgfd/raw/pronghorn-crucial.geojson, 3,110,805 bytes, SHA-256 16f9a3dcb61a48ca315072615c1f4cdf4ce5da8701582fdb5a8f16576d848350.\
+    \ Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, UC Berkeley.\",\n  \"created\": \"\
+    2026-08-21T23:34:54Z\",\n  \"updated\": \"2026-08-21T23:36:21Z\",\n  \"keywords\": [\n    \"Wyoming\"\
+    ,\n    \"pronghorn\",\n    \"wildlife\",\n    \"habitat\",\n    \"crucial range\",\n    \"seasonal\
+    \ range\",\n    \"WGFD\",\n    \"big game\"\n  ],\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\"\
+    : [\n        [\n          -111.047,\n          40.998,\n          -104.305,\n          44.857\n  \
+    \      ]\n      ]\n    },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\"\
+    ,\n          null\n        ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"\
+    Wyoming Game & Fish Department\",\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\
+    \n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\n    },\n    {\n      \"\
+    name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\",\n        \"host\"\
+    \n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n  \"links\": [\n   \
+    \ {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"about\",\n      \"href\": \"https://wyoming-wgfd.opendata.arcgis.com/\",\n      \"type\"\
+    : \"text/html\",\n      \"title\": \"WGFD ArcGIS Hub (upstream distribution)\"\n    }\n  ],\n  \"\
+    assets\": {\n    \"pronghorn-crucial-parquet\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Pronghorn crucial range \\u2014 GeoParquet\",\n      \"created\": \"2026-08-21T23:34:54Z\"\
+    ,\n      \"description\": \"Pronghorn crucial range polygons as GeoParquet, one row per polygon, in\
+    \ EPSG:4326. Query directly with DuckDB over HTTP.\",\n      \"table:columns\": [\n        {\n   \
+    \       \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier\
+    \ assigned to every polygon during conversion, unique within this dataset. Count features or remove\
+    \ repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation. Every polygon here is crucial range, so each code combines\
+    \ the crucial prefix CRU with the seasonal type. Values: CRUWYL=crucial winter/yearlong range, CRUSWR=crucial\
+    \ severe winter relief range, CRUWIN=crucial winter range.\",\n          \"values\": [\n         \
+    \   \"CRUWYL\",\n            \"CRUSWR\",\n            \"CRUWIN\"\n          ]\n        },\n      \
+    \  {\n          \"name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\":\
+    \ \"Area of the range polygon in acres, as published by the Wyoming Game & Fish Department.\"\n  \
+    \      },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n        \
+    \  \"description\": \"Area of the range polygon in square miles, as published by the Wyoming Game\
+    \ & Fish Department.\"\n        },\n        {\n          \"name\": \"geom\",\n          \"type\":\
+    \ \"geometry\",\n          \"description\": \"Polygon geometry of the range, in EPSG:4326.\"\n   \
+    \     }\n      ]\n    },\n    \"pronghorn-crucial-pmtiles\": {\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial.pmtiles\"\
+    ,\n      \"type\": \"application/vnd.pmtiles\",\n      \"roles\": [\n        \"visual\"\n      ],\n\
+    \      \"title\": \"Pronghorn crucial range \\u2014 PMTiles\",\n      \"created\": \"2026-08-21T23:35:08Z\"\
+    ,\n      \"description\": \"Vector tiles for web maps. In MapLibre GL JS the source layer is \\\"\
+    pronghorn-crucial\\\"; style or filter on RANGE to separate the crucial range types.\",\n      \"\
+    vector:layers\": [\n        \"pronghorn-crucial\"\n      ],\n      \"table:columns\": [\n        {\n\
+    \          \"name\": \"_cng_fid\",\n          \"type\": \"int64\"\n        },\n        {\n       \
+    \   \"name\": \"OGC_FID\",\n          \"type\": \"int64\"\n        },\n        {\n          \"name\"\
+    : \"OBJECTID\",\n          \"type\": \"int32\"\n        },\n        {\n          \"name\": \"RANGE\"\
+    ,\n          \"type\": \"string\",\n          \"values\": [\n            \"CRUWYL\",\n           \
+    \ \"CRUSWR\",\n            \"CRUWIN\"\n          ]\n        },\n        {\n          \"name\": \"\
+    Acres\",\n          \"type\": \"double\"\n        },\n        {\n          \"name\": \"SQMiles\",\n\
+    \          \"type\": \"double\"\n        }\n      ]\n    },\n    \"pronghorn-crucial-hex\": {\n  \
+    \    \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial/hex/h0=*/data_0.parquet\"\
+    ,\n      \"type\": \"application/x-parquet\",\n      \"roles\": [\n        \"data\"\n      ],\n  \
+    \    \"title\": \"Pronghorn crucial range \\u2014 H3 resolution 10\",\n      \"created\": \"2026-08-21T23:36:21Z\"\
+    ,\n      \"description\": \"Pronghorn crucial range as H3 cells at resolution 10, with resolution\
+    \ 9, 8 and 0 identifiers alongside for rolling up or joining to other datasets. There is one row for\
+    \ each combination of a range polygon and a cell it covers, so a polygon that spans many cells appears\
+    \ on many rows, and the per-polygon values Acres and SQMiles are repeated on every one of its cells.\
+    \ Reduce to one row per polygon before totalling either of them:\\n\\nSELECT SUM(Acres) FROM (SELECT\
+    \ DISTINCT _cng_fid, Acres FROM \\u2026)\\n\\nFor the ground area of a set of cells, aggregate the\
+    \ cell areas over distinct cells rather than these published columns. Covers 36,879 resolution 8 cells\
+    \ across 1 resolution 0 partition.\",\n      \"h3:native_resolution\": 10,\n      \"h3:parent_resolutions\"\
+    : [\n        9,\n        8,\n        0\n      ],\n      \"table:columns\": [\n        {\n        \
+    \  \"name\": \"_cng_fid\",\n          \"type\": \"int64\",\n          \"description\": \"Identifier\
+    \ assigned to every polygon during conversion, unique within this dataset. Count features or remove\
+    \ repeated rows with COUNT(DISTINCT _cng_fid).\"\n        },\n        {\n          \"name\": \"OGC_FID\"\
+    ,\n          \"type\": \"int64\",\n          \"description\": \"Sequential record number carried over\
+    \ from the source GeoJSON export.\"\n        },\n        {\n          \"name\": \"OBJECTID\",\n  \
+    \        \"type\": \"int32\",\n          \"description\": \"Feature identifier assigned by the Wyoming\
+    \ Game & Fish Department in the published layer. Unique for every polygon in this dataset.\"\n   \
+    \     },\n        {\n          \"name\": \"RANGE\",\n          \"type\": \"string\",\n          \"\
+    description\": \"Seasonal range designation. Every polygon here is crucial range, so each code combines\
+    \ the crucial prefix CRU with the seasonal type. Values: CRUWYL=crucial winter/yearlong range, CRUSWR=crucial\
+    \ severe winter relief range, CRUWIN=crucial winter range.\",\n          \"values\": [\n         \
+    \   \"CRUWYL\",\n            \"CRUSWR\",\n            \"CRUWIN\"\n          ]\n        },\n      \
+    \  {\n          \"name\": \"Acres\",\n          \"type\": \"double\",\n          \"description\":\
+    \ \"Area of the range polygon in acres, as published by the Wyoming Game & Fish Department.\"\n  \
+    \      },\n        {\n          \"name\": \"SQMiles\",\n          \"type\": \"double\",\n        \
+    \  \"description\": \"Area of the range polygon in square miles, as published by the Wyoming Game\
+    \ & Fish Department.\"\n        },\n        {\n          \"name\": \"h10\",\n          \"type\": \"\
+    uint64\",\n          \"description\": \"H3 cell identifier at resolution 10, the native resolution\
+    \ of this hex table.\"\n        },\n        {\n          \"name\": \"h9\",\n          \"type\": \"\
+    uint64\",\n          \"description\": \"H3 cell identifier at resolution 9.\"\n        },\n      \
+    \  {\n          \"name\": \"h8\",\n          \"type\": \"uint64\",\n          \"description\": \"\
+    H3 cell identifier at resolution 8, the resolution shared across this catalog for joining datasets\
+    \ to one another.\"\n        },\n        {\n          \"name\": \"h0\",\n          \"type\": \"int64\"\
+    ,\n          \"description\": \"H3 cell identifier at resolution 0, used as the partition key for\
+    \ hive-partitioned reads.\"\n        }\n      ]\n    }\n  }\n}"
+  bucket.json: "{\n  \"type\": \"Collection\",\n  \"stac_version\": \"1.0.0\",\n  \"id\": \"wgfd\",\n\
+    \  \"title\": \"Wyoming Game & Fish Department (WGFD)\",\n  \"description\": \"Wildlife habitat data\
+    \ published by the Wyoming Game & Fish Department. The department maps big-game seasonal ranges and\
+    \ other habitat layers across Wyoming, its area of jurisdiction, so these datasets cover the state\
+    \ in full rather than being regional excerpts of a national product.\\n\\nDatasets are grouped here\
+    \ by the agency that produces them, which is how they are found and cited upstream.\",\n  \"license\"\
+    : \"other\",\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n        [\n          -111.049,\n\
+    \          40.996,\n          -104.056,\n          45.0\n        ]\n      ]\n    },\n    \"temporal\"\
+    : {\n      \"interval\": [\n        [\n          \"2024-01-01T00:00:00Z\",\n          null\n     \
+    \   ]\n      ]\n    }\n  },\n  \"providers\": [\n    {\n      \"name\": \"Wyoming Game & Fish Department\"\
+    ,\n      \"roles\": [\n        \"producer\",\n        \"licensor\"\n      ],\n      \"url\": \"https://wyoming-wgfd.opendata.arcgis.com/\"\
+    \n    },\n    {\n      \"name\": \"Boettiger Lab, UC Berkeley\",\n      \"roles\": [\n        \"processor\"\
+    ,\n        \"host\"\n      ],\n      \"url\": \"https://github.com/boettiger-lab\"\n    }\n  ],\n\
+    \  \"links\": [\n    {\n      \"rel\": \"self\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"root\",\n      \"href\":\
+    \ \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\",\n      \"type\": \"application/json\"\
+    \n    },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-data/stac/catalog.json\"\
+    ,\n      \"type\": \"application/json\"\n    },\n    {\n      \"rel\": \"license\",\n      \"href\"\
+    : \"https://wgfd.wyo.gov/geospatial-data\",\n      \"type\": \"text/html\"\n    },\n    {\n      \"\
+    rel\": \"child\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/elk-crucial/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\",\n      \"title\": \"Elk Crucial Range (Wyoming)\"\n    },\n\
+    \    {\n      \"rel\": \"child\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/mule-deer-crucial/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\",\n      \"title\": \"Mule deer Crucial Range (Wyoming)\"\n\
+    \    },\n    {\n      \"rel\": \"child\",\n      \"href\": \"https://s3-west.nrp-nautilus.io/public-wgfd/pronghorn-crucial/stac-collection.json\"\
+    ,\n      \"type\": \"application/json\",\n      \"title\": \"Pronghorn Crucial Range (Wyoming)\"\n\
+    \    }\n  ]\n}"
+  publish.py: "\nimport json, subprocess, sys\n\nNRP = 'https://s3-west.nrp-nautilus.io'\nBUCKET = 'public-wgfd'\n\
+    ROOT_KEY = 'nrp:public-data/stac/catalog.json'\nDATASETS = ['elk-crucial', 'mule-deer-crucial', 'pronghorn-crucial']\n\
+    \ndef put(local, key):\n    # read via python, write to /tmp: a ConfigMap mount is a symlink into\
+    \ ../data and\n    # rclone will not follow it (\"not a directory\").\n    doc = json.load(open(local))\n\
+    \    open('/tmp/o.json', 'w').write(json.dumps(doc, indent=2))\n    json.load(open('/tmp/o.json'))\n\
+    \    subprocess.check_call(['rclone', 'copyto', '/tmp/o.json', key])\n    return doc\n\n# 1. leaf\
+    \ collections\nfor ds in DATASETS:\n    d = put(f'/config/{ds}.json', f'nrp:{BUCKET}/{ds}/stac-collection.json')\n\
+    \    print('published\\t%s\\t%s' % (d['id'], len(d['assets'])))\n\n# 2. bucket-level collection (the\
+    \ new top-level sub-catalog)\nput('/config/bucket.json', f'nrp:{BUCKET}/stac-collection.json')\nprint('published\\\
+    tbucket collection')\n\n# 3. register it in the ROOT catalog. Only done because this is a brand-new\n\
+    #    top-level sub-catalog; nothing else justifies touching the root.\nroot = json.loads(subprocess.check_output(['rclone',\
+    \ 'cat', ROOT_KEY]))\nhref = f'{NRP}/{BUCKET}/stac-collection.json'\nif any(l.get('rel') == 'child'\
+    \ and l.get('href') == href for l in root['links']):\n    print('root\\tALREADY')\nelse:\n    before\
+    \ = sum(1 for l in root['links'] if l.get('rel') == 'child')\n    root['links'].append({'rel': 'child',\
+    \ 'href': href, 'type': 'application/json',\n                          'title': 'Wyoming Game & Fish\
+    \ Department (WGFD)'})\n    open('/tmp/root.json', 'w').write(json.dumps(root, indent=2))\n    json.load(open('/tmp/root.json'))\n\
+    \    subprocess.check_call(['rclone', 'copyto', '/tmp/root.json', ROOT_KEY])\n    after = sum(1 for\
+    \ l in json.loads(subprocess.check_output(['rclone', 'cat', ROOT_KEY]))['links']\n               \
+    \ if l.get('rel') == 'child')\n    print('root\\tREGISTERED\\tchildren %d -> %d' % (before, after))\n\
+    \    if after != before + 1:\n        print('FAIL: root child count did not grow by exactly one');\
+    \ sys.exit(1)\n\n# 4. round-trip every document we wrote\nfail = 0\nfor key, want in [(f'nrp:{BUCKET}/{ds}/stac-collection.json',\
+    \ f'wgfd-{ds}') for ds in DATASETS] \\\n                 + [(f'nrp:{BUCKET}/stac-collection.json',\
+    \ 'wgfd')]:\n    got = json.loads(subprocess.check_output(['rclone', 'cat', key]))\n    if got.get('id')\
+    \ != want:\n        print('FAIL: %s has id %r, expected %r' % (key, got.get('id'), want)); fail +=\
+    \ 1\n    hexa = [a for k, a in got.get('assets', {}).items() if k.endswith('-hex')]\n    for a in\
+    \ hexa:\n        if not a['href'].endswith('/h0=*/data_0.parquet'):\n            print('FAIL: %s hex\
+    \ href not a glob: %s' % (key, a['href'])); fail += 1\n        if a.get('h3:native_resolution') !=\
+    \ 10 or 0 not in a.get('h3:parent_resolutions', []):\n            print('FAIL: %s hex h3:* wrong'\
+    \ % key); fail += 1\nsys.exit(1 if fail else 0)\n"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: stac-publish-wgfd
+  namespace: geo-workflows
+  labels:
+    k8s-app: stac-publish-wgfd
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata:
+      labels:
+        k8s-app: stac-publish-wgfd
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: publish
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - name: AWS_S3_ENDPOINT
+          value: rook-ceph-rgw-nautiluss3.rook
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /root/.config/rclone
+          readOnly: true
+        - name: cfg
+          mountPath: /config
+          readOnly: true
+        command:
+        - bash
+        - -c
+        - set -uo pipefail; python3 /config/publish.py
+        resources:
+          requests:
+            cpu: '1'
+            memory: 1Gi
+            ephemeral-storage: 1Gi
+          limits:
+            cpu: '1'
+            memory: 1Gi
+            ephemeral-storage: 1Gi
+      volumes:
+      - name: rclone-config
+        secret:
+          secretName: rclone-config
+      - name: cfg
+        configMap:
+          name: stac-publish-wgfd

--- a/catalog/wgfd/k8s/stage-raw.yaml
+++ b/catalog/wgfd/k8s/stage-raw.yaml
@@ -1,0 +1,71 @@
+# data-workflows#578 — stage the WGFD raw sources into public-wgfd/raw/ under clean names.
+#
+# The upstream GeoJSON is already on NRP, staged 2026-02-25 under public-wyoming/raw/ with
+# ArcGIS export hash suffixes. This copies it into the new provider-named bucket so
+# public-wgfd is self-contained: public-wyoming is slated for retirement (#225), and the raw
+# must not disappear with it. For cwhr/#417 reasons the staged raw IS the provenance here —
+# WGFD publishes through an ArcGIS Hub endpoint with no stable versioned download URL, so
+# these bytes plus their checksum are the only reproducible anchor.
+#
+# Renamed to match the dataset names (the `coal-cases.geojson` convention), so
+# --source-url s3://public-wgfd/raw/<dataset>.geojson is derivable from the dataset name.
+#
+# Server-side S3 copy over the internal endpoint. Idempotent: rclone skips identical objects.
+# ⚠️ Runs AFTER *-setup-bucket (the bucket does not exist until then, and rclone with
+# --s3-no-check-bucket would fail the upload with NoSuchBucket after doing the work).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wgfd-stage-raw
+  namespace: geo-workflows
+  labels: {k8s-app: wgfd-stage-raw}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 604800
+  template:
+    metadata: {labels: {k8s-app: wgfd-stage-raw}}
+    spec:
+      restartPolicy: Never
+      priorityClassName: opportunistic
+      containers:
+      - name: stage
+        image: ghcr.io/boettiger-lab/datasets:latest
+        imagePullPolicy: Always
+        env:
+        - {name: AWS_S3_ENDPOINT, value: rook-ceph-rgw-nautiluss3.rook}
+        volumeMounts:
+        - {name: rclone-config, mountPath: /root/.config/rclone, readOnly: true}
+        command:
+        - bash
+        - -c
+        - |
+          set -euo pipefail
+          SRC=nrp:public-wyoming/raw
+          DST=nrp:public-wgfd/raw
+
+          copy() {  # <upstream-name> <clean-name>
+            echo "=== $2"
+            rclone copyto "$SRC/$1" "$DST/$2" -P --retries 5 --low-level-retries 20
+            rclone lsl "$DST/$2"
+          }
+
+          copy 'Elk_Crucial_Range_6814964145904153641.geojson'      elk-crucial.geojson
+          copy 'MuleDeerCrucialRange_-6928355498246013770.geojson'  mule-deer-crucial.geojson
+          copy 'Antelope_Crucial_Range_2840206821211723664.geojson' pronghorn-crucial.geojson
+          # Antelope == pronghorn: WGFD names the file for the common name, the dataset for
+          # the species. Recorded here so nobody "fixes" the mapping later.
+
+          echo "=== staged, with fingerprints for the STAC provenance (#417) ==="
+          for f in elk-crucial mule-deer-crucial pronghorn-crucial; do
+            rclone cat "$DST/$f.geojson" | sha256sum | sed "s|-|$f.geojson|"
+          done
+          rclone lsjson "$DST" | python3 -c "
+          import json,sys
+          for o in json.load(sys.stdin):
+              print(f\"{o['Name']:32s} {o['Size']:>12,} bytes  {o.get('ModTime','')}\")
+          "
+        resources:
+          requests: {cpu: '1', memory: 2Gi, ephemeral-storage: 2Gi}
+          limits:   {cpu: '1', memory: 2Gi, ephemeral-storage: 2Gi}
+      volumes:
+      - {name: rclone-config, secret: {secretName: rclone-config}}

--- a/catalog/wgfd/scripts_gen_stac.py
+++ b/catalog/wgfd/scripts_gen_stac.py
@@ -1,0 +1,297 @@
+"""Author the STAC for the three public-wgfd crucial-range collections (#578).
+
+Every value here is MEASURED from the published data (schemas, RANGE value sets, bboxes,
+feature counts, build times, raw sha256) — nothing transcribed from the old public-wyoming
+STAC except the licence fact and the provider identities, which are statements about
+upstream rather than about our build.
+
+One schema is written identically to every asset (the mcp-data-server#303 fold is
+first-seen-wins, so divergent text silently drops a version). Hex-only guidance therefore
+lives in the hex asset DESCRIPTION, never as a per-column clause.
+"""
+import json
+
+NRP = "https://s3-west.nrp-nautilus.io"
+BUCKET = "public-wgfd"
+ROOT = f"{NRP}/public-data/stac/catalog.json"
+PARENT = f"{NRP}/{BUCKET}/stac-collection.json"
+
+TABLE_EXT = "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+SCI_EXT = "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+
+# --- measured -------------------------------------------------------------------------
+D = {
+    "elk-crucial": dict(
+        species="elk", Species="Elk",
+        features=150, h8=28617, cells=1159248,
+        bbox=[-111.049, 40.999, -104.981, 44.988],
+        ranges={"CRUWYL": 91, "CRUWIN": 57, "CRUSWR": 2},
+        acres=(747.09, 592503.3, 4442987),
+        sha256="3d56458f6bf2d6d6bcd1b648c1716cf7188bd40ab2641e85d370172f35b03fd2",
+        raw_bytes=2324827,
+        built={"parquet": "2026-08-21T23:29:26Z", "pmtiles": "2026-08-21T23:29:37Z",
+               "hex": "2026-08-21T23:31:13Z"},
+        partitions=2,
+    ),
+    "mule-deer-crucial": dict(
+        species="mule deer", Species="Mule deer",
+        features=145, h8=40955, cells=None,
+        bbox=[-111.048, 40.996, -104.056, 45.0],
+        ranges={"CRUWYL": 116, "CRUWIN": 29},
+        acres=(231.46, 1352702.2, 6431769),
+        sha256="e464111b26c949cfd81e060ab9ddea0b98fb303b9f154dd99ca0c1474b2ce81b",
+        raw_bytes=2619807,
+        built={"parquet": "2026-08-21T23:32:13Z", "pmtiles": "2026-08-21T23:32:26Z",
+               "hex": "2026-08-21T23:33:52Z"},
+        partitions=1,
+    ),
+    "pronghorn-crucial": dict(
+        species="pronghorn", Species="Pronghorn",
+        features=105, h8=36879, cells=None,
+        bbox=[-111.047, 40.998, -104.305, 44.857],
+        ranges={"CRUWYL": 101, "CRUSWR": 3, "CRUWIN": 1},
+        acres=(730.41, 1327564.2, 5972722),
+        sha256="16f9a3dcb61a48ca315072615c1f4cdf4ce5da8701582fdb5a8f16576d848350",
+        raw_bytes=3110805,
+        built={"parquet": "2026-08-21T23:34:54Z", "pmtiles": "2026-08-21T23:35:08Z",
+               "hex": "2026-08-21T23:36:21Z"},
+        partitions=1,
+    ),
+}
+
+# WGFD seasonal-range terminology. CRU = crucial; the suffix is the seasonal type.
+RANGE_DEFS = {
+    "CRUWIN": "crucial winter range",
+    "CRUWYL": "crucial winter/yearlong range",
+    "CRUSWR": "crucial severe winter relief range",
+    "CRUSSF": "crucial spring/summer/fall range",
+    "CRUYRL": "crucial yearlong range",
+    "CRUOUT": "crucial range outside other seasonal types",
+}
+
+ACCESS_DATE = "2026-02-25"   # when the source GeoJSON was pulled from the WGFD ArcGIS Hub
+
+
+def col_defs(ds):
+    d = D[ds]
+    present = sorted(d["ranges"], key=lambda c: -d["ranges"][c])
+    listed = ", ".join(f"{c}={RANGE_DEFS[c]}" for c in present)
+    return {
+        "_cng_fid": ("int64",
+            "Identifier assigned to every polygon during conversion, unique within this "
+            "dataset. Count features or remove repeated rows with COUNT(DISTINCT _cng_fid)."),
+        "OGC_FID": ("int64",
+            "Sequential record number carried over from the source GeoJSON export."),
+        "OBJECTID": ("int32",
+            "Feature identifier assigned by the Wyoming Game & Fish Department in the "
+            "published layer. Unique for every polygon in this dataset."),
+        "RANGE": ("string",
+            "Seasonal range designation. Every polygon here is crucial range, so each code "
+            f"combines the crucial prefix CRU with the seasonal type. Values: {listed}."),
+        "Acres": ("double",
+            "Area of the range polygon in acres, as published by the Wyoming Game & Fish "
+            "Department."),
+        "SQMiles": ("double",
+            "Area of the range polygon in square miles, as published by the Wyoming Game & "
+            "Fish Department."),
+        "geom": ("geometry", "Polygon geometry of the range, in EPSG:4326."),
+        "h10": ("uint64",
+            "H3 cell identifier at resolution 10, the native resolution of this hex table."),
+        "h9": ("uint64", "H3 cell identifier at resolution 9."),
+        "h8": ("uint64",
+            "H3 cell identifier at resolution 8, the resolution shared across this catalog "
+            "for joining datasets to one another."),
+        "h0": ("int64",
+            "H3 cell identifier at resolution 0, used as the partition key for "
+            "hive-partitioned reads."),
+    }
+
+
+FLAT_COLS = ["_cng_fid", "OGC_FID", "OBJECTID", "RANGE", "Acres", "SQMiles", "geom"]
+HEX_COLS = ["_cng_fid", "OGC_FID", "OBJECTID", "RANGE", "Acres", "SQMiles",
+            "h10", "h9", "h8", "h0"]
+PMT_COLS = ["_cng_fid", "OGC_FID", "OBJECTID", "RANGE", "Acres", "SQMiles"]
+
+
+def columns(ds, names, lean=False):
+    defs = col_defs(ds)
+    present = sorted(D[ds]["ranges"], key=lambda c: -D[ds]["ranges"][c])
+    out = []
+    for n in names:
+        t, desc = defs[n]
+        c = {"name": n, "type": t}
+        if not lean:
+            c["description"] = desc
+        if n == "RANGE":
+            c["values"] = present
+        out.append(c)
+    return out
+
+
+def collection(ds):
+    d = D[ds]
+    sp, Sp = d["species"], d["Species"]
+    lo, hi, total = d["acres"]
+    present = sorted(d["ranges"], key=lambda c: -d["ranges"][c])
+    breakdown = ", ".join(f"{c} ({d['ranges'][c]})" for c in present)
+
+    description = (
+        f"Crucial seasonal habitat range for {sp} in Wyoming, mapped by the Wyoming Game & "
+        f"Fish Department. Crucial ranges are the seasonal habitats the department identifies "
+        f"as a determining factor in the population's ability to sustain itself, so they carry "
+        f"more management weight than ordinary seasonal range. This dataset holds "
+        f"{d['features']:,} polygons covering about {total:,.0f} acres, broken down by range "
+        f"type as {breakdown}.\n\n"
+        f"Coverage is the state of Wyoming. That is the full extent of the source: the Wyoming "
+        f"Game & Fish Department maps range within its own jurisdiction, so this is a complete "
+        f"dataset rather than a regional excerpt of something larger.\n\n"
+        f"The department publishes crucial range as a separate layer from full {sp} seasonal "
+        f"range, and every polygon here is crucial, which is why each RANGE code begins with "
+        f"CRU."
+    )
+
+    citation = (
+        f"Wyoming Game & Fish Department, {Sp} Crucial Range. Accessed {ACCESS_DATE} from the "
+        f"WGFD ArcGIS Hub (wyoming-wgfd.opendata.arcgis.com). The department publishes through "
+        f"an ArcGIS Hub endpoint with no stable versioned download URL, so the retained source "
+        f"is the anchor: s3://{BUCKET}/raw/{ds}.geojson, {d['raw_bytes']:,} bytes, SHA-256 "
+        f"{d['sha256']}. Converted to GeoParquet, PMTiles and H3 by the Boettiger Lab, "
+        f"UC Berkeley."
+    )
+
+    hex_desc = (
+        f"{Sp} crucial range as H3 cells at resolution 10, with resolution 9, 8 and 0 "
+        f"identifiers alongside for rolling up or joining to other datasets. There is one row "
+        f"for each combination of a range polygon and a cell it covers, so a polygon that spans "
+        f"many cells appears on many rows, and the per-polygon values Acres and SQMiles are "
+        f"repeated on every one of its cells. Reduce to one row per polygon before totalling "
+        f"either of them:\n\n"
+        f"SELECT SUM(Acres) FROM (SELECT DISTINCT _cng_fid, Acres FROM …)\n\n"
+        f"For the ground area of a set of cells, aggregate the cell areas over distinct cells "
+        f"rather than these published columns. Covers {d['h8']:,} resolution 8 cells across "
+        f"{d['partitions']} resolution 0 partition"
+        f"{'s' if d['partitions'] != 1 else ''}."
+    )
+
+    assets = {
+        f"{ds}-parquet": {
+            "href": f"{NRP}/{BUCKET}/{ds}.parquet",
+            "type": "application/x-parquet",
+            "roles": ["data"],
+            "title": f"{Sp} crucial range — GeoParquet",
+            "created": d["built"]["parquet"],
+            "description": (
+                f"{Sp} crucial range polygons as GeoParquet, one row per polygon, in EPSG:4326. "
+                f"Query directly with DuckDB over HTTP."),
+            "table:columns": columns(ds, FLAT_COLS),
+        },
+        f"{ds}-pmtiles": {
+            "href": f"{NRP}/{BUCKET}/{ds}.pmtiles",
+            "type": "application/vnd.pmtiles",
+            "roles": ["visual"],
+            "title": f"{Sp} crucial range — PMTiles",
+            "created": d["built"]["pmtiles"],
+            "description": (
+                f"Vector tiles for web maps. In MapLibre GL JS the source layer is "
+                f"\"{ds}\"; style or filter on RANGE to separate the crucial range types."),
+            "vector:layers": [ds],
+            "table:columns": columns(ds, PMT_COLS, lean=True),
+        },
+        f"{ds}-hex": {
+            "href": f"{NRP}/{BUCKET}/{ds}/hex/h0=*/data_0.parquet",
+            "type": "application/x-parquet",
+            "roles": ["data"],
+            "title": f"{Sp} crucial range — H3 resolution 10",
+            "created": d["built"]["hex"],
+            "description": hex_desc,
+            "h3:native_resolution": 10,
+            "h3:parent_resolutions": [9, 8, 0],
+            "table:columns": columns(ds, HEX_COLS),
+        },
+    }
+
+    return {
+        "type": "Collection",
+        "stac_version": "1.0.0",
+        "stac_extensions": [TABLE_EXT, SCI_EXT],
+        "id": f"wgfd-{ds}",
+        "title": f"{Sp} Crucial Range (Wyoming)",
+        "description": description,
+        "license": "other",
+        "sci:citation": citation,
+        "created": d["built"]["parquet"],
+        "updated": d["built"]["hex"],
+        "keywords": ["Wyoming", sp, "wildlife", "habitat", "crucial range", "seasonal range",
+                     "WGFD", "big game"],
+        "extent": {
+            "spatial": {"bbox": [d["bbox"]]},
+            "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+        },
+        "providers": [
+            {"name": "Wyoming Game & Fish Department", "roles": ["producer", "licensor"],
+             "url": "https://wyoming-wgfd.opendata.arcgis.com/"},
+            {"name": "Boettiger Lab, UC Berkeley", "roles": ["processor", "host"],
+             "url": "https://github.com/boettiger-lab"},
+        ],
+        "links": [
+            {"rel": "self", "href": f"{NRP}/{BUCKET}/{ds}/stac-collection.json",
+             "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": PARENT, "type": "application/json"},
+            {"rel": "license", "href": "https://wgfd.wyo.gov/geospatial-data",
+             "type": "text/html"},
+            {"rel": "about", "href": "https://wyoming-wgfd.opendata.arcgis.com/",
+             "type": "text/html", "title": "WGFD ArcGIS Hub (upstream distribution)"},
+        ],
+        "assets": assets,
+    }
+
+
+def bucket_collection():
+    return {
+        "type": "Collection",
+        "stac_version": "1.0.0",
+        "id": "wgfd",
+        "title": "Wyoming Game & Fish Department (WGFD)",
+        "description": (
+            "Wildlife habitat data published by the Wyoming Game & Fish Department. The "
+            "department maps big-game seasonal ranges and other habitat layers across Wyoming, "
+            "its area of jurisdiction, so these datasets cover the state in full rather than "
+            "being regional excerpts of a national product.\n\n"
+            "Datasets are grouped here by the agency that produces them, which is how they are "
+            "found and cited upstream."),
+        "license": "other",
+        "extent": {
+            "spatial": {"bbox": [[-111.049, 40.996, -104.056, 45.0]]},
+            "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+        },
+        "providers": [
+            {"name": "Wyoming Game & Fish Department", "roles": ["producer", "licensor"],
+             "url": "https://wyoming-wgfd.opendata.arcgis.com/"},
+            {"name": "Boettiger Lab, UC Berkeley", "roles": ["processor", "host"],
+             "url": "https://github.com/boettiger-lab"},
+        ],
+        "links": [
+            {"rel": "self", "href": PARENT, "type": "application/json"},
+            {"rel": "root", "href": ROOT, "type": "application/json"},
+            {"rel": "parent", "href": ROOT, "type": "application/json"},
+            {"rel": "license", "href": "https://wgfd.wyo.gov/geospatial-data",
+             "type": "text/html"},
+        ] + [
+            {"rel": "child", "href": f"{NRP}/{BUCKET}/{ds}/stac-collection.json",
+             "type": "application/json", "title": collection(ds)["title"]}
+            for ds in D
+        ],
+    }
+
+
+if __name__ == "__main__":
+    import os
+    out = os.environ.get("OUT", "/tmp/wgfd-stac")
+    os.makedirs(out, exist_ok=True)
+    for ds in D:
+        p = f"{out}/{ds}.json"
+        json.dump(collection(ds), open(p, "w"), indent=2)
+        print("wrote", p)
+    json.dump(bucket_collection(), open(f"{out}/bucket.json", "w"), indent=2)
+    print("wrote", f"{out}/bucket.json")


### PR DESCRIPTION
First tranche of #578, whose scope was resolved with the repo owner earlier today. **Built, published, registered, and gating clean** — `public-wgfd` is live.

## Why these three first

The three `*-crucial` layers have **no downstream consumer**. Verified from `layers-input.json` in both `boettiger-lab/wyoming` and `wyoming-public-demo`: only the `*-seasonal` layers are wired in. So these move with zero app coordination, while the four consumer-facing layers wait on app PRs.

## Why a rebuild rather than a STAC edit

These predate #369, so the flats carry no `_cng_fid`, and `verify-stac.py` HARD-fails a vector asset declaring `table:columns` without it — documenting the schema would have traded six findings for a different one. Going back through `cng-datasets` synthesises `_cng_fid` and fixes the bare-directory hex hrefs and missing `h3:*` resolutions for free.

## Bucket naming

`public-wgfd`, named for the **provider** — how anyone familiar with these data would look for them, matching the #414 precedent (`public-tpl` → `public-cdfw`).

**The extent does not change, and never was the problem.** WGFD's jurisdiction *is* Wyoming; there is no larger product these are a clip of. Only the place-named bucket was wrong. Dataset names drop the redundant `wgfd-` prefix, so `public-wgfd/elk-crucial` yields the STAC id `wgfd-elk-crucial` instead of today's `wyoming-wgfd-elk-crucial` — shorter *and* more accurate.

Raw was re-staged into `public-wgfd/raw/` rather than read across from `public-wyoming`, which is slated for retirement (#225) — the raw must not disappear with it.

## Verification

Feature counts match #578's table exactly, and every hex holds every feature of its flat:

| dataset | flat features | `_cng_fid` flat / hex | features missing from hex | h8 cells | build |
|---|---:|---|---:|---:|---:|
| `elk-crucial` | 150 | 150 / 150 | **0** | 28,617 | 2m17s |
| `mule-deer-crucial` | 145 | 145 / 145 | **0** | 40,955 | 2m26s |
| `pronghorn-crucial` | 105 | 105 / 105 | **0** | 36,879 | 2m27s |

```
verify-stac.py --bucket public-wgfd --dataset elk-crucial        -> PASS, exit 0
verify-stac.py --bucket public-wgfd --dataset mule-deer-crucial  -> PASS, exit 0
verify-stac.py --bucket public-wgfd --dataset pronghorn-crucial  -> PASS, exit 0
```

Pre-publish gate was clean on all four documents (three collections + the new bucket collection) *before* anything was written to S3.

## STAC is measured, not transcribed

Schemas via `DESCRIBE`, `RANGE` value sets via `GROUP BY`, bboxes via `ST_XMin/Max`, per-asset `created` from object mtimes, and the raw SHA-256 computed during staging. Nothing was carried over from the old STAC except the licence fact and provider identities — statements about upstream, not about our build.

Also measured and found **absent**, so deliberately *not* documented as sentinels: zero NULL and zero non-positive `Acres`/`SQMiles` in all three. (Per the #518 lesson — a sentinel note copied from upstream docs is worse than none.)

Provenance follows the rule merged in #601: WGFD publishes through an ArcGIS Hub endpoint with no stable versioned URL, so `sci:citation` records the access date (**2026-02-25**, when the source was pulled — *not* today, which is only the intra-NRP copy), the staged object, and its SHA-256.

## Root registration

`public-wgfd` is a brand-new top-level sub-catalog, which is the one case Step 6 sanctions touching the root. The job asserts the root child count grows by **exactly one** (62 → 63), so a concurrent edit or a re-run cannot silently duplicate the entry.

## Still to come on #578

The four consumer-facing layers — three `wgfd-*-seasonal` plus `sage-grouse-priority` — need PRs on both app repos first (URL, asset key, **and** the `wyoming-`-prefixed collection id all change). Per Hard Boundary 2 those edits are out of scope for this repo. `wy-counties`/`wyoming-places` are retired in favour of the already-published national `census-2024/county` and `census-2024/place`; nothing to rebuild.

⚠️ Nothing has been removed from `public-wyoming` — retirement is gated on the app PRs landing.
